### PR TITLE
Remote team bootstrap: init --from, scheduled collection, signed push

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ Adapters skip gracefully when a tool isn't installed.
 
 ## Team usage
 
+### Remote rollout (lead → team)
+
+The lead hosts one config file anywhere (gist, internal wiki, S3) and sends one line — pasteable by the dev, an MDM/onboarding script, or their coding agent:
+
+```sh
+npx github:ryandemelo/token-monitor init --from https://example.com/team-config.json
+```
+
+```jsonc
+// team-config.json
+{
+  "teamName": "acme-eng",
+  "push": { "type": "http", "url": "https://reports.example.com/token-monitor" },
+  // or: "push": { "type": "path", "dir": "/Volumes/shared/token-monitor" }
+  "scheduleHours": 24,
+  "windowDays": 30
+}
+```
+
+`init` saves the config, generates the signing keypair, runs the first collection, installs the recurring collect+push job (launchd on macOS, cron on Linux), and prints the dev's fingerprint for the lead's `keys.json`. From then on signed exports arrive on schedule; the lead runs `merge <files> --verify --keys keys.json`. `token-monitor schedule --remove` uninstalls.
+
+### Manual flow
+
 Each developer exports locally; the JSON contains aggregate metrics only (no prompts, no code, no file paths beyond project basenames), so it's safe to share:
 
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,9 @@ import { syncFindings } from './followthrough.js';
 import { computeMetrics } from './metrics.js';
 import { renderHtml } from './html.js';
 import { renderAnalysis, deepAnalysis, buildLlmPrompt, runLlm, detectAgent } from './analyze.js';
-import { signObject, verifyObject, ensureKeypair, fingerprint, loadKeyring, checkKeyring, keyDirFor } from './sign.js';
+import { signObject, verifyObject, ensureKeypair, fingerprint, loadKeyring, checkKeyring, keyDirFor, DEFAULT_KEY_DIR } from './sign.js';
+import { fetchTeamConfig, saveConfig, loadConfig, pushExport, installSchedule, removeSchedule } from './deploy.js';
+import { realpathSync } from 'node:fs';
 import type { ExportV1 } from './team.js';
 import type { Source } from './types.js';
 
@@ -22,6 +24,9 @@ Usage:
   token-monitor analyze [--days <n>] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team team.yaml] [--verify] [--keys keys.json] [--json]
+  token-monitor init    --from <url-or-path>
+  token-monitor push    [--db <path>]
+  token-monitor schedule [--hours <n>] [--remove]
   token-monitor fingerprint [--db <path>]
 
 Commands:
@@ -31,6 +36,10 @@ Commands:
             prioritized recommendations (sends aggregate metrics only)
   html      Self-contained HTML dashboard (no server, no external assets)
   merge     Combine member exports (report --json > me.json) into a team report
+  init      Join a team: fetch the lead's config, set up keys, first collect,
+            and (if configured) install the collection schedule
+  push      Sign and deliver an export to the team destination from config
+  schedule  Install/remove a recurring collect+push job (launchd/cron)
   fingerprint  Print this machine's signing-key fingerprint (for keyring enrollment)
 
 Integrity:
@@ -47,7 +56,36 @@ Options:
   --db        SQLite path (default: ${DEFAULT_DB})
 `;
 
-function main() {
+function buildSignedExportJson(
+  db: ReturnType<typeof openDb>,
+  days: number,
+  dbPath?: string,
+  filters: { project?: string; source?: string } = {},
+): string {
+  const events = loadEvents(db, { days, ...filters });
+  const ex = buildExport(events, days);
+  const persona = assignPersona(ex.overall);
+  const signed = signObject(
+    { ...ex, persona, recommendations: [...persona.recommendations, ...generalRecommendations(ex.overall)] },
+    keyDirFor(dbPath),
+  );
+  return JSON.stringify(signed, null, 2);
+}
+
+function runCollect(db: ReturnType<typeof openDb>, sources: Source[]): void {
+  for (const source of sources) {
+    const { events, result } = ADAPTERS[source]();
+    result.eventsInserted = insertEvents(db, events);
+    const note = result.note ? `  (${result.note})` : '';
+    console.log(
+      `${source.padEnd(12)} ${String(result.filesScanned).padStart(5)} files  ` +
+        `${String(result.eventsFound).padStart(7)} turns  ` +
+        `${String(result.eventsInserted).padStart(7)} new${note}`,
+    );
+  }
+}
+
+async function main() {
   const { values, positionals } = parseArgs({
     allowPositionals: true,
     options: {
@@ -61,6 +99,9 @@ function main() {
       agent: { type: 'string' },
       verify: { type: 'boolean', default: false },
       keys: { type: 'string' },
+      from: { type: 'string' },
+      hours: { type: 'string' },
+      remove: { type: 'boolean', default: false },
       db: { type: 'string' },
       help: { type: 'boolean', short: 'h', default: false },
     },
@@ -120,33 +161,57 @@ function main() {
     const sources = values.source
       ? [values.source as Source]
       : (Object.keys(ADAPTERS) as Source[]);
-    for (const source of sources) {
-      const adapter = ADAPTERS[source];
-      if (!adapter) {
-        console.error(`Unknown source "${source}". Valid: ${Object.keys(ADAPTERS).join(', ')}`);
-        process.exit(1);
-      }
-      const { events, result } = adapter();
-      result.eventsInserted = insertEvents(db, events);
-      const note = result.note ? `  (${result.note})` : '';
-      console.log(
-        `${source.padEnd(12)} ${String(result.filesScanned).padStart(5)} files  ` +
-          `${String(result.eventsFound).padStart(7)} turns  ` +
-          `${String(result.eventsInserted).padStart(7)} new${note}`,
-      );
+    if (values.source && !ADAPTERS[values.source as Source]) {
+      console.error(`Unknown source "${values.source}". Valid: ${Object.keys(ADAPTERS).join(', ')}`);
+      process.exit(1);
     }
+    runCollect(db, sources);
     console.log(`\nStored in ${values.db ?? DEFAULT_DB}. Run \`token-monitor report\` next.`);
+  } else if (cmd === 'init') {
+    if (!values.from) {
+      console.error('init requires --from <url-or-path> pointing at the team config JSON');
+      process.exit(1);
+    }
+    const dir = keyDirFor(values.db) ?? DEFAULT_KEY_DIR;
+    const config = await fetchTeamConfig(values.from);
+    saveConfig(config, dir);
+    const { publicPem } = ensureKeypair(keyDirFor(values.db));
+    console.log(`Joined team "${config.teamName}". First collection:\n`);
+    runCollect(db, Object.keys(ADAPTERS) as Source[]);
+    let scheduleNote = 'none configured — run `token-monitor push` manually';
+    if (config.scheduleHours) {
+      scheduleNote = installSchedule(process.execPath, realpathSync(process.argv[1]), config.scheduleHours);
+    }
+    console.log(`
+Schedule: ${scheduleNote}
+Signing fingerprint (send to your team lead for keys.json):
+
+  ${fingerprint(publicPem)}
+`);
+  } else if (cmd === 'push') {
+    const config = loadConfig(keyDirFor(values.db) ?? DEFAULT_KEY_DIR);
+    const days = Number(values.days) || config.windowDays || 30;
+    const where = await pushExport(buildSignedExportJson(db, days, values.db), config);
+    console.log(`Export (last ${days} days, signed) — ${where}`);
+  } else if (cmd === 'schedule') {
+    if (values.remove) {
+      console.log(removeSchedule());
+    } else {
+      let hours = Number(values.hours) || 0;
+      if (!hours) {
+        try {
+          hours = loadConfig(keyDirFor(values.db) ?? DEFAULT_KEY_DIR).scheduleHours ?? 24;
+        } catch {
+          hours = 24;
+        }
+      }
+      console.log(installSchedule(process.execPath, realpathSync(process.argv[1]), hours));
+    }
   } else if (cmd === 'report') {
     const days = Number(values.days) || 30;
     const events = loadEvents(db, { days, project: values.project, source: values.source });
     if (values.json) {
-      const ex = buildExport(events, days);
-      const persona = assignPersona(ex.overall);
-      const signed = signObject(
-        { ...ex, persona, recommendations: [...persona.recommendations, ...generalRecommendations(ex.overall)] },
-        keyDirFor(values.db),
-      );
-      console.log(JSON.stringify(signed, null, 2));
+      console.log(buildSignedExportJson(db, days, values.db, { project: values.project, source: values.source }));
     } else {
       // Follow-through baselines only on unfiltered runs, so --project/--source
       // slices can't pollute them.
@@ -189,4 +254,7 @@ function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,0 +1,183 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir, userInfo, platform } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { DEFAULT_KEY_DIR } from './sign.js';
+
+/**
+ * Team rollout. A lead hosts one config file; each dev (or their MDM /
+ * onboarding script / coding agent) runs:
+ *
+ *   npx github:ryandemelo/token-monitor init --from <url>
+ *
+ * init stores the config, generates the signing keypair, runs a first
+ * collect, optionally installs the collection schedule, and prints the
+ * fingerprint for keyring enrollment.
+ */
+
+export interface TeamDeployConfig {
+  teamName: string;
+  push: { type: 'http'; url: string } | { type: 'path'; dir: string };
+  /** Install a recurring collect+push job every N hours (launchd/cron). */
+  scheduleHours?: number;
+  /** Export window passed to report; default 30. */
+  windowDays?: number;
+}
+
+export function validateTeamConfig(data: unknown): TeamDeployConfig {
+  const c = data as TeamDeployConfig;
+  if (!c || typeof c !== 'object') throw new Error('team config must be a JSON object');
+  if (!c.teamName || typeof c.teamName !== 'string') throw new Error('team config: "teamName" (string) required');
+  const p = c.push as { type?: string; url?: string; dir?: string } | undefined;
+  if (!p || (p.type !== 'http' && p.type !== 'path')) {
+    throw new Error('team config: "push" must be {type:"http", url} or {type:"path", dir}');
+  }
+  if (p.type === 'http' && !p.url?.startsWith('https://') && !p.url?.startsWith('http://localhost')) {
+    throw new Error('team config: push.url must be https (or http://localhost for testing)');
+  }
+  if (p.type === 'path' && !p.dir) throw new Error('team config: push.dir required');
+  if (c.scheduleHours !== undefined && (typeof c.scheduleHours !== 'number' || c.scheduleHours < 1 || c.scheduleHours > 168)) {
+    throw new Error('team config: scheduleHours must be 1-168');
+  }
+  if (c.windowDays !== undefined && (typeof c.windowDays !== 'number' || c.windowDays < 1)) {
+    throw new Error('team config: windowDays must be >= 1');
+  }
+  return c;
+}
+
+export async function fetchTeamConfig(source: string): Promise<TeamDeployConfig> {
+  let text: string;
+  if (/^https?:\/\//.test(source)) {
+    const res = await fetch(source);
+    if (!res.ok) throw new Error(`fetching team config: HTTP ${res.status} from ${source}`);
+    text = await res.text();
+  } else {
+    text = readFileSync(source, 'utf8');
+  }
+  return validateTeamConfig(JSON.parse(text));
+}
+
+export function configPath(dir: string = DEFAULT_KEY_DIR): string {
+  return join(dir, 'config.json');
+}
+
+export function saveConfig(config: TeamDeployConfig, dir: string = DEFAULT_KEY_DIR): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(configPath(dir), JSON.stringify(config, null, 2));
+}
+
+export function loadConfig(dir: string = DEFAULT_KEY_DIR): TeamDeployConfig {
+  const p = configPath(dir);
+  if (!existsSync(p)) {
+    throw new Error(`no team config at ${p} — run \`token-monitor init --from <url>\` first`);
+  }
+  return validateTeamConfig(JSON.parse(readFileSync(p, 'utf8')));
+}
+
+export function exportFilename(user: string, date = new Date()): string {
+  return `${user}-${date.toISOString().slice(0, 10)}.json`;
+}
+
+/** Deliver a signed export per config. Returns a human description of where it went. */
+export async function pushExport(signedJson: string, config: TeamDeployConfig): Promise<string> {
+  if (config.push.type === 'http') {
+    const res = await fetch(config.push.url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-token-monitor-team': config.teamName },
+      body: signedJson,
+    });
+    if (!res.ok) throw new Error(`push failed: HTTP ${res.status} from ${config.push.url}`);
+    return `POSTed to ${config.push.url}`;
+  }
+  mkdirSync(config.push.dir, { recursive: true });
+  const file = join(config.push.dir, exportFilename(userInfo().username));
+  writeFileSync(file, signedJson);
+  return `wrote ${file}`;
+}
+
+// ---------- scheduling ----------
+
+const LAUNCHD_LABEL = 'com.token-monitor.collect';
+const CRON_MARKER = '# token-monitor';
+
+export function launchdPlistPath(): string {
+  return join(homedir(), 'Library', 'LaunchAgents', `${LAUNCHD_LABEL}.plist`);
+}
+
+export function buildLaunchdPlist(nodePath: string, cliPath: string, hours: number): string {
+  const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LAUNCHD_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>${esc(`"${nodePath}" "${cliPath}" collect && "${nodePath}" "${cliPath}" push`)}</string>
+  </array>
+  <key>StartInterval</key><integer>${Math.round(hours * 3600)}</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardErrorPath</key><string>/tmp/token-monitor.err</string>
+</dict>
+</plist>
+`;
+}
+
+export function buildCronLine(nodePath: string, cliPath: string, hours: number): string {
+  const h = Math.max(1, Math.min(23, Math.round(hours)));
+  return `0 */${h} * * * "${nodePath}" "${cliPath}" collect && "${nodePath}" "${cliPath}" push ${CRON_MARKER}`;
+}
+
+export function installSchedule(nodePath: string, cliPath: string, hours: number): string {
+  if (platform() === 'darwin') {
+    const plist = launchdPlistPath();
+    mkdirSync(join(homedir(), 'Library', 'LaunchAgents'), { recursive: true });
+    writeFileSync(plist, buildLaunchdPlist(nodePath, cliPath, hours));
+    try {
+      execFileSync('launchctl', ['unload', plist], { stdio: 'ignore' });
+    } catch { /* not loaded yet */ }
+    try {
+      execFileSync('launchctl', ['load', plist], { stdio: 'ignore' });
+      return `launchd agent installed (${plist}), every ${hours}h`;
+    } catch {
+      return `wrote ${plist} — load it with: launchctl load ${plist}`;
+    }
+  }
+  if (platform() === 'linux') {
+    let existing = '';
+    try {
+      existing = execFileSync('crontab', ['-l'], { encoding: 'utf8' });
+    } catch { /* empty crontab */ }
+    const kept = existing.split('\n').filter((l) => l.trim() && !l.includes(CRON_MARKER));
+    kept.push(buildCronLine(nodePath, cliPath, hours));
+    execFileSync('crontab', ['-'], { input: kept.join('\n') + '\n' });
+    return `cron entry installed, every ${hours}h`;
+  }
+  throw new Error(`scheduling not supported on ${platform()} yet — run \`collect\` + \`push\` from your own scheduler`);
+}
+
+export function removeSchedule(): string {
+  if (platform() === 'darwin') {
+    const plist = launchdPlistPath();
+    if (!existsSync(plist)) return 'no schedule installed';
+    try {
+      execFileSync('launchctl', ['unload', plist], { stdio: 'ignore' });
+    } catch { /* fine */ }
+    rmSync(plist);
+    return 'launchd agent removed';
+  }
+  if (platform() === 'linux') {
+    let existing = '';
+    try {
+      existing = execFileSync('crontab', ['-l'], { encoding: 'utf8' });
+    } catch {
+      return 'no schedule installed';
+    }
+    const kept = existing.split('\n').filter((l) => l.trim() && !l.includes(CRON_MARKER));
+    execFileSync('crontab', ['-'], { input: kept.length ? kept.join('\n') + '\n' : '' });
+    return 'cron entry removed';
+  }
+  return 'no schedule installed';
+}

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir, userInfo } from 'node:os';
+import {
+  validateTeamConfig,
+  fetchTeamConfig,
+  saveConfig,
+  loadConfig,
+  pushExport,
+  exportFilename,
+  buildLaunchdPlist,
+  buildCronLine,
+} from '../src/deploy.js';
+
+const tmp = () => mkdtempSync(join(tmpdir(), 'tm-deploy-'));
+
+test('validateTeamConfig accepts valid configs and rejects broken ones', () => {
+  const ok = validateTeamConfig({ teamName: 't', push: { type: 'path', dir: '/x' }, scheduleHours: 12 });
+  assert.equal(ok.teamName, 't');
+  assert.throws(() => validateTeamConfig({}), /teamName/);
+  assert.throws(() => validateTeamConfig({ teamName: 't' }), /push/);
+  assert.throws(() => validateTeamConfig({ teamName: 't', push: { type: 'http', url: 'http://evil.com/x' } }), /https/);
+  assert.throws(() => validateTeamConfig({ teamName: 't', push: { type: 'path', dir: '/x' }, scheduleHours: 0 }), /scheduleHours/);
+});
+
+test('fetchTeamConfig reads local paths; save/load roundtrip', async () => {
+  const dir = tmp();
+  const cfgFile = join(dir, 'team.json');
+  writeFileSync(cfgFile, JSON.stringify({ teamName: 'acme', push: { type: 'path', dir: join(dir, 'drop') } }));
+  const cfg = await fetchTeamConfig(cfgFile);
+  assert.equal(cfg.teamName, 'acme');
+
+  saveConfig(cfg, dir);
+  assert.deepEqual(loadConfig(dir), cfg);
+  assert.throws(() => loadConfig(tmp()), /run `token-monitor init/);
+});
+
+test('pushExport path destination writes a per-user dated file', async () => {
+  const dir = tmp();
+  const cfg = validateTeamConfig({ teamName: 'acme', push: { type: 'path', dir: join(dir, 'drop') } });
+  const where = await pushExport('{"hello":1}', cfg);
+  assert.match(where, /wrote /);
+  const files = readdirSync(join(dir, 'drop'));
+  assert.equal(files.length, 1);
+  assert.equal(files[0], exportFilename(userInfo().username));
+  assert.equal(readFileSync(join(dir, 'drop', files[0]), 'utf8'), '{"hello":1}');
+});
+
+test('launchd plist embeds node, cli and interval; xml-escapes', () => {
+  const plist = buildLaunchdPlist('/usr/local/bin/node', '/a&b/cli.js', 6);
+  assert.ok(plist.includes('<integer>21600</integer>'));
+  assert.ok(plist.includes('com.token-monitor.collect'));
+  assert.ok(plist.includes('&amp;'));
+  assert.ok(!plist.includes('/a&b/')); // raw ampersand must not survive
+  assert.ok(plist.includes('collect') && plist.includes('push'));
+});
+
+test('cron line clamps interval and carries the removal marker', () => {
+  const line = buildCronLine('/usr/bin/node', '/cli.js', 6);
+  assert.match(line, /^0 \*\/6 \* \* \* /);
+  assert.ok(line.endsWith('# token-monitor'));
+  assert.match(buildCronLine('/n', '/c', 100), /\*\/23/); // clamped to cron-expressible
+});


### PR DESCRIPTION
## What

Completes the v0.3 team-deployment story:

- **`init --from <url-or-path>`** — the one-liner a lead sends (or pushes via MDM): fetches+validates team config, stores it, generates the Ed25519 keypair, runs first collect, installs the collection schedule when configured, prints the enrollment fingerprint
- **`push`** — signs the export and delivers it: HTTPS POST (built-in fetch, https enforced) or per-user dated file on a shared path
- **`schedule`** — launchd agent on macOS / crontab entry on Linux for recurring collect+push; `--remove` uninstalls; marker-based cron management won't clobber other entries
- README: remote-rollout section with example config

## Testing

55 tests pass — config validation, local fetch + save/load roundtrip, path push (dated per-user file), plist/cron builders (XML escaping, interval clamp). E2E on this machine: `init` from a local config → `push` to a drop dir → `merge --verify` confirms the signature with matching fingerprint.

Closes #5, closes #6