### PR TITLE
analyze: session-level deep dive + LLM-powered recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ token-monitor merge exports/*.json --team team.yaml
 
 The team report shows per-discipline rollups: tokens, cost, cache hit, rework, think:code ratio, dominant activity, and persona — so you can see *which discipline* needs which intervention, not just a total bill.
 
+## Deep analysis & LLM-powered recommendations
+
+`token-monitor analyze` goes a level deeper than the report — which sessions and habits burn the tokens:
+
+- **Most expensive sessions** — turns, fix loops, avg context per turn, duration, dominant activity
+- **Fix-loop sessions** — testing→coding churn
+- **Context-heavy sessions** — average tokens fed per turn (context-bloat proxy)
+- **Tool error rates** — tools that keep failing
+
+Add `--llm` and the aggregates go to a coding agent you already have installed (`claude`, `gemini`, or `codex` — auto-detected, override with `--agent`), which returns prioritized interventions with the evidence, the workflow change, and the metric to watch:
+
+```sh
+token-monitor analyze --llm
+```
+
+No API key management: it reuses your existing agent CLI and its subscription. The payload is the same aggregates-only data as `report --json` (token counts, ratios, tool names, project basenames — never prompts or code). It does leave your machine via that agent's provider, so skip `--llm` if even project names are sensitive.
+
 ## Follow-through
 
 Recommendations are tracked, not just printed. The first time one fires, its target metric is recorded as a baseline; every later report re-measures and shows the delta:
@@ -117,6 +134,7 @@ Resolved findings re-open automatically if the metric regresses.
 ```
 token-monitor collect [--source claude-code|gemini-cli|codex] [--db <path>]
 token-monitor report  [--days 30] [--project <name>] [--source <name>] [--json] [--db <path>]
+token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
 token-monitor merge   <export.json>... [--team team.yaml] [--json]
 ```
@@ -137,6 +155,8 @@ The most valuable contribution: an adapter for another agent CLI (Aider, OpenCod
 ## Privacy
 
 Everything stays on your machine. token-monitor reads log files locally, stores aggregate numbers in a local SQLite file, and never makes a network request. Prompt and code content is never stored — only token counts, tool names, timestamps, and project/branch names.
+
+The one opt-in exception: `analyze --llm` sends those aggregates to your own agent CLI's provider for analysis. Everything else is fully offline.
 
 ## License
 

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,0 +1,272 @@
+import { spawnSync } from 'node:child_process';
+import type { StoredEvent } from './store.js';
+import { computeMetrics, groupBy } from './metrics.js';
+import { costOf } from './pricing.js';
+import { assignPersona } from './personas.js';
+import { structuredFindings } from './followthrough.js';
+import type { Activity } from './types.js';
+import { ACTIVITIES } from './types.js';
+import { table, section, fmtTokens } from './report.js';
+
+/**
+ * Deeper, session-level analysis. The report answers "where do tokens go";
+ * analyze answers "which sessions and habits burn them" — and can hand the
+ * aggregates to a local agent CLI for prioritized, LLM-written
+ * recommendations.
+ */
+
+export interface SessionStat {
+  sessionId: string;
+  project: string;
+  source: string;
+  turns: number;
+  spendTokens: number;
+  costUsd: number;
+  errorTurns: number;
+  /** testing -> coding transitions: each is one fix-loop iteration. */
+  fixIterations: number;
+  /** Mean context fed per turn (input + cache read/creation) — bloat proxy. */
+  avgContextTokens: number;
+  durationMin: number;
+  dominant: Activity;
+}
+
+export function computeSessionStats(events: StoredEvent[]): SessionStat[] {
+  const out: SessionStat[] = [];
+  for (const [sessionId, evs] of groupBy(events, 'session_id')) {
+    let spend = 0, cost = 0, errors = 0, fixes = 0, context = 0;
+    const actTokens = Object.fromEntries(ACTIVITIES.map((a) => [a, 0])) as Record<Activity, number>;
+    let prev: string | undefined;
+    for (const e of evs) {
+      spend += e.input_tokens + e.output_tokens;
+      cost += costOf(e.model, e.input_tokens, e.output_tokens, e.cache_read_tokens, e.cache_creation_tokens).usd;
+      if (e.is_error) errors++;
+      if (prev === 'testing' && e.activity === 'coding') fixes++;
+      prev = e.activity;
+      context += e.input_tokens + e.cache_read_tokens + e.cache_creation_tokens;
+      if (ACTIVITIES.includes(e.activity as Activity)) {
+        actTokens[e.activity as Activity] += e.input_tokens + e.output_tokens;
+      }
+    }
+    const first = Date.parse(evs[0].ts);
+    const last = Date.parse(evs[evs.length - 1].ts);
+    out.push({
+      sessionId,
+      project: evs[0].project,
+      source: evs[0].source,
+      turns: evs.length,
+      spendTokens: spend,
+      costUsd: cost,
+      errorTurns: errors,
+      fixIterations: fixes,
+      avgContextTokens: Math.round(context / evs.length),
+      durationMin: Math.max(0, Math.round((last - first) / 60_000)),
+      dominant: ACTIVITIES.reduce((b, a) => (actTokens[a] > actTokens[b] ? a : b)),
+    });
+  }
+  return out;
+}
+
+export interface ToolStat {
+  tool: string;
+  turns: number;
+  errorTurns: number;
+  /** Share of this tool's turns that hit an error. Errors are attributed to
+   *  every tool in the failing turn — an upper bound, not exact blame. */
+  errorRate: number;
+}
+
+export function computeToolStats(events: StoredEvent[]): ToolStat[] {
+  const map = new Map<string, { turns: number; errorTurns: number }>();
+  for (const e of events) {
+    let tools: string[];
+    try {
+      tools = JSON.parse(e.tools);
+    } catch {
+      continue;
+    }
+    for (const t of new Set(tools)) {
+      const s = map.get(t) ?? { turns: 0, errorTurns: 0 };
+      s.turns++;
+      if (e.is_error) s.errorTurns++;
+      map.set(t, s);
+    }
+  }
+  return [...map.entries()]
+    .map(([tool, s]) => ({ tool, ...s, errorRate: s.turns ? s.errorTurns / s.turns : 0 }))
+    .sort((a, b) => b.turns - a.turns);
+}
+
+export interface DeepAnalysis {
+  expensiveSessions: SessionStat[];
+  fixLoopSessions: SessionStat[];
+  contextHeavySessions: SessionStat[];
+  toolStats: ToolStat[];
+}
+
+export function deepAnalysis(events: StoredEvent[]): DeepAnalysis {
+  const stats = computeSessionStats(events);
+  return {
+    expensiveSessions: [...stats].sort((a, b) => b.spendTokens - a.spendTokens).slice(0, 8),
+    fixLoopSessions: stats
+      .filter((s) => s.fixIterations >= 2)
+      .sort((a, b) => b.fixIterations - a.fixIterations)
+      .slice(0, 8),
+    contextHeavySessions: stats
+      .filter((s) => s.turns >= 10)
+      .sort((a, b) => b.avgContextTokens - a.avgContextTokens)
+      .slice(0, 8),
+    toolStats: computeToolStats(events).slice(0, 15),
+  };
+}
+
+// ---------- LLM-powered recommendations ----------
+
+const round = (n: number, d = 3) => Number(n.toFixed(d));
+
+/**
+ * Compact, aggregates-only payload. By construction this contains token
+ * counts, ratios, tool names, project basenames, and persona ids — never
+ * prompt or code content.
+ */
+export function buildLlmPayload(events: StoredEvent[], days: number): object {
+  const m = computeMetrics(events);
+  const deep = deepAnalysis(events);
+  const slim = (s: SessionStat) => ({
+    project: s.project,
+    source: s.source,
+    turns: s.turns,
+    spendTokens: s.spendTokens,
+    costUsd: round(s.costUsd, 2),
+    errorTurns: s.errorTurns,
+    fixIterations: s.fixIterations,
+    avgContextTokens: s.avgContextTokens,
+    durationMin: s.durationMin,
+    dominant: s.dominant,
+  });
+  return {
+    windowDays: days,
+    overall: {
+      sessions: m.sessions,
+      turns: m.events,
+      spendTokens: m.spendTokens,
+      costUsd: round(m.costUsd, 2),
+      cacheHitRatio: round(m.cacheHitRatio),
+      reworkRatio: round(m.reworkRatio),
+      thinkToCodeRatio: round(m.thinkToCodeRatio),
+      activityShares: Object.fromEntries(
+        ACTIVITIES.filter((a) => m.byActivity[a].tokens > 0).map((a) => [a, round(m.byActivity[a].share)]),
+      ),
+      models: Object.fromEntries(
+        Object.entries(m.byModel).map(([k, v]) => [k, { tokens: v.tokens, costUsd: round(v.costUsd, 2) }]),
+      ),
+      persona: assignPersona(m).id,
+    },
+    projects: [...groupBy(events, 'project').entries()]
+      .map(([proj, evs]) => ({ proj, m: computeMetrics(evs) }))
+      .sort((a, b) => b.m.spendTokens - a.m.spendTokens)
+      .slice(0, 10)
+      .map(({ proj, m: pm }) => ({
+        project: proj,
+        spendTokens: pm.spendTokens,
+        costUsd: round(pm.costUsd, 2),
+        cacheHitRatio: round(pm.cacheHitRatio),
+        reworkRatio: round(pm.reworkRatio),
+        thinkToCodeRatio: round(pm.thinkToCodeRatio),
+        persona: assignPersona(pm).id,
+      })),
+    expensiveSessions: deep.expensiveSessions.map(slim),
+    fixLoopSessions: deep.fixLoopSessions.map(slim),
+    contextHeavySessions: deep.contextHeavySessions.map(slim),
+    toolErrorRates: deep.toolStats
+      .filter((t) => t.errorRate > 0.05 && t.turns >= 20)
+      .map((t) => ({ tool: t.tool, turns: t.turns, errorRate: round(t.errorRate, 2) })),
+    ruleBasedFindings: structuredFindings(m).map((f) => f.key),
+  };
+}
+
+export function buildLlmPrompt(events: StoredEvent[], days: number): string {
+  return `You are an engineering-efficiency analyst. The JSON below contains AGGREGATE token-usage telemetry from AI coding agents (Claude Code / Gemini CLI / Codex) for one developer or team over ${days} days. There is no prompt or code content — only counts, ratios, tool names, and project names.
+
+Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.
+
+Analyze the data and respond in markdown:
+1. **Top 3 interventions**, prioritized by expected token/cost savings. For each: the evidence (cite specific numbers/projects/sessions from the data), the concrete workflow change, and which metric will move if it works.
+2. **Anomalies** worth investigating (outlier sessions, suspicious tool error rates, odd activity mixes).
+3. **Per-project notes** for the 3 highest-spend projects — one or two sentences each.
+
+Be specific to this data. No generic advice that ignores the numbers. If the data is too thin for a conclusion, say so.
+
+DATA:
+${JSON.stringify(buildLlmPayload(events, days))}`;
+}
+
+export function renderAnalysis(events: StoredEvent[], days: number): string {
+  const deep = deepAnalysis(events);
+  const out: string[] = [];
+  const sessRow = (s: SessionStat) => [
+    s.project.length > 24 ? s.project.slice(0, 23) + '…' : s.project,
+    s.source,
+    String(s.turns),
+    fmtTokens(s.spendTokens),
+    '$' + s.costUsd.toFixed(2),
+    String(s.fixIterations),
+    fmtTokens(s.avgContextTokens),
+    s.durationMin + 'm',
+    s.dominant,
+  ];
+  const headers = ['Project', 'Source', 'Turns', 'Tokens', 'Cost', 'Fix loops', 'Ctx/turn', 'Span', 'Dominant'];
+
+  out.push(section(`Deep analysis — last ${days} days`));
+  out.push(`${'\x1b[1m'}Most expensive sessions${'\x1b[0m'}`);
+  out.push(table(headers, deep.expensiveSessions.map(sessRow)));
+
+  if (deep.fixLoopSessions.length) {
+    out.push(`\n${'\x1b[1m'}Fix-loop sessions (testing→coding churn)${'\x1b[0m'}`);
+    out.push(table(headers, deep.fixLoopSessions.map(sessRow)));
+  }
+  if (deep.contextHeavySessions.length) {
+    out.push(`\n${'\x1b[1m'}Context-heavy sessions (avg tokens fed per turn)${'\x1b[0m'}`);
+    out.push(table(headers, deep.contextHeavySessions.map(sessRow)));
+  }
+  const failing = deep.toolStats.filter((t) => t.errorRate > 0.05 && t.turns >= 20);
+  if (failing.length) {
+    out.push(`\n${'\x1b[1m'}Tool error rates (errors attributed to all tools in the failing turn)${'\x1b[0m'}`);
+    out.push(
+      table(
+        ['Tool', 'Turns', 'Error turns', 'Error rate'],
+        failing.map((t) => [t.tool, String(t.turns), String(t.errorTurns), (t.errorRate * 100).toFixed(1) + '%']),
+      ),
+    );
+  }
+  out.push(
+    `\n\x1b[2mAdd --llm to get prioritized recommendations from your local agent CLI (claude/gemini/codex).\x1b[0m\n`,
+  );
+  return out.join('\n');
+}
+
+export const LLM_AGENTS: Record<string, (prompt: string) => { cmd: string; args: string[] }> = {
+  claude: (p) => ({ cmd: 'claude', args: ['-p', p] }),
+  gemini: (p) => ({ cmd: 'gemini', args: ['-p', p] }),
+  codex: (p) => ({ cmd: 'codex', args: ['exec', p] }),
+};
+
+export function detectAgent(): string | undefined {
+  for (const name of Object.keys(LLM_AGENTS)) {
+    const r = spawnSync('which', [name], { stdio: 'ignore' });
+    if (r.status === 0) return name;
+  }
+  return undefined;
+}
+
+export function runLlm(prompt: string, agent: string): number {
+  const spec = LLM_AGENTS[agent];
+  if (!spec) {
+    console.error(`Unknown agent "${agent}". Supported: ${Object.keys(LLM_AGENTS).join(', ')}`);
+    return 1;
+  }
+  const { cmd, args } = spec(prompt);
+  console.error(`Sending aggregate metrics (no prompts/code) to ${cmd} for analysis...\n`);
+  const r = spawnSync(cmd, args, { stdio: ['ignore', 'inherit', 'inherit'] });
+  return r.status ?? 1;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { buildExport, parseTeamConfig, mergeMetrics } from './team.js';
 import { syncFindings } from './followthrough.js';
 import { computeMetrics } from './metrics.js';
 import { renderHtml } from './html.js';
+import { renderAnalysis, deepAnalysis, buildLlmPrompt, runLlm, detectAgent } from './analyze.js';
 import type { ExportV1 } from './team.js';
 import type { Source } from './types.js';
 
@@ -17,12 +18,15 @@ const HELP = `token-monitor — measure how effectively your team spends AI codi
 Usage:
   token-monitor collect [--source <name>] [--db <path>]
   token-monitor report  [--days <n>] [--project <name>] [--source <name>] [--json] [--db <path>]
+  token-monitor analyze [--days <n>] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team team.yaml] [--json]
 
 Commands:
   collect   Scan local agent logs (Claude Code, Gemini CLI, Codex) into SQLite
   report    Activity breakdown, cost, personas, and recommendations
+  analyze   Session-level deep dive; --llm asks your local agent CLI for
+            prioritized recommendations (sends aggregate metrics only)
   html      Self-contained HTML dashboard (no server, no external assets)
   merge     Combine member exports (report --json > me.json) into a team report
 
@@ -45,6 +49,8 @@ function main() {
       json: { type: 'boolean', default: false },
       team: { type: 'string' },
       out: { type: 'string', default: 'report.html' },
+      llm: { type: 'boolean', default: false },
+      agent: { type: 'string' },
       db: { type: 'string' },
       help: { type: 'boolean', short: 'h', default: false },
     },
@@ -122,6 +128,26 @@ function main() {
           ? syncFindings(db, computeMetrics(events))
           : undefined;
       console.log(renderReport(events, { days, follow }));
+    }
+  } else if (cmd === 'analyze') {
+    const days = Number(values.days) || 30;
+    const events = loadEvents(db, { days, project: values.project, source: values.source });
+    if (events.length === 0) {
+      console.log('No events in range. Run `token-monitor collect` first, or widen --days.');
+      process.exit(0);
+    }
+    if (values.json) {
+      console.log(JSON.stringify(deepAnalysis(events), null, 2));
+    } else {
+      console.log(renderAnalysis(events, days));
+    }
+    if (values.llm) {
+      const agent = values.agent ?? detectAgent();
+      if (!agent) {
+        console.error('No agent CLI found (looked for: claude, gemini, codex). Install one or pass --agent.');
+        process.exit(1);
+      }
+      process.exit(runLlm(buildLlmPrompt(events, days), agent));
     }
   } else if (cmd === 'html') {
     const days = Number(values.days) || 30;

--- a/src/report.ts
+++ b/src/report.ts
@@ -33,7 +33,7 @@ function bar(share: number, width = 24): string {
   return '█'.repeat(filled) + DIM + '░'.repeat(width - filled) + RESET;
 }
 
-function table(headers: string[], rows: string[][]): string {
+export function table(headers: string[], rows: string[][]): string {
   const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
   const widths = headers.map((h, i) =>
     Math.max(strip(h).length, ...rows.map((r) => strip(r[i] ?? '').length)),
@@ -47,7 +47,7 @@ function table(headers: string[], rows: string[][]): string {
   ].join('\n');
 }
 
-function section(title: string): string {
+export function section(title: string): string {
   return `\n${BOLD}${CYAN}${title}${RESET}\n`;
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -75,6 +75,8 @@ export interface StoredEvent {
   cache_read_tokens: number;
   cache_creation_tokens: number;
   thinking_tokens: number;
+  /** JSON-encoded string[] of tool names. */
+  tools: string;
   has_thinking: number;
   is_error: number;
   activity: string;
@@ -100,7 +102,7 @@ export function loadEvents(
   }
   const sql = `SELECT source, session_id, project, ts, model,
       input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, thinking_tokens,
-      has_thinking, is_error, activity
+      tools, has_thinking, is_error, activity
     FROM events ${where.length ? 'WHERE ' + where.join(' AND ') : ''} ORDER BY ts`;
   return db.prepare(sql).all(...params) as unknown as StoredEvent[];
 }

--- a/test/analyze.test.ts
+++ b/test/analyze.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeSessionStats, computeToolStats, deepAnalysis, buildLlmPayload, buildLlmPrompt } from '../src/analyze.js';
+import { makeStored } from './helpers.js';
+
+const fixLoopSession = [
+  makeStored({ session_id: 'fx', ts: '2026-06-01T10:00:00Z', activity: 'coding', input_tokens: 1000, output_tokens: 0 }),
+  makeStored({ session_id: 'fx', ts: '2026-06-01T10:05:00Z', activity: 'testing', is_error: 1, input_tokens: 500, output_tokens: 0 }),
+  makeStored({ session_id: 'fx', ts: '2026-06-01T10:10:00Z', activity: 'coding', input_tokens: 800, output_tokens: 0 }),
+  makeStored({ session_id: 'fx', ts: '2026-06-01T10:15:00Z', activity: 'testing', input_tokens: 500, output_tokens: 0 }),
+  makeStored({ session_id: 'fx', ts: '2026-06-01T10:20:00Z', activity: 'coding', input_tokens: 700, output_tokens: 0 }),
+];
+
+test('computeSessionStats: fix iterations, duration, context, dominant', () => {
+  const [s] = computeSessionStats(fixLoopSession);
+  assert.equal(s.turns, 5);
+  assert.equal(s.fixIterations, 2); // two testing->coding transitions
+  assert.equal(s.errorTurns, 1);
+  assert.equal(s.durationMin, 20);
+  assert.equal(s.spendTokens, 3500);
+  assert.equal(s.avgContextTokens, 700); // 3500 input / 5 turns, no cache
+  assert.equal(s.dominant, 'coding');
+});
+
+test('computeToolStats attributes errors to tools in failing turns', () => {
+  const stats = computeToolStats([
+    makeStored({ tools: '["Bash","Read"]', is_error: 1 }),
+    makeStored({ tools: '["Bash"]' }),
+    makeStored({ tools: '["Read"]' }),
+    makeStored({ tools: 'not-json' }), // ignored, no throw
+  ]);
+  const bash = stats.find((t) => t.tool === 'Bash');
+  const read = stats.find((t) => t.tool === 'Read');
+  assert.equal(bash?.turns, 2);
+  assert.equal(bash?.errorRate, 0.5);
+  assert.equal(read?.turns, 2);
+  assert.equal(read?.errorRate, 0.5);
+});
+
+test('deepAnalysis surfaces fix-loop sessions and sorts expensive first', () => {
+  const events = [
+    ...fixLoopSession,
+    makeStored({ session_id: 'big', ts: '2026-06-02T10:00:00Z', activity: 'coding', input_tokens: 100_000, output_tokens: 0 }),
+  ];
+  const d = deepAnalysis(events);
+  assert.equal(d.expensiveSessions[0].sessionId, 'big');
+  assert.equal(d.fixLoopSessions.length, 1);
+  assert.equal(d.fixLoopSessions[0].sessionId, 'fx');
+});
+
+test('llm payload contains aggregates only — no transcript-shaped fields', () => {
+  const payload = buildLlmPayload(fixLoopSession, 30) as Record<string, unknown>;
+  const json = JSON.stringify(payload);
+  assert.ok(json.includes('reworkRatio'));
+  assert.ok(!json.includes('sessionId')); // session ids are slimmed out
+  for (const banned of ['"content"', '"message"', '"prompt"', '"command"', 'tool_use']) {
+    assert.ok(!json.includes(banned), `payload must not contain ${banned}`);
+  }
+});
+
+test('llm prompt embeds definitions, asks for prioritized interventions, stays compact', () => {
+  const prompt = buildLlmPrompt(fixLoopSession, 30);
+  assert.ok(prompt.includes('Top 3 interventions'));
+  assert.ok(prompt.includes('reworkRatio = '));
+  assert.ok(prompt.includes('DATA:'));
+  assert.ok(prompt.length < 20_000, `prompt too large: ${prompt.length}`);
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -36,6 +36,7 @@ export function makeStored(partial: Partial<StoredEvent> = {}): StoredEvent {
     cache_read_tokens: 0,
     cache_creation_tokens: 0,
     thinking_tokens: 0,
+    tools: '[]',
     has_thinking: 0,
     is_error: 0,
     activity: 'coding',


### PR DESCRIPTION
## What

New `token-monitor analyze` command:

- **Deterministic deep-dive** — most expensive sessions, fix-loop sessions (testing→coding churn), context-heavy sessions (avg tokens fed per turn as a bloat proxy), per-tool error rates
- **`--llm`** — builds a compact aggregates-only payload and pipes it into a locally installed agent CLI (`claude -p` / `gemini -p` / `codex exec`, auto-detected, `--agent` to override). The agent returns prioritized interventions citing the actual numbers. Reuses the user's existing subscription — no API key handling, zero new deps.
- StoredEvent now surfaces the tools column; README documents the command and the privacy boundary (`--llm` is the only thing that ever leaves the machine, and it's aggregates only)

## Testing

- 42 tests pass; new coverage for session stats (fix iterations, duration, context), tool error attribution, payload hygiene (asserts no transcript-shaped fields), prompt size cap
- Live-tested `--llm` end to end against real local data with the claude CLI — returned specific, evidence-cited interventions