### PR TITLE
Tamper-evident signed exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ The most valuable contribution: an adapter for another agent CLI (Aider, OpenCod
 - [ ] Org-level cross-check via provider usage APIs
 - [ ] npm publish
 
+## Integrity & threat model
+
+Exports are **tamper-evident**. Each machine generates an Ed25519 keypair on first export (`~/.token-monitor/signing-key.pem`, mode 0600); `report --json` signs a canonical serialization of the payload. The team lead verifies on merge:
+
+```sh
+# dev, once: print fingerprint for enrollment
+token-monitor fingerprint            # e.g. 3f9a1c0b2d4e5f67
+
+# lead: pin who may sign for whom (keys.json), then verify on every merge
+echo '{"alice": "3f9a1c0b2d4e5f67"}' > keys.json
+token-monitor merge exports/*.json --verify --keys keys.json
+```
+
+`--verify` rejects any export modified after signing or unsigned; `--keys` additionally rejects exports signed by a key not enrolled for that username (impersonation).
+
+**What this does not cover — read before relying on it:** a developer controls their own machine, so someone determined to game metrics could edit the *source logs* before collection. Signing detects tampering after export, not dishonest inputs. The planned mitigation is reconciling team totals against the provider's billing/usage APIs (roadmap) — gamed numbers won't reconcile. Treat these metrics as a coaching instrument, not a performance-review weapon; the latter invites exactly the gaming this can't stop.
+
 ## Privacy
 
 Everything stays on your machine. token-monitor reads log files locally, stores aggregate numbers in a local SQLite file, and never makes a network request. Prompt and code content is never stored — only token counts, tool names, timestamps, and project/branch names.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { syncFindings } from './followthrough.js';
 import { computeMetrics } from './metrics.js';
 import { renderHtml } from './html.js';
 import { renderAnalysis, deepAnalysis, buildLlmPrompt, runLlm, detectAgent } from './analyze.js';
+import { signObject, verifyObject, ensureKeypair, fingerprint, loadKeyring, checkKeyring, keyDirFor } from './sign.js';
 import type { ExportV1 } from './team.js';
 import type { Source } from './types.js';
 
@@ -20,7 +21,8 @@ Usage:
   token-monitor report  [--days <n>] [--project <name>] [--source <name>] [--json] [--db <path>]
   token-monitor analyze [--days <n>] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
-  token-monitor merge   <export.json>... [--team team.yaml] [--json]
+  token-monitor merge   <export.json>... [--team team.yaml] [--verify] [--keys keys.json] [--json]
+  token-monitor fingerprint [--db <path>]
 
 Commands:
   collect   Scan local agent logs (Claude Code, Gemini CLI, Codex) into SQLite
@@ -29,6 +31,12 @@ Commands:
             prioritized recommendations (sends aggregate metrics only)
   html      Self-contained HTML dashboard (no server, no external assets)
   merge     Combine member exports (report --json > me.json) into a team report
+  fingerprint  Print this machine's signing-key fingerprint (for keyring enrollment)
+
+Integrity:
+  Exports from \`report --json\` are Ed25519-signed. \`merge --verify\` rejects
+  tampered or unsigned exports; add --keys keys.json ({"user": "fingerprint"})
+  to also pin who may sign for whom.
 
 Options:
   --source    one of: ${Object.keys(ADAPTERS).join(', ')} (default: all)
@@ -51,6 +59,8 @@ function main() {
       out: { type: 'string', default: 'report.html' },
       llm: { type: 'boolean', default: false },
       agent: { type: 'string' },
+      verify: { type: 'boolean', default: false },
+      keys: { type: 'string' },
       db: { type: 'string' },
       help: { type: 'boolean', short: 'h', default: false },
     },
@@ -68,13 +78,26 @@ function main() {
       console.error('merge requires at least one export file (token-monitor report --json > me.json)');
       process.exit(1);
     }
+    const keyring = values.keys ? loadKeyring(values.keys) : undefined;
+    let verifyFailed = false;
     const exports: ExportV1[] = files.map((f) => {
       const data = JSON.parse(readFileSync(f, 'utf8'));
       if (data.version !== 1 || !data.overall) {
         throw new Error(`${f} is not a token-monitor v1 export`);
       }
+      if (values.verify || keyring) {
+        let vr = verifyObject(data);
+        if (vr.ok && keyring) vr = checkKeyring(keyring, data.user, vr.fingerprint!);
+        const mark = vr.ok ? '✓' : '✗';
+        console.error(`${mark} ${f} (${data.user})${vr.ok ? ` — signed by ${vr.fingerprint}` : ` — ${vr.reason}`}`);
+        if (!vr.ok) verifyFailed = true;
+      }
       return data as ExportV1;
     });
+    if (verifyFailed) {
+      console.error('\nVerification failed — refusing to merge. Fix or exclude the exports above.');
+      process.exit(1);
+    }
     const team = values.team ? parseTeamConfig(values.team) : {};
     if (values.json) {
       const overall = mergeMetrics(exports.map((e) => e.overall));
@@ -82,6 +105,12 @@ function main() {
     } else {
       console.log(renderTeamReport(exports, team));
     }
+    return;
+  }
+
+  if (cmd === 'fingerprint') {
+    const { publicPem } = ensureKeypair(keyDirFor(values.db));
+    console.log(fingerprint(publicPem));
     return;
   }
 
@@ -113,13 +142,11 @@ function main() {
     if (values.json) {
       const ex = buildExport(events, days);
       const persona = assignPersona(ex.overall);
-      console.log(
-        JSON.stringify(
-          { ...ex, persona, recommendations: [...persona.recommendations, ...generalRecommendations(ex.overall)] },
-          null,
-          2,
-        ),
+      const signed = signObject(
+        { ...ex, persona, recommendations: [...persona.recommendations, ...generalRecommendations(ex.overall)] },
+        keyDirFor(values.db),
       );
+      console.log(JSON.stringify(signed, null, 2));
     } else {
       // Follow-through baselines only on unfiltered runs, so --project/--source
       // slices can't pollute them.

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -1,0 +1,129 @@
+import {
+  generateKeyPairSync,
+  createPrivateKey,
+  createPublicKey,
+  createHash,
+  sign as cryptoSign,
+  verify as cryptoVerify,
+  type KeyObject,
+} from 'node:crypto';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+
+/**
+ * Tamper-evident exports. Each machine holds an Ed25519 keypair; exports are
+ * signed over a canonical serialization, and `merge --verify` checks
+ * signatures (optionally against a pinned username -> fingerprint map).
+ *
+ * Threat model (see README): this detects modification after export and
+ * impersonation of another member. It cannot stop a malicious developer
+ * editing their own source logs before collection — they control the
+ * machine. The mitigation for that is cross-checking totals against the
+ * provider's billing/usage APIs (roadmap).
+ */
+
+export const DEFAULT_KEY_DIR = join(homedir(), '.token-monitor');
+const PRIV = 'signing-key.pem';
+const PUB = 'signing-key.pub.pem';
+
+export function ensureKeypair(dir: string = DEFAULT_KEY_DIR): { privateKey: KeyObject; publicPem: string } {
+  const privPath = join(dir, PRIV);
+  const pubPath = join(dir, PUB);
+  if (!existsSync(privPath)) {
+    mkdirSync(dir, { recursive: true });
+    const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+    writeFileSync(privPath, privateKey.export({ type: 'pkcs8', format: 'pem' }), { mode: 0o600 });
+    writeFileSync(pubPath, publicKey.export({ type: 'spki', format: 'pem' }));
+    chmodSync(privPath, 0o600);
+  }
+  const privateKey = createPrivateKey(readFileSync(privPath, 'utf8'));
+  const publicPem = readFileSync(pubPath, 'utf8');
+  return { privateKey, publicPem };
+}
+
+/** Deterministic JSON: object keys sorted recursively, no whitespace. */
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalize).join(',') + ']';
+  const obj = value as Record<string, unknown>;
+  return (
+    '{' +
+    Object.keys(obj)
+      .sort()
+      .filter((k) => obj[k] !== undefined)
+      .map((k) => JSON.stringify(k) + ':' + canonicalize(obj[k]))
+      .join(',') +
+    '}'
+  );
+}
+
+/** Short, human-comparable identity for a public key. */
+export function fingerprint(publicPem: string): string {
+  const der = createPublicKey(publicPem).export({ type: 'spki', format: 'der' });
+  return createHash('sha256').update(der).digest('hex').slice(0, 16);
+}
+
+export interface Signature {
+  alg: 'ed25519';
+  publicKey: string;
+  signature: string;
+}
+
+export function signObject<T extends object>(payload: T, dir?: string): T & { sig: Signature } {
+  const { privateKey, publicPem } = ensureKeypair(dir);
+  const signature = cryptoSign(null, Buffer.from(canonicalize(payload)), privateKey).toString('base64');
+  return { ...payload, sig: { alg: 'ed25519', publicKey: publicPem, signature } };
+}
+
+export interface VerifyResult {
+  ok: boolean;
+  reason?: string;
+  fingerprint?: string;
+}
+
+export function verifyObject(obj: Record<string, unknown>): VerifyResult {
+  const sig = obj.sig as Signature | undefined;
+  if (!sig?.signature || !sig.publicKey) return { ok: false, reason: 'unsigned' };
+  if (sig.alg !== 'ed25519') return { ok: false, reason: `unsupported alg ${sig.alg}` };
+  const { sig: _drop, ...payload } = obj;
+  try {
+    const publicKey = createPublicKey(sig.publicKey);
+    const ok = cryptoVerify(
+      null,
+      Buffer.from(canonicalize(payload)),
+      publicKey,
+      Buffer.from(sig.signature, 'base64'),
+    );
+    return ok
+      ? { ok: true, fingerprint: fingerprint(sig.publicKey) }
+      : { ok: false, reason: 'signature mismatch — export was modified after signing', fingerprint: fingerprint(sig.publicKey) };
+  } catch (e) {
+    return { ok: false, reason: `invalid key or signature: ${(e as Error).message}` };
+  }
+}
+
+/** keys.json: { "username": "fingerprint", ... } pinned by the team lead. */
+export function loadKeyring(path: string): Record<string, string> {
+  const data = JSON.parse(readFileSync(path, 'utf8'));
+  if (typeof data !== 'object' || data === null) throw new Error('keyring must be an object');
+  return data as Record<string, string>;
+}
+
+export function checkKeyring(
+  keyring: Record<string, string>,
+  user: string,
+  fp: string,
+): VerifyResult {
+  const pinned = keyring[user];
+  if (!pinned) return { ok: false, reason: `user "${user}" not in keyring — enroll fingerprint ${fp}`, fingerprint: fp };
+  if (pinned !== fp) {
+    return { ok: false, reason: `fingerprint mismatch for "${user}": keyring has ${pinned}, export signed by ${fp}`, fingerprint: fp };
+  }
+  return { ok: true, fingerprint: fp };
+}
+
+export function keyDirFor(dbPath?: string): string | undefined {
+  // Keep keys beside a custom db so tests and parallel setups stay isolated.
+  return dbPath ? dirname(dbPath) : undefined;
+}

--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  canonicalize,
+  ensureKeypair,
+  fingerprint,
+  signObject,
+  verifyObject,
+  checkKeyring,
+} from '../src/sign.js';
+
+const keyDir = () => mkdtempSync(join(tmpdir(), 'tm-keys-'));
+
+test('canonicalize is stable across key order and drops undefined', () => {
+  assert.equal(canonicalize({ b: 1, a: [2, { d: 3, c: 4 }] }), canonicalize({ a: [2, { c: 4, d: 3 }], b: 1 }));
+  assert.equal(canonicalize({ a: 1, skip: undefined }), '{"a":1}');
+});
+
+test('sign/verify roundtrip', () => {
+  const dir = keyDir();
+  const signed = signObject({ user: 'alice', total: 42 }, dir);
+  const vr = verifyObject(signed as unknown as Record<string, unknown>);
+  assert.equal(vr.ok, true);
+  assert.equal(vr.fingerprint, fingerprint(ensureKeypair(dir).publicPem));
+});
+
+test('any payload modification breaks the signature', () => {
+  const dir = keyDir();
+  const signed = signObject({ user: 'alice', total: 42 }, dir) as unknown as Record<string, unknown>;
+  const tampered = { ...signed, total: 43 };
+  const vr = verifyObject(tampered);
+  assert.equal(vr.ok, false);
+  assert.match(vr.reason!, /modified after signing/);
+});
+
+test('unsigned and garbage objects are rejected, not thrown', () => {
+  assert.equal(verifyObject({ user: 'x' }).ok, false);
+  assert.equal(verifyObject({ user: 'x' }).reason, 'unsigned');
+  const vr = verifyObject({ user: 'x', sig: { alg: 'ed25519', publicKey: 'not a key', signature: 'xx' } });
+  assert.equal(vr.ok, false);
+});
+
+test('keypair is stable across calls; fingerprints differ between machines', () => {
+  const dirA = keyDir();
+  const dirB = keyDir();
+  const fpA1 = fingerprint(ensureKeypair(dirA).publicPem);
+  const fpA2 = fingerprint(ensureKeypair(dirA).publicPem);
+  const fpB = fingerprint(ensureKeypair(dirB).publicPem);
+  assert.equal(fpA1, fpA2);
+  assert.notEqual(fpA1, fpB);
+  assert.match(fpA1, /^[0-9a-f]{16}$/);
+});
+
+test('keyring pins user -> fingerprint', () => {
+  assert.equal(checkKeyring({ alice: 'aabb' }, 'alice', 'aabb').ok, true);
+  assert.match(checkKeyring({ alice: 'aabb' }, 'alice', 'ccdd').reason!, /mismatch/);
+  assert.match(checkKeyring({}, 'bob', 'eeff').reason!, /not in keyring — enroll fingerprint eeff/);
+});


### PR DESCRIPTION
## What

- `src/sign.ts` — Ed25519 keypair management, canonical JSON, sign/verify, fingerprints, keyring checks. Zero new dependencies (node:crypto).
- `report --json` output is now signed; `merge --verify` refuses tampered/unsigned exports; `--keys keys.json` pins who may sign for whom
- `token-monitor fingerprint` prints the local key fingerprint for enrollment
- README: integrity section with an explicit threat model (and a note that these metrics should coach, not punish — gaming incentives are the real adversary)

## Testing

50 tests pass. New: canonicalization stability, roundtrip, tamper detection, garbage-key handling, keyring pin/mismatch/enroll paths. E2E: real export verified, then a 1-field tamper rejected with exit 1.

Closes #4, closes #7