### PR TITLE
feat: Antigravity adapter — per-call tokens from protobuf blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Personas are computed per-project and overall, so one expensive workflow can't h
 | **Claude Code** | `~/.claude/projects/**/*.jsonl` | ✅ Verified — per-turn tokens, cache split, model, tools, git branch |
 | **Gemini CLI** | `~/.gemini/tmp/*/chats/*.json` | ✅ Verified — per-turn tokens incl. thoughts, tool calls |
 | **Codex CLI** | `~/.codex/sessions/**/rollout-*.jsonl` | ⚠️ Experimental — diffs cumulative `token_count` events; verify against Codex's own usage screens |
+| **Antigravity CLI** | `~/.gemini/antigravity-cli/conversations/*.db` (SQLite + protobuf) | ✅ Verified — per-call prompt/cached/output tokens, per-row model, tool steps, workspace + branch. Vendor-internal format: fails soft if the schema changes |
 
 Adapters skip gracefully when a tool isn't installed.
 

--- a/src/adapters/antigravity.ts
+++ b/src/adapters/antigravity.ts
@@ -1,0 +1,198 @@
+import { readdirSync, existsSync, copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+import type { UsageEvent, CollectResult } from '../types.js';
+import { classify } from '../classify.js';
+import { decodeMessage, intField, strField, msgField, msgFields, type WireMessage } from './../protowire.js';
+
+/**
+ * Antigravity CLI stores one SQLite db per conversation under
+ * ~/.gemini/antigravity-cli/conversations/<id>.db. The interesting table is
+ * gen_metadata: one protobuf blob per LLM call, with token usage, model id,
+ * and timestamps. The steps table records turn/tool events; a gen row's
+ * "last step index at request time" lets us attribute the tool steps each
+ * generation produced. Field numbers were mapped empirically (issue #10) —
+ * the schema is vendor-internal, so everything here fails soft.
+ *
+ * Privacy: only usage/model/timing fields are decoded. The blobs also carry
+ * full prompt/conversation snapshots (f1.1/f1.2/f1.8/f1.16) — those are
+ * never descended into.
+ */
+
+const ROOT = join(homedir(), '.gemini', 'antigravity-cli');
+
+// steps.step_type -> normalized tool name (observed enum values)
+const STEP_TOOLS: Record<number, string> = {
+  8: 'view_file',
+  9: 'list_directory',
+  21: 'run_command',
+  23: 'update_plan',
+};
+// Non-tool step types: 14 = user input, 15 = planner response, 98 = history.
+const NON_TOOL_STEPS = new Set([14, 15, 98]);
+
+interface StepInfo {
+  idx: number;
+  type: number;
+  status: number;
+  command?: string;
+  errorShort?: string;
+}
+
+function tsToIso(msg: WireMessage | undefined): string | undefined {
+  const sec = intField(msg, 1);
+  if (!sec) return undefined;
+  return new Date(sec * 1000 + Math.floor(intField(msg, 2) / 1e6)).toISOString();
+}
+
+function collectConversation(dbPath: string, scratch: string, events: UsageEvent[]): void {
+  const convId = basename(dbPath, '.db');
+  const copy = join(scratch, `${convId}.db`);
+  copyFileSync(dbPath, copy);
+  for (const suffix of ['-wal', '-shm']) {
+    if (existsSync(dbPath + suffix)) copyFileSync(dbPath + suffix, copy + suffix);
+  }
+  const db = new DatabaseSync(copy);
+  try {
+    // Workspace / branch attribution.
+    let project = 'unknown';
+    let gitBranch: string | undefined;
+    try {
+      const row = db.prepare('SELECT data FROM trajectory_metadata_blob LIMIT 1').get() as { data?: Uint8Array } | undefined;
+      if (row?.data) {
+        const ctx = msgField(decodeMessage(row.data), 1);
+        const workspaceUri = strField(ctx, 1);
+        if (workspaceUri) project = basename(decodeURIComponent(workspaceUri.replace(/^file:\/\//, '')));
+        gitBranch = strField(ctx, 4);
+      }
+    } catch {
+      /* attribution is optional */
+    }
+
+    // Step events, for tool attribution per generation.
+    const steps: StepInfo[] = [];
+    try {
+      const rows = db
+        .prepare('SELECT idx, step_type, status, step_payload, error_details FROM steps ORDER BY idx')
+        .all() as Array<{ idx: number; step_type: number; status: number; step_payload?: Uint8Array; error_details?: Uint8Array }>;
+      for (const r of rows) {
+        const info: StepInfo = { idx: r.idx, type: r.step_type, status: r.status };
+        if (r.step_type === 21 && r.step_payload) {
+          try {
+            const payload = msgField(decodeMessage(r.step_payload), 28);
+            info.command = strField(payload, 25) ?? strField(payload, 23);
+          } catch { /* ignore */ }
+        }
+        if (r.status === 7 && r.error_details) {
+          try {
+            info.errorShort = strField(decodeMessage(r.error_details), 2);
+          } catch { /* ignore */ }
+        }
+        steps.push(info);
+      }
+    } catch {
+      /* steps are optional — events still carry tokens */
+    }
+
+    const genRows = db.prepare('SELECT idx, data FROM gen_metadata ORDER BY idx').all() as Array<{ idx: number; data?: Uint8Array }>;
+    interface Gen { idx: number; lastStep: number; gen: WireMessage }
+    const gens: Gen[] = [];
+    for (const r of genRows) {
+      if (!r.data) continue;
+      try {
+        const gen = msgField(decodeMessage(r.data), 1);
+        if (!gen) continue;
+        // f20 is a repeated {1: key, 2: value} annotation list; last_step_index
+        // is authoritative there (f6 is off by one from it).
+        let lastStep = intField(gen, 6) + 1;
+        for (const kv of msgFields(gen, 20)) {
+          if (strField(kv, 1) === 'last_step_index') {
+            const v = Number(strField(kv, 2));
+            if (Number.isFinite(v)) lastStep = v;
+          }
+        }
+        gens.push({ idx: r.idx, lastStep, gen });
+      } catch {
+        continue; // unknown layout — fail soft per row
+      }
+    }
+
+    gens.forEach(({ idx, lastStep, gen }, i) => {
+      const usage = msgField(gen, 4);
+      if (!usage) return;
+      // Steps produced by this generation: after its request snapshot, up to
+      // the next generation's snapshot (or end of trajectory for the last).
+      const upper = i + 1 < gens.length ? gens[i + 1].lastStep : Number.MAX_SAFE_INTEGER;
+      const mySteps = steps.filter((s) => s.idx > lastStep && s.idx <= upper);
+      const tools: string[] = [];
+      const commands: string[] = [];
+      let isError = false;
+      for (const s of mySteps) {
+        if (NON_TOOL_STEPS.has(s.type)) continue;
+        tools.push(STEP_TOOLS[s.type] ?? `step_${s.type}`);
+        if (s.command) commands.push(s.command);
+        // status 7 covers both failures and user cancellations — a cancel is a choice, not an error.
+        if (s.status === 7 && !/cancel/i.test(s.errorShort ?? '')) isError = true;
+      }
+
+      const timing = msgField(gen, 9);
+      const ev: UsageEvent = {
+        source: 'antigravity',
+        eventKey: `${convId}:${idx}`,
+        sessionId: convId,
+        project,
+        timestamp: tsToIso(msgField(timing, 4)) ?? new Date(0).toISOString(),
+        model: strField(gen, 19) ?? strField(gen, 21) ?? 'antigravity',
+        inputTokens: intField(usage, 2),
+        outputTokens: intField(usage, 3),
+        cacheReadTokens: intField(usage, 5),
+        cacheCreationTokens: 0,
+        thinkingTokens: 0,
+        tools,
+        commands,
+        hasThinking: false,
+        isError,
+        gitBranch,
+      };
+      ev.activity = classify(ev);
+      events.push(ev);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export function collectAntigravity(root: string = ROOT): { events: UsageEvent[]; result: CollectResult } {
+  const events: UsageEvent[] = [];
+  const convDir = join(root, 'conversations');
+  if (!existsSync(convDir)) {
+    return { events, result: { source: 'antigravity', filesScanned: 0, eventsFound: 0, eventsInserted: 0, note: `${convDir} not found — Antigravity not detected` } };
+  }
+  const scratch = mkdtempSync(join(tmpdir(), 'tm-antigravity-'));
+  let filesScanned = 0;
+  let failed = 0;
+  try {
+    for (const file of readdirSync(convDir)) {
+      if (!file.endsWith('.db')) continue;
+      filesScanned++;
+      try {
+        collectConversation(join(convDir, file), scratch, events);
+      } catch {
+        failed++; // vendor-internal format — skip conversations we can't read
+      }
+    }
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+  return {
+    events,
+    result: {
+      source: 'antigravity',
+      filesScanned,
+      eventsFound: events.length,
+      eventsInserted: 0,
+      note: failed > 0 ? `${failed} conversation db(s) skipped (unreadable or unknown format)` : undefined,
+    },
+  };
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -2,6 +2,7 @@ import type { UsageEvent, CollectResult, Source } from '../types.js';
 import { collectClaudeCode } from './claude-code.js';
 import { collectGeminiCli } from './gemini-cli.js';
 import { collectCodex } from './codex.js';
+import { collectAntigravity } from './antigravity.js';
 
 export type Adapter = () => { events: UsageEvent[]; result: CollectResult };
 
@@ -15,4 +16,5 @@ export const ADAPTERS: Record<Source, Adapter> = {
   'claude-code': collectClaudeCode,
   'gemini-cli': collectGeminiCli,
   codex: collectCodex,
+  antigravity: collectAntigravity,
 };

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -8,13 +8,13 @@ const WRITE_TOOLS = new Set([
 ]);
 
 const SHELL_TOOLS = new Set([
-  'bash', 'shell', 'run_shell_command', 'run_terminal_cmd', 'local_shell', 'exec_command',
+  'bash', 'shell', 'run_shell_command', 'run_terminal_cmd', 'run_command', 'local_shell', 'exec_command',
 ]);
 
 const READ_TOOLS = new Set([
   'read', 'grep', 'glob', 'ls', 'webfetch', 'websearch', 'agent', 'task', 'explore', 'toolsearch',
   'read_file', 'read_many_files', 'search_file_content', 'list_directory', 'find_files',
-  'google_web_search', 'web_fetch', 'codebase_search', 'view',
+  'google_web_search', 'web_fetch', 'codebase_search', 'view', 'view_file',
 ]);
 
 const PLAN_TOOLS = new Set([

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ Usage:
   token-monitor fingerprint [--db <path>]
 
 Commands:
-  collect   Scan local agent logs (Claude Code, Gemini CLI, Codex) into SQLite
+  collect   Scan local agent logs (Claude Code, Gemini CLI, Codex, Antigravity) into SQLite
   report    Activity breakdown, cost, personas, and recommendations
   analyze   Session-level deep dive; --llm asks your local agent CLI for
             prioritized recommendations (sends aggregate metrics only)

--- a/src/protowire.ts
+++ b/src/protowire.ts
@@ -1,0 +1,105 @@
+/**
+ * Minimal protobuf wire-format reader (no .proto, no dependencies).
+ * Enough to walk known field numbers out of opaque vendor blobs: varints,
+ * fixed32/64, and length-delimited fields that may be nested messages or
+ * UTF-8 strings. Callers decide which LEN fields to descend into — anything
+ * not asked for is skipped untouched, which is also the privacy-preserving
+ * behavior (conversation text is never decoded).
+ */
+
+export interface WireField {
+  wireType: number;
+  /** wire types 0/1/5 */
+  num: bigint;
+  /** wire type 2 */
+  bytes: Uint8Array;
+}
+
+export type WireMessage = Map<number, WireField[]>;
+
+function readVarint(buf: Uint8Array, off: number): [bigint, number] {
+  let result = 0n;
+  let shift = 0n;
+  for (let i = 0; i < 10; i++) {
+    if (off >= buf.length) throw new Error('truncated varint');
+    const b = buf[off++];
+    result |= BigInt(b & 0x7f) << shift;
+    if ((b & 0x80) === 0) return [result, off];
+    shift += 7n;
+  }
+  throw new Error('varint too long');
+}
+
+/** Parse one message level. Throws on malformed input — callers treat that as "not a message". */
+export function decodeMessage(buf: Uint8Array): WireMessage {
+  const fields: WireMessage = new Map();
+  let off = 0;
+  while (off < buf.length) {
+    const [tag, afterTag] = readVarint(buf, off);
+    off = afterTag;
+    const fieldNum = Number(tag >> 3n);
+    const wireType = Number(tag & 7n);
+    if (fieldNum === 0) throw new Error('field 0');
+    let field: WireField;
+    if (wireType === 0) {
+      const [v, next] = readVarint(buf, off);
+      off = next;
+      field = { wireType, num: v, bytes: new Uint8Array(0) };
+    } else if (wireType === 1 || wireType === 5) {
+      const size = wireType === 1 ? 8 : 4;
+      if (off + size > buf.length) throw new Error('truncated fixed');
+      field = { wireType, num: 0n, bytes: buf.subarray(off, off + size) };
+      off += size;
+    } else if (wireType === 2) {
+      const [len, next] = readVarint(buf, off);
+      off = next;
+      const end = off + Number(len);
+      if (end > buf.length) throw new Error('truncated bytes');
+      field = { wireType, num: 0n, bytes: buf.subarray(off, end) };
+      off = end;
+    } else {
+      throw new Error(`unsupported wire type ${wireType}`);
+    }
+    let list = fields.get(fieldNum);
+    if (!list) fields.set(fieldNum, (list = []));
+    list.push(field);
+  }
+  return fields;
+}
+
+/** First occurrence of a varint field, as Number (0 when absent). */
+export function intField(msg: WireMessage | undefined, id: number): number {
+  const f = msg?.get(id)?.find((x) => x.wireType === 0);
+  return f ? Number(f.num) : 0;
+}
+
+/** First occurrence of a LEN field decoded as UTF-8 (undefined when absent). */
+export function strField(msg: WireMessage | undefined, id: number): string | undefined {
+  const f = msg?.get(id)?.find((x) => x.wireType === 2);
+  return f ? new TextDecoder().decode(f.bytes) : undefined;
+}
+
+/** First occurrence of a LEN field parsed as a nested message (undefined when absent/not a message). */
+export function msgField(msg: WireMessage | undefined, id: number): WireMessage | undefined {
+  const f = msg?.get(id)?.find((x) => x.wireType === 2);
+  if (!f) return undefined;
+  try {
+    return decodeMessage(f.bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+/** All occurrences of a repeated LEN field parsed as nested messages. */
+export function msgFields(msg: WireMessage | undefined, id: number): WireMessage[] {
+  const out: WireMessage[] = [];
+  for (const f of msg?.get(id) ?? []) {
+    if (f.wireType !== 2) continue;
+    try {
+      out.push(decodeMessage(f.bytes));
+    } catch {
+      /* not a message */
+    }
+  }
+  return out;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Source = 'claude-code' | 'gemini-cli' | 'codex';
+export type Source = 'claude-code' | 'gemini-cli' | 'codex' | 'antigravity';
 
 export type Activity =
   | 'thinking'

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -5,6 +5,10 @@ import { join, dirname } from 'node:path';
 import { collectClaudeCode } from '../src/adapters/claude-code.js';
 import { collectGeminiCli } from '../src/adapters/gemini-cli.js';
 import { collectCodex } from '../src/adapters/codex.js';
+import { collectAntigravity } from '../src/adapters/antigravity.js';
+import { makeAntigravityFixture } from './helpers.js';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 // dist/test/ -> repo root -> test/fixtures
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'test', 'fixtures');
@@ -76,8 +80,44 @@ test('codex adapter diffs cumulative token counts into per-turn events', () => {
   assert.equal(t2.activity, 'coding'); // apply_patch
 });
 
+test('antigravity adapter decodes gen_metadata blobs and attributes tool steps', () => {
+  const root = mkdtempSync(join(tmpdir(), 'tm-antigravity-fixture-'));
+  makeAntigravityFixture(root);
+  const { events, result } = collectAntigravity(root);
+
+  assert.equal(result.filesScanned, 1);
+  assert.equal(events.length, 3);
+  const [g0, g1, g2] = events;
+
+  assert.equal(g0.eventKey, 'conv-1:0');
+  assert.equal(g0.sessionId, 'conv-1');
+  assert.equal(g0.project, 'proj-anti'); // trajectory_metadata_blob workspace URI
+  assert.equal(g0.gitBranch, 'feat/x');
+  assert.equal(g0.model, 'gemini-3-flash-a');
+  assert.equal(g0.inputTokens, 1000);
+  assert.equal(g0.outputTokens, 50);
+  assert.equal(g0.cacheReadTokens, 0); // f5 absent = 0
+  assert.equal(g0.timestamp, new Date(1780000000500).toISOString());
+  assert.deepEqual(g0.tools, ['view_file']); // steps between this and next gen snapshot
+  assert.equal(g0.activity, 'exploration');
+  assert.equal(g0.isError, false);
+
+  assert.equal(g1.inputTokens, 1500);
+  assert.equal(g1.cacheReadTokens, 2000);
+  assert.deepEqual(g1.commands, ['npm test']);
+  assert.equal(g1.activity, 'testing');
+  assert.equal(g1.isError, true); // run_command failed with "exit status 1"
+
+  assert.equal(g2.model, 'Claude Sonnet'); // f21 display-name fallback
+  assert.equal(g2.isError, false); // "context canceled" is a user choice, not a failure
+  assert.equal(g2.activity, 'exploration'); // bare shell command
+
+  // Privacy: no conversation text in output.
+  assert.ok(!JSON.stringify(events).includes('long trace'));
+});
+
 test('adapters return a note instead of throwing when logs are absent', () => {
-  for (const collect of [collectClaudeCode, collectGeminiCli, collectCodex]) {
+  for (const collect of [collectClaudeCode, collectGeminiCli, collectCodex, collectAntigravity]) {
     const { events, result } = collect('/nonexistent/path/xyz');
     assert.equal(events.length, 0);
     assert.ok(result.note);

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, cpSync, writeFileSync, readFileSync, mkdirSync, existsSync
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { makeAntigravityFixture } from './helpers.js';
 
 /**
  * True end-to-end: runs the built CLI as a subprocess against a synthetic
@@ -22,6 +23,7 @@ const HOME = mkdtempSync(join(tmpdir(), 'tm-e2e-home-'));
 cpSync(join(FIXTURES, 'claude'), join(HOME, '.claude', 'projects'), { recursive: true });
 cpSync(join(FIXTURES, 'gemini'), join(HOME, '.gemini', 'tmp'), { recursive: true });
 cpSync(join(FIXTURES, 'codex'), join(HOME, '.codex', 'sessions'), { recursive: true });
+makeAntigravityFixture(join(HOME, '.gemini', 'antigravity-cli'));
 
 function run(args: string[], opts: { home?: string } = {}) {
   const home = opts.home ?? HOME;
@@ -41,6 +43,7 @@ test('e2e: collect parses all three sources into the default db', () => {
   assert.match(stdout, /claude-code\s+\d+ files\s+3 turns\s+3 new/);
   assert.match(stdout, /gemini-cli\s+\d+ files\s+2 turns\s+2 new/);
   assert.match(stdout, /codex\s+\d+ files\s+2 turns\s+2 new/);
+  assert.match(stdout, /antigravity\s+\d+ files\s+3 turns\s+3 new/);
   assert.ok(existsSync(join(HOME, '.token-monitor', 'token-monitor.sqlite')));
 });
 
@@ -53,7 +56,7 @@ test('e2e: collect is idempotent', () => {
 test('e2e: report renders all sections from collected data', () => {
   const { stdout, code } = run(['report', ...DAYS]);
   assert.equal(code, 0);
-  for (const expected of ['Where the tokens go', 'By project', 'By model', 'Recommendations', 'proj-alpha', 'proj-g', 'proj-c', 'gpt-5-codex']) {
+  for (const expected of ['Where the tokens go', 'By project', 'By model', 'Recommendations', 'proj-alpha', 'proj-g', 'proj-c', 'proj-anti', 'gpt-5-codex']) {
     assert.ok(stdout.includes(expected), `report missing "${expected}"`);
   }
 });
@@ -62,7 +65,7 @@ test('e2e: report --json emits a signed v1 export; fingerprint command matches i
   const exportJson = run(['report', '--json', ...DAYS]).stdout;
   const data = JSON.parse(exportJson);
   assert.equal(data.version, 1);
-  assert.equal(data.overall.events, 7); // 3 claude + 2 gemini + 2 codex
+  assert.equal(data.overall.events, 10); // 3 claude + 2 gemini + 2 codex + 3 antigravity
   assert.equal(data.sig.alg, 'ed25519');
 
   const fp = run(['fingerprint']).stdout.trim();

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,3 +1,6 @@
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import type { UsageEvent } from '../src/types.js';
 import type { StoredEvent } from '../src/store.js';
 
@@ -42,4 +45,102 @@ export function makeStored(partial: Partial<StoredEvent> = {}): StoredEvent {
     activity: 'coding',
     ...partial,
   };
+}
+
+/** Tiny protobuf wire-format encoder for building synthetic vendor blobs. */
+export interface ProtoMsg {
+  [field: number]: number | string | Uint8Array | ProtoMsg | Array<number | string | Uint8Array | ProtoMsg>;
+}
+
+function varint(n: number | bigint): number[] {
+  let v = BigInt(n);
+  const out: number[] = [];
+  do {
+    let b = Number(v & 0x7fn);
+    v >>= 7n;
+    if (v > 0n) b |= 0x80;
+    out.push(b);
+  } while (v > 0n);
+  return out;
+}
+
+export function encodeProto(msg: ProtoMsg): Uint8Array {
+  const parts: number[] = [];
+  for (const [field, value] of Object.entries(msg)) {
+    for (const v of Array.isArray(value) ? value : [value]) {
+      const id = Number(field);
+      if (typeof v === 'number') {
+        parts.push(...varint((id << 3) | 0), ...varint(v));
+      } else {
+        const bytes =
+          typeof v === 'string' ? new TextEncoder().encode(v) : v instanceof Uint8Array ? v : encodeProto(v);
+        parts.push(...varint((id << 3) | 2), ...varint(bytes.length), ...bytes);
+      }
+    }
+  }
+  return Uint8Array.from(parts);
+}
+
+/**
+ * Synthetic Antigravity conversation db mirroring the real layout (issue #10):
+ * three generations — an exploration turn, a failed `npm test` turn, and a
+ * user-cancelled command (which must NOT count as an error).
+ */
+export function makeAntigravityFixture(root: string): void {
+  const convDir = join(root, 'conversations');
+  mkdirSync(convDir, { recursive: true });
+  const db = new DatabaseSync(join(convDir, 'conv-1.db'));
+  db.exec(`
+    CREATE TABLE trajectory_meta (trajectory_id text, cascade_id text, trajectory_type integer, source integer, PRIMARY KEY (trajectory_id));
+    CREATE TABLE trajectory_metadata_blob (id text DEFAULT "main", data blob, PRIMARY KEY (id));
+    CREATE TABLE steps (idx integer, step_type integer NOT NULL DEFAULT 0, status integer NOT NULL DEFAULT 0,
+      metadata blob, error_details blob, step_payload blob, PRIMARY KEY (idx));
+    CREATE TABLE gen_metadata (idx integer, data blob, size integer NOT NULL DEFAULT 0, PRIMARY KEY (idx));
+  `);
+
+  db.prepare('INSERT INTO trajectory_metadata_blob (id, data) VALUES (?, ?)').run(
+    'main',
+    encodeProto({ 1: { 1: 'file:///home/u/proj-anti', 4: 'feat/x' }, 7: 'file:///home/u/proj-anti' }),
+  );
+
+  const step = db.prepare('INSERT INTO steps (idx, step_type, status, step_payload, error_details) VALUES (?, ?, ?, ?, ?)');
+  const planner = encodeProto({ 1: 15, 4: 3 });
+  step.run(0, 14, 3, encodeProto({ 1: 14, 4: 3 }), null);
+  step.run(1, 98, 3, null, null);
+  step.run(2, 15, 3, planner, null);
+  step.run(3, 8, 3, encodeProto({ 1: 8, 4: 3 }), null);
+  step.run(4, 15, 3, planner, null);
+  step.run(5, 21, 7,
+    encodeProto({ 1: 21, 4: 7, 28: { 2: '/home/u/proj-anti', 23: 'npm test', 25: 'npm test' } }),
+    encodeProto({ 2: 'exit status 1', 3: 'exit status 1\nlong trace' }));
+  step.run(6, 15, 3, planner, null);
+  step.run(7, 21, 7,
+    encodeProto({ 1: 21, 4: 7, 28: { 25: 'sleep 100' } }),
+    encodeProto({ 2: 'context canceled', 3: 'context canceled\n(1) attached stack trace' }));
+
+  const gen = db.prepare('INSERT INTO gen_metadata (idx, data, size) VALUES (?, ?, ?)');
+  const genBlob = (g: ProtoMsg) => encodeProto({ 1: g });
+  gen.run(0, genBlob({
+    4: { 1: 1020, 2: 1000, 3: 50 },
+    6: 0,
+    9: { 4: { 1: 1780000000, 2: 500000000 } },
+    19: 'gemini-3-flash-a',
+    20: [{ 1: 'last_step_index', 2: '1' }, { 1: 'used_claude', 2: 'false' }],
+    21: 'Gemini 3.5 Flash (Medium)',
+  }), 0);
+  gen.run(1, genBlob({
+    4: { 1: 1020, 2: 1500, 3: 80, 5: 2000 },
+    6: 2,
+    9: { 4: { 1: 1780000100, 2: 0 } },
+    19: 'gemini-3-pro-x',
+    20: [{ 1: 'last_step_index', 2: '3' }],
+  }), 0);
+  gen.run(2, genBlob({
+    4: { 1: 1020, 2: 500, 3: 20 },
+    6: 4,
+    9: { 4: { 1: 1780000200, 2: 0 } },
+    20: [{ 1: 'last_step_index', 2: '5' }],
+    21: 'Claude Sonnet',
+  }), 0);
+  db.close();
 }


### PR DESCRIPTION
## What

Antigravity CLI adapter (#10), built on the spike findings posted in that issue.

- `src/protowire.ts` — minimal protobuf wire-format reader (varint + wire types 0/1/2/5, ~100 LOC, zero deps). Callers choose which LEN fields to descend; everything else is skipped, so conversation text is never decoded (privacy by construction).
- `src/adapters/antigravity.ts` — per `conversations/*.db`: one UsageEvent per `gen_metadata` row. Prompt tokens f1.4.2, output f1.4.3, cached f1.4.5 (absent = 0), model f1.19 (display-name f1.21 fallback), timestamp f1.9.4. Tool steps attributed per generation via the `last_step_index` annotation; `run_command` commands extracted for test/ship classification; status-7 steps count as errors **except** "context canceled" (a user choice). Workspace + branch from `trajectory_metadata_blob`.
- Classifier: `view_file` added to read tools, `run_command` to shell tools.
- Fail-soft everywhere — vendor-internal ("jetski") schema may change without notice; unreadable conversations are skipped and counted in the note.

## Validation

- 66 tests pass. New unit test builds a synthetic conversation db with a tiny protobuf **encoder** in test helpers (exploration turn, failed `npm test` turn, cancelled command) and asserts tokens, attribution, cancel-vs-error, and that no conversation text reaches the output. e2e runs the full pipeline with the fixture in the synthetic HOME.
- Ran against the real local db: 4 events matching the spike's decoded values exactly (15341/16257/30666/18299 prompt tokens, 28586 cached on the last call, `git status` command, branch + workspace attribution, cancelled final command not flagged as error).