### PR TITLE
feat: Cursor adapter — per-turn tokens from state.vscdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Personas are computed per-project and overall, so one expensive workflow can't h
 | **Claude Code** | `~/.claude/projects/**/*.jsonl` | ✅ Verified — per-turn tokens, cache split, model, tools, git branch |
 | **Gemini CLI** | `~/.gemini/tmp/*/chats/*.json` | ✅ Verified — per-turn tokens incl. thoughts, tool calls |
 | **Codex CLI** | `~/.codex/sessions/**/rollout-*.jsonl` | ⚠️ Experimental — diffs cumulative `token_count` events; verify against Codex's own usage screens |
+| **Cursor** | `Cursor/User/globalStorage/state.vscdb` (SQLite) | ✅ Verified — per-turn tokens on completed turns, tool calls, agent/chat sessions. Cursor doesn't persist cache tokens or the resolved backend model (Auto mode reports as `cursor-auto`) |
 
-Adapters skip gracefully when a tool isn't installed.
+Adapters skip gracefully when a tool isn't installed. The Cursor adapter reads only composer/bubble keys — never the auth entries that live in the same database.
 
 ## Team usage
 

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -1,0 +1,229 @@
+import { readdirSync, readFileSync, existsSync, copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+import type { UsageEvent, CollectResult } from '../types.js';
+import { classify } from '../classify.js';
+
+/**
+ * Cursor stores composer (chat/agent) state in a SQLite key/value store:
+ *   <User dir>/globalStorage/state.vscdb, table cursorDiskKV
+ *     composerData:<composerId>            one JSON doc per session
+ *     bubbleId:<composerId>:<bubbleId>     one JSON doc per turn event
+ * Token counts (tokenCount.inputTokens/outputTokens) are populated only on
+ * the turn-final assistant bubble and are that turn's totals; intermediate
+ * tool bubbles carry zeros. Cache tokens, cost, and the resolved backend
+ * model are not persisted locally (model reads "default" in Auto mode).
+ *
+ * SECURITY: the same database's ItemTable holds Cursor auth credentials
+ * (cursorAuth/*). This adapter must only ever read the two cursorDiskKV key
+ * prefixes above from globalStorage, and the single `composer.composerData`
+ * ItemTable key from per-workspace databases (composer -> workspace mapping).
+ * Never SELECT * and never touch globalStorage ItemTable.
+ */
+
+export function cursorUserDir(home: string = homedir()): string {
+  if (process.platform === 'darwin') return join(home, 'Library', 'Application Support', 'Cursor', 'User');
+  if (process.platform === 'win32') {
+    return join(process.env.APPDATA ?? join(home, 'AppData', 'Roaming'), 'Cursor', 'User');
+  }
+  return join(home, '.config', 'Cursor', 'User');
+}
+
+interface Bubble {
+  type?: number; // 1 = user, 2 = assistant
+  createdAt?: string;
+  tokenCount?: { inputTokens?: number; outputTokens?: number };
+  toolFormerData?: { name?: string; status?: string; rawArgs?: string };
+  modelInfo?: { modelName?: string };
+}
+
+interface ComposerDoc {
+  composerId?: string;
+  createdAt?: number;
+  lastUpdatedAt?: number;
+  modelConfig?: { modelName?: string };
+  fullConversationHeadersOnly?: Array<{ bubbleId?: string }>;
+}
+
+const SHELL_TOOL_RE = /terminal|shell|command/i;
+
+/** Open a copy of a (possibly WAL-journaled, possibly live) SQLite db read-only. */
+function openDbCopy(dbPath: string, scratch: string, name: string): DatabaseSync {
+  const copy = join(scratch, name);
+  copyFileSync(dbPath, copy);
+  for (const suffix of ['-wal', '-shm']) {
+    if (existsSync(dbPath + suffix)) copyFileSync(dbPath + suffix, copy + suffix);
+  }
+  return new DatabaseSync(copy);
+}
+
+/** composerId -> project basename, via each workspace's composer list + folder URI. */
+function loadWorkspaceMap(userDir: string, scratch: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const wsRoot = join(userDir, 'workspaceStorage');
+  let dirs: string[];
+  try {
+    dirs = readdirSync(wsRoot);
+  } catch {
+    return map;
+  }
+  for (const dir of dirs) {
+    let project: string | undefined;
+    try {
+      const ws = JSON.parse(readFileSync(join(wsRoot, dir, 'workspace.json'), 'utf8'));
+      const folder = ws.folder ?? ws.workspace;
+      if (typeof folder === 'string') project = basename(decodeURIComponent(folder.replace(/^file:\/\//, '')));
+    } catch {
+      continue;
+    }
+    const wsDb = join(wsRoot, dir, 'state.vscdb');
+    if (!project || !existsSync(wsDb)) continue;
+    try {
+      const db = openDbCopy(wsDb, scratch, `ws-${dir}.vscdb`);
+      try {
+        // Only this exact key — workspace ItemTable is UI state, but stay narrow anyway.
+        const row = db
+          .prepare(`SELECT value FROM ItemTable WHERE key = 'composer.composerData'`)
+          .get() as { value?: string } | undefined;
+        if (row?.value) {
+          const data = JSON.parse(row.value);
+          for (const c of data.allComposers ?? []) {
+            if (typeof c?.composerId === 'string') map.set(c.composerId, project);
+          }
+        }
+      } finally {
+        db.close();
+      }
+    } catch {
+      continue;
+    }
+  }
+  return map;
+}
+
+export function collectCursor(userDir: string = cursorUserDir()): { events: UsageEvent[]; result: CollectResult } {
+  const events: UsageEvent[] = [];
+  const globalDb = join(userDir, 'globalStorage', 'state.vscdb');
+  if (!existsSync(globalDb)) {
+    return { events, result: { source: 'cursor', filesScanned: 0, eventsFound: 0, eventsInserted: 0, note: `${globalDb} not found — Cursor not detected` } };
+  }
+
+  const scratch = mkdtempSync(join(tmpdir(), 'tm-cursor-'));
+  try {
+    const composers = new Map<string, ComposerDoc>();
+    const bubbles = new Map<string, Map<string, Bubble>>(); // composerId -> bubbleId -> bubble
+
+    const db = openDbCopy(globalDb, scratch, 'state.vscdb');
+    try {
+      const rows = db
+        .prepare(
+          `SELECT key, value FROM cursorDiskKV
+           WHERE key LIKE 'composerData:%' OR key LIKE 'bubbleId:%'`,
+        )
+        .all() as Array<{ key: string; value: string | null }>;
+      for (const { key, value } of rows) {
+        if (!value) continue;
+        let doc: unknown;
+        try {
+          doc = JSON.parse(value);
+        } catch {
+          continue;
+        }
+        if (key.startsWith('composerData:')) {
+          composers.set(key.slice('composerData:'.length), doc as ComposerDoc);
+        } else {
+          const [, composerId, bubbleId] = key.split(':');
+          if (!composerId || !bubbleId) continue;
+          let forComposer = bubbles.get(composerId);
+          if (!forComposer) bubbles.set(composerId, (forComposer = new Map()));
+          forComposer.set(bubbleId, doc as Bubble);
+        }
+      }
+    } finally {
+      db.close();
+    }
+
+    const projects = loadWorkspaceMap(userDir, scratch);
+
+    for (const [composerId, composer] of composers) {
+      const byId = bubbles.get(composerId);
+      if (!byId || byId.size === 0) continue;
+      const headers = composer.fullConversationHeadersOnly ?? [];
+      const ordered: Array<[string, Bubble]> = headers.length
+        ? headers.flatMap((h) => {
+            const b = h.bubbleId ? byId.get(h.bubbleId) : undefined;
+            return b && h.bubbleId ? [[h.bubbleId, b] as [string, Bubble]] : [];
+          })
+        : [...byId.entries()];
+
+      const project = projects.get(composerId) ?? 'unknown';
+      let tools: string[] = [];
+      let commands: string[] = [];
+      let isError = false;
+
+      for (const [bubbleId, bubble] of ordered) {
+        const tf = bubble.toolFormerData;
+        if (tf?.name) {
+          tools.push(tf.name);
+          if (tf.status === 'error' || tf.status === 'failed') isError = true;
+          if (SHELL_TOOL_RE.test(tf.name) && typeof tf.rawArgs === 'string') {
+            try {
+              const cmd = JSON.parse(tf.rawArgs).command;
+              if (typeof cmd === 'string') commands.push(cmd);
+            } catch { /* ignore */ }
+          }
+        }
+        const input = bubble.tokenCount?.inputTokens ?? 0;
+        const output = bubble.tokenCount?.outputTokens ?? 0;
+        // Zero on intermediate bubbles; the turn-final bubble carries turn totals.
+        if (input === 0 && output === 0) continue;
+
+        const modelName = bubble.modelInfo?.modelName ?? composer.modelConfig?.modelName;
+        const ts =
+          bubble.createdAt ??
+          (composer.lastUpdatedAt ? new Date(composer.lastUpdatedAt).toISOString() : new Date(0).toISOString());
+        const ev: UsageEvent = {
+          source: 'cursor',
+          eventKey: `${composerId}:${bubbleId}`,
+          sessionId: composerId,
+          project,
+          timestamp: ts,
+          model: !modelName || modelName === 'default' ? 'cursor-auto' : modelName,
+          inputTokens: input,
+          outputTokens: output,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          thinkingTokens: 0,
+          tools,
+          commands,
+          hasThinking: false,
+          isError,
+        };
+        ev.activity = classify(ev);
+        events.push(ev);
+        tools = [];
+        commands = [];
+        isError = false;
+      }
+    }
+
+    return {
+      events,
+      result: {
+        source: 'cursor',
+        filesScanned: 1,
+        eventsFound: events.length,
+        eventsInserted: 0,
+        note: events.length > 0 ? 'tokens cover completed turns only; Cursor does not persist cache tokens or the resolved model locally' : undefined,
+      },
+    };
+  } catch (err) {
+    return {
+      events: [],
+      result: { source: 'cursor', filesScanned: 1, eventsFound: 0, eventsInserted: 0, note: `cursor parse failed: ${err instanceof Error ? err.message : String(err)}` },
+    };
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -2,6 +2,7 @@ import type { UsageEvent, CollectResult, Source } from '../types.js';
 import { collectClaudeCode } from './claude-code.js';
 import { collectGeminiCli } from './gemini-cli.js';
 import { collectCodex } from './codex.js';
+import { collectCursor } from './cursor.js';
 
 export type Adapter = () => { events: UsageEvent[]; result: CollectResult };
 
@@ -15,4 +16,5 @@ export const ADAPTERS: Record<Source, Adapter> = {
   'claude-code': collectClaudeCode,
   'gemini-cli': collectGeminiCli,
   codex: collectCodex,
+  cursor: collectCursor,
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ Usage:
   token-monitor fingerprint [--db <path>]
 
 Commands:
-  collect   Scan local agent logs (Claude Code, Gemini CLI, Codex) into SQLite
+  collect   Scan local agent logs (Claude Code, Gemini CLI, Codex, Cursor) into SQLite
   report    Activity breakdown, cost, personas, and recommendations
   analyze   Session-level deep dive; --llm asks your local agent CLI for
             prioritized recommendations (sends aggregate metrics only)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Source = 'claude-code' | 'gemini-cli' | 'codex';
+export type Source = 'claude-code' | 'gemini-cli' | 'codex' | 'cursor';
 
 export type Activity =
   | 'thinking'

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -5,6 +5,10 @@ import { join, dirname } from 'node:path';
 import { collectClaudeCode } from '../src/adapters/claude-code.js';
 import { collectGeminiCli } from '../src/adapters/gemini-cli.js';
 import { collectCodex } from '../src/adapters/codex.js';
+import { collectCursor } from '../src/adapters/cursor.js';
+import { makeCursorFixture } from './helpers.js';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 // dist/test/ -> repo root -> test/fixtures
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'test', 'fixtures');
@@ -76,8 +80,36 @@ test('codex adapter diffs cumulative token counts into per-turn events', () => {
   assert.equal(t2.activity, 'coding'); // apply_patch
 });
 
+test('cursor adapter emits turn-final token events, maps workspaces, skips aborted turns', () => {
+  const userDir = mkdtempSync(join(tmpdir(), 'tm-cursor-fixture-'));
+  makeCursorFixture(userDir);
+  const { events, result } = collectCursor(userDir);
+
+  assert.equal(events.length, 2); // c2 aborted -> nothing
+  const [t1, t2] = events;
+  assert.equal(t1.eventKey, 'c1:b4');
+  assert.equal(t1.sessionId, 'c1');
+  assert.equal(t1.project, 'proj-cur'); // via workspaceStorage join
+  assert.equal(t1.model, 'cursor-auto'); // "default" = Auto mode, backend model not persisted
+  assert.equal(t1.inputTokens, 1200);
+  assert.equal(t1.outputTokens, 300);
+  assert.equal(t1.timestamp, '2026-06-01T10:01:00.000Z');
+  assert.deepEqual(t1.tools, ['read_file', 'run_terminal_cmd']);
+  assert.deepEqual(t1.commands, ['pytest -q']);
+  assert.equal(t1.activity, 'testing');
+  assert.equal(t1.isError, false);
+
+  assert.equal(t2.eventKey, 'c1:b7');
+  assert.equal(t2.activity, 'coding'); // edit_file
+  assert.equal(t2.isError, true); // errored tool linked to its turn
+
+  // The auth canary in ItemTable must never appear in adapter output.
+  assert.ok(!JSON.stringify({ events, result }).includes('AUTH-CANARY'));
+  assert.ok(result.note?.includes('completed turns'));
+});
+
 test('adapters return a note instead of throwing when logs are absent', () => {
-  for (const collect of [collectClaudeCode, collectGeminiCli, collectCodex]) {
+  for (const collect of [collectClaudeCode, collectGeminiCli, collectCodex, collectCursor]) {
     const { events, result } = collect('/nonexistent/path/xyz');
     assert.equal(events.length, 0);
     assert.ok(result.note);

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -5,6 +5,8 @@ import { mkdtempSync, cpSync, writeFileSync, readFileSync, mkdirSync, existsSync
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { makeCursorFixture } from './helpers.js';
+import { cursorUserDir } from '../src/adapters/cursor.js';
 
 /**
  * True end-to-end: runs the built CLI as a subprocess against a synthetic
@@ -22,12 +24,14 @@ const HOME = mkdtempSync(join(tmpdir(), 'tm-e2e-home-'));
 cpSync(join(FIXTURES, 'claude'), join(HOME, '.claude', 'projects'), { recursive: true });
 cpSync(join(FIXTURES, 'gemini'), join(HOME, '.gemini', 'tmp'), { recursive: true });
 cpSync(join(FIXTURES, 'codex'), join(HOME, '.codex', 'sessions'), { recursive: true });
+makeCursorFixture(cursorUserDir(HOME));
 
 function run(args: string[], opts: { home?: string } = {}) {
   const home = opts.home ?? HOME;
   const r = spawnSync(process.execPath, [CLI, ...args], {
     encoding: 'utf8',
-    env: { ...process.env, HOME: home, USERPROFILE: home },
+    // APPDATA keeps win32 path resolution inside the synthetic home too.
+    env: { ...process.env, HOME: home, USERPROFILE: home, APPDATA: join(home, 'AppData', 'Roaming') },
   });
   return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.status };
 }
@@ -35,12 +39,13 @@ function run(args: string[], opts: { home?: string } = {}) {
 // Fixture windows are dated 2026-06-01; keep a generous window.
 const DAYS = ['--days', '36500'];
 
-test('e2e: collect parses all three sources into the default db', () => {
+test('e2e: collect parses all sources into the default db', () => {
   const { stdout, code } = run(['collect']);
   assert.equal(code, 0);
   assert.match(stdout, /claude-code\s+\d+ files\s+3 turns\s+3 new/);
   assert.match(stdout, /gemini-cli\s+\d+ files\s+2 turns\s+2 new/);
   assert.match(stdout, /codex\s+\d+ files\s+2 turns\s+2 new/);
+  assert.match(stdout, /cursor\s+\d+ files\s+2 turns\s+2 new/);
   assert.ok(existsSync(join(HOME, '.token-monitor', 'token-monitor.sqlite')));
 });
 
@@ -53,7 +58,7 @@ test('e2e: collect is idempotent', () => {
 test('e2e: report renders all sections from collected data', () => {
   const { stdout, code } = run(['report', ...DAYS]);
   assert.equal(code, 0);
-  for (const expected of ['Where the tokens go', 'By project', 'By model', 'Recommendations', 'proj-alpha', 'proj-g', 'proj-c', 'gpt-5-codex']) {
+  for (const expected of ['Where the tokens go', 'By project', 'By model', 'Recommendations', 'proj-alpha', 'proj-g', 'proj-c', 'proj-cur', 'gpt-5-codex']) {
     assert.ok(stdout.includes(expected), `report missing "${expected}"`);
   }
 });
@@ -62,7 +67,7 @@ test('e2e: report --json emits a signed v1 export; fingerprint command matches i
   const exportJson = run(['report', '--json', ...DAYS]).stdout;
   const data = JSON.parse(exportJson);
   assert.equal(data.version, 1);
-  assert.equal(data.overall.events, 7); // 3 claude + 2 gemini + 2 codex
+  assert.equal(data.overall.events, 9); // 3 claude + 2 gemini + 2 codex + 2 cursor
   assert.equal(data.sig.alg, 'ed25519');
 
   const fp = run(['fingerprint']).stdout.trim();

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import type { UsageEvent } from '../src/types.js';
 import type { StoredEvent } from '../src/store.js';
 
@@ -20,6 +23,75 @@ export function makeEvent(partial: Partial<UsageEvent> = {}): UsageEvent {
     isError: false,
     ...partial,
   };
+}
+
+/**
+ * Build a synthetic Cursor User dir (globalStorage/state.vscdb + one mapped
+ * workspace) the way Cursor lays it out. Two composers: c1 has two completed
+ * turns (testing, then an errored edit), c2 was aborted before its final
+ * bubble, so it must yield no events. The ItemTable auth canary must never
+ * surface anywhere in adapter output.
+ */
+export function makeCursorFixture(userDir: string): void {
+  const globalDir = join(userDir, 'globalStorage');
+  mkdirSync(globalDir, { recursive: true });
+  const db = new DatabaseSync(join(globalDir, 'state.vscdb'));
+  db.exec(`CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB);
+           CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value BLOB);`);
+  const put = db.prepare('INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)');
+  db.prepare('INSERT INTO ItemTable (key, value) VALUES (?, ?)').run(
+    'cursorAuth/accessToken', 'AUTH-CANARY-DO-NOT-READ',
+  );
+
+  const bubble = (extra: object) => JSON.stringify({ _v: 3, ...extra });
+  put.run('composerData:c1', JSON.stringify({
+    _v: 13, composerId: 'c1', unifiedMode: 'agent',
+    createdAt: 1748700000000, lastUpdatedAt: 1748700300000,
+    modelConfig: { modelName: 'default' },
+    fullConversationHeadersOnly: [
+      { bubbleId: 'b1' }, { bubbleId: 'b2' }, { bubbleId: 'b3' }, { bubbleId: 'b4' },
+      { bubbleId: 'b5' }, { bubbleId: 'b6' }, { bubbleId: 'b7' },
+    ],
+  }));
+  put.run('bubbleId:c1:b1', bubble({ type: 1, createdAt: '2026-06-01T10:00:00.000Z' }));
+  put.run('bubbleId:c1:b2', bubble({
+    type: 2, toolFormerData: { name: 'read_file', status: 'completed', rawArgs: '{}' },
+  }));
+  put.run('bubbleId:c1:b3', bubble({
+    type: 2, toolFormerData: { name: 'run_terminal_cmd', status: 'completed', rawArgs: '{"command":"pytest -q"}' },
+  }));
+  put.run('bubbleId:c1:b4', bubble({
+    type: 2, createdAt: '2026-06-01T10:01:00.000Z',
+    tokenCount: { inputTokens: 1200, outputTokens: 300 },
+    modelInfo: { modelName: 'default' },
+  }));
+  put.run('bubbleId:c1:b5', bubble({ type: 1, createdAt: '2026-06-01T10:02:00.000Z' }));
+  put.run('bubbleId:c1:b6', bubble({
+    type: 2, toolFormerData: { name: 'edit_file', status: 'error', rawArgs: '{}' },
+  }));
+  put.run('bubbleId:c1:b7', bubble({
+    type: 2, createdAt: '2026-06-01T10:03:00.000Z',
+    tokenCount: { inputTokens: 500, outputTokens: 100 },
+  }));
+
+  // Aborted session: bubbles exist but no token-bearing final bubble.
+  put.run('composerData:c2', JSON.stringify({
+    _v: 13, composerId: 'c2',
+    fullConversationHeadersOnly: [{ bubbleId: 'b1' }],
+  }));
+  put.run('bubbleId:c2:b1', bubble({ type: 1 }));
+  db.close();
+
+  const wsDir = join(userDir, 'workspaceStorage', 'ws1');
+  mkdirSync(wsDir, { recursive: true });
+  writeFileSync(join(wsDir, 'workspace.json'), JSON.stringify({ folder: 'file:///home/u/proj-cur' }));
+  const wsDb = new DatabaseSync(join(wsDir, 'state.vscdb'));
+  wsDb.exec('CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)');
+  wsDb.prepare('INSERT INTO ItemTable (key, value) VALUES (?, ?)').run(
+    'composer.composerData',
+    JSON.stringify({ allComposers: [{ composerId: 'c1', name: 'fix tests' }] }),
+  );
+  wsDb.close();
 }
 
 let seq = 0;


### PR DESCRIPTION
## What

Cursor adapter (#9), built on the spike findings posted in that issue.

- `src/adapters/cursor.ts` — copies `globalStorage/state.vscdb` (+WAL) to a scratch dir, reads **only** `cursorDiskKV` keys `composerData:%` / `bubbleId:%`, emits a UsageEvent per turn-final token-bearing bubble with tools/commands accumulated from the turn's intermediate bubbles.
- Project attribution: `workspaceStorage/<hash>/state.vscdb` ItemTable key `composer.composerData` (exact-key query only) joined to `workspace.json` folder basename — 100% coverage on non-empty composers in spike data.
- Security: globalStorage `ItemTable` (where `cursorAuth/*` lives) is never queried; unit test plants an auth canary and asserts it can't surface.
- Limits (documented in README): no cache tokens, no cost, model is `cursor-auto` under Auto mode; aborted turns carry no token counts.

## Validation

- 66 tests pass incl. new unit test (synthetic SQLite fixture) and e2e (full collect→report→export pipeline with the Cursor fixture in the synthetic HOME).
- Ran against real local Cursor data: 31 events across 5 projects, 602k input / 21k output tokens, activities classified. (Spike counted 33 token-bearing bubbles; 2 are orphaned from deleted/edited conversations and not referenced by any composer's headers.)