### PR TITLE
Agent-friendly install: npx support, llms.txt, AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent instructions
+
+Instructions for coding agents (Claude Code, Gemini CLI, Codex, Cursor, …) working with this repository — whether installing it for a user or contributing to it.
+
+## Installing for a user
+
+Requires Node.js ≥ 24 (uses built-in `node:sqlite`). No other dependencies.
+
+```sh
+# one-off, no install
+npx github:ryandemelo/token-monitor collect
+npx github:ryandemelo/token-monitor report
+
+# or persistent
+npm install -g github:ryandemelo/token-monitor
+token-monitor collect && token-monitor report
+```
+
+`collect` reads the user's local agent session logs (`~/.claude/projects/`, `~/.gemini/tmp/`, `~/.codex/sessions/`) into `~/.token-monitor/token-monitor.sqlite`. It is idempotent — safe to re-run any time. `report` prints the analysis; `html` writes a dashboard file; nothing makes network calls.
+
+After installing, run `collect` then `report` and walk the user through their activity breakdown, cache hit ratio, rework ratio, and persona.
+
+## Working on the codebase
+
+- Build/test: `npm install && npm test` (TypeScript build + `node:test` suite). Tests must pass before any commit.
+- **Zero runtime dependencies is a hard constraint** — only Node built-ins (`node:sqlite`, `node:util` parseArgs). Do not add packages.
+- Privacy is a hard constraint: adapters store aggregate numbers, tool names, timestamps, and project basenames — never prompt or code content. Fixtures must be synthetic; sample output in docs must use fictional project names and costs.
+- New adapters: follow CONTRIBUTING.md — `src/adapters/<name>.ts` with the log root as a parameter, fixtures under `test/fixtures/<name>/`, registered in `src/adapters/index.ts`.
+- Workflow: feature branches (`feat/...`, `fix/...`, `chore/...`) → PR → merge to `main`. Releases are tagged `vX.Y.Z`.
+- Never commit user-specific agent context (`.claude/`, `CLAUDE.md`, `.gemini/`) or generated reports/exports (`report.html`, `exports/`) — these are gitignored; keep them that way.

--- a/README.md
+++ b/README.md
@@ -29,13 +29,20 @@ Where the tokens go (activity share of input+output)
 Requires Node.js ≥ 24 (uses the built-in `node:sqlite` — zero runtime dependencies).
 
 ```sh
-git clone https://github.com/ryandemelo/token-monitor && cd token-monitor
-npm install && npm run build && npm link
-
-token-monitor collect    # scan local agent logs into ~/.token-monitor/
-token-monitor report     # activity breakdown, personas, recommendations
-token-monitor html       # self-contained dashboard -> report.html
+npx github:ryandemelo/token-monitor collect   # scan local agent logs
+npx github:ryandemelo/token-monitor report    # activity breakdown, personas, recommendations
+npx github:ryandemelo/token-monitor html      # self-contained dashboard -> report.html
 ```
+
+Persistent install: `npm install -g github:ryandemelo/token-monitor`, then `token-monitor <command>`. For development: clone, `npm install && npm test`.
+
+### Or let your coding agent install it
+
+Paste this into Claude Code, Gemini CLI, or any coding agent:
+
+> Install token-monitor from https://github.com/ryandemelo/token-monitor (instructions in its AGENTS.md), run `collect` and `report`, and walk me through what my token usage says.
+
+The repo ships [`AGENTS.md`](AGENTS.md) and [`llms.txt`](llms.txt) so agents can install and operate it without guesswork.
 
 ## What it measures
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,30 @@
+# token-monitor
+
+> Local-first CLI that measures how effectively a developer or team spends AI coding-agent tokens. Parses session logs that Claude Code, Gemini CLI, and Codex already write to disk; classifies every turn by activity (thinking / exploration / coding / testing / shipping); reports cache hit ratio, rework ratio, cost, usage personas, and tracked recommendations. Zero runtime dependencies, no API keys, no network calls — all data stays on the machine.
+
+## Install and run (requires Node.js >= 24)
+
+```sh
+npx github:ryandemelo/token-monitor collect   # scan local agent logs into ~/.token-monitor/
+npx github:ryandemelo/token-monitor report    # terminal report
+npx github:ryandemelo/token-monitor html      # self-contained dashboard -> report.html
+```
+
+Or persistent install: `npm install -g github:ryandemelo/token-monitor`, then use `token-monitor <command>`.
+
+## Commands
+
+- `collect [--source claude-code|gemini-cli|codex] [--db <path>]` — parse local logs into SQLite (idempotent, safe to re-run)
+- `report [--days 30] [--project <name>] [--json] [--db <path>]` — activity breakdown, personas, recommendations, follow-through deltas
+- `html [--out report.html] [--days 30]` — static dashboard, no server
+- `merge <export.json>... [--team team.yaml]` — combine member exports (`report --json`) into a per-discipline team report
+
+## Key files
+
+- README.md — full usage, metrics definitions, personas
+- CONTRIBUTING.md — how to add an adapter for another agent CLI
+- src/types.ts — the normalized UsageEvent schema adapters produce
+
+## Privacy
+
+Stores aggregate numbers only (token counts, tool names, timestamps, project basenames) — never prompt or code content. `report --json` exports are aggregates and safe to share for team rollups.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepare": "tsc",
     "test": "npm run build && node --test \"dist/test/*.test.js\""
   },
   "devDependencies": {


### PR DESCRIPTION
## What

- `prepare` script so `npx github:ryandemelo/token-monitor <cmd>` and `npm install -g github:...` build automatically — install is now one command, no clone
- `llms.txt` — machine-readable project summary + commands for LLMs
- `AGENTS.md` — instructions for coding agents: installing for a user, and hard constraints when contributing (zero runtime deps, privacy rules, branch workflow)
- README quick start rewritten around npx + a copy-paste prompt that lets any coding agent do the setup

## Testing

- 37 tests pass
- `npm pack --dry-run` confirms dist/src ships in the package