### PR TITLE
feat: Copilot Chat adapter (experimental, estimated tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Personas are computed per-project and overall, so one expensive workflow can't h
 | **Codex CLI** | `~/.codex/sessions/**/rollout-*.jsonl` | ⚠️ Experimental — diffs cumulative `token_count` events; verify against Codex's own usage screens |
 | **Cursor** | `Cursor/User/globalStorage/state.vscdb` (SQLite) | ✅ Verified — per-turn tokens on completed turns, tool calls, agent/chat sessions. Cursor doesn't persist cache tokens or the resolved backend model (Auto mode reports as `cursor-auto`) |
 | **Antigravity CLI** | `~/.gemini/antigravity-cli/conversations/*.db` (SQLite + protobuf) | ✅ Verified — per-call prompt/cached/output tokens, per-row model, tool steps, workspace + branch. Vendor-internal format: fails soft if the schema changes |
+| **Copilot Chat** (VS Code) | `Code/User/workspaceStorage/*/chatSessions/*` | ⚠️ Experimental — Copilot doesn't record token usage locally, so counts are **estimated** from text length (~4 chars/token) and models are suffixed `(est)`. Turn counts, timestamps, tools, and errors are real |
 
 Adapters skip gracefully when a tool isn't installed. The Cursor adapter reads only composer/bubble keys — never the auth entries that live in the same database.
 

--- a/src/adapters/copilot.ts
+++ b/src/adapters/copilot.ts
@@ -1,0 +1,165 @@
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { homedir } from 'node:os';
+import type { UsageEvent, CollectResult } from '../types.js';
+import { classify } from '../classify.js';
+
+/**
+ * EXPERIMENTAL — VS Code Copilot Chat persists sessions under
+ * <User dir>/workspaceStorage/<hash>/chatSessions/ as either *.json (full
+ * serialized session) or *.jsonl (line 0 = {kind: 0, v: <full session>},
+ * later lines are incremental ops we don't apply). Copilot does NOT record
+ * token usage locally, so per issue #11 token counts are ESTIMATED from
+ * text length (~4 chars/token) and flagged as such in the collect note and
+ * via the model name suffix. Turn counts, timestamps, tools, and error
+ * linkage are real.
+ */
+
+export function codeUserDir(home: string = homedir()): string {
+  if (process.platform === 'darwin') return join(home, 'Library', 'Application Support', 'Code', 'User');
+  if (process.platform === 'win32') {
+    return join(process.env.APPDATA ?? join(home, 'AppData', 'Roaming'), 'Code', 'User');
+  }
+  return join(home, '.config', 'Code', 'User');
+}
+
+interface ChatRequest {
+  requestId?: string;
+  timestamp?: number;
+  modelId?: string;
+  isCanceled?: boolean;
+  message?: { text?: string };
+  response?: unknown[];
+  result?: { errorDetails?: { message?: string } };
+}
+
+interface ChatSession {
+  sessionId?: string;
+  creationDate?: number;
+  lastMessageDate?: number;
+  requests?: ChatRequest[];
+}
+
+const estimateTokens = (text: string): number => Math.ceil(text.length / 4);
+
+/** Harvest assistant-visible text and tool names from a response part array. */
+function walkResponse(parts: unknown[]): { text: string; tools: string[]; commands: string[] } {
+  let text = '';
+  const tools: string[] = [];
+  const commands: string[] = [];
+  for (const part of parts) {
+    if (!part || typeof part !== 'object') continue;
+    const p = part as Record<string, unknown>;
+    if (typeof p.value === 'string') text += p.value;
+    else if (p.value && typeof (p.value as { value?: unknown }).value === 'string') {
+      text += (p.value as { value: string }).value;
+    }
+    if (p.content && typeof (p.content as { value?: unknown }).value === 'string') {
+      text += (p.content as { value: string }).value;
+    }
+    if (p.kind === 'toolInvocationSerialized' || p.kind === 'toolInvocation') {
+      const name = (p.toolId ?? p.toolName ?? 'tool') as string;
+      tools.push(name);
+      if (/terminal|shell|command/i.test(name)) {
+        const inv = p.invocationMessage as { value?: string } | string | undefined;
+        const msg = typeof inv === 'string' ? inv : inv?.value;
+        if (typeof msg === 'string') commands.push(msg.replace(/`/g, ''));
+      }
+    }
+  }
+  return { text, tools, commands };
+}
+
+function parseSessionFile(path: string): ChatSession | undefined {
+  try {
+    const raw = readFileSync(path, 'utf8');
+    if (path.endsWith('.jsonl')) {
+      const first = raw.slice(0, raw.indexOf('\n') === -1 ? raw.length : raw.indexOf('\n'));
+      const line = JSON.parse(first);
+      // kind 0 = initial full snapshot; later incremental ops are not applied.
+      return line?.kind === 0 ? (line.v as ChatSession) : undefined;
+    }
+    return JSON.parse(raw) as ChatSession;
+  } catch {
+    return undefined;
+  }
+}
+
+function projectOf(wsDir: string): string {
+  try {
+    const ws = JSON.parse(readFileSync(join(wsDir, 'workspace.json'), 'utf8'));
+    const folder = ws.folder ?? ws.workspace;
+    if (typeof folder === 'string') return basename(decodeURIComponent(folder.replace(/^file:\/\//, '')));
+  } catch {
+    /* fall through */
+  }
+  return 'unknown';
+}
+
+export function collectCopilot(userDir: string = codeUserDir()): { events: UsageEvent[]; result: CollectResult } {
+  const events: UsageEvent[] = [];
+  let filesScanned = 0;
+  const wsRoot = join(userDir, 'workspaceStorage');
+  if (!existsSync(wsRoot)) {
+    return { events, result: { source: 'copilot', filesScanned: 0, eventsFound: 0, eventsInserted: 0, note: `${wsRoot} not found — VS Code not detected` } };
+  }
+
+  for (const dir of readdirSync(wsRoot)) {
+    const sessionsDir = join(wsRoot, dir, 'chatSessions');
+    let files: string[];
+    try {
+      files = readdirSync(sessionsDir).filter((f) => f.endsWith('.json') || f.endsWith('.jsonl'));
+    } catch {
+      continue;
+    }
+    if (files.length === 0) continue;
+    const project = projectOf(join(wsRoot, dir));
+
+    for (const file of files) {
+      filesScanned++;
+      const session = parseSessionFile(join(sessionsDir, file));
+      if (!session) continue;
+      const sessionId = session.sessionId ?? basename(file).replace(/\.jsonl?$/, '');
+      (session.requests ?? []).forEach((req, i) => {
+        const userText = req.message?.text ?? '';
+        const { text: responseText, tools, commands } = walkResponse(req.response ?? []);
+        if (!userText && !responseText) return;
+        const ts = req.timestamp ?? session.lastMessageDate ?? session.creationDate;
+        const ev: UsageEvent = {
+          source: 'copilot',
+          eventKey: `${sessionId}:${req.requestId ?? i}`,
+          sessionId,
+          project,
+          timestamp: ts ? new Date(ts).toISOString() : new Date(0).toISOString(),
+          // Suffix marks every per-model rollup row as an estimate.
+          model: `${req.modelId ?? 'copilot'} (est)`,
+          inputTokens: estimateTokens(userText),
+          outputTokens: estimateTokens(responseText),
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          thinkingTokens: 0,
+          tools,
+          commands,
+          hasThinking: false,
+          isError: !!req.result?.errorDetails && !req.isCanceled,
+        };
+        ev.activity = classify(ev);
+        events.push(ev);
+      });
+    }
+  }
+
+  return {
+    events,
+    result: {
+      source: 'copilot',
+      filesScanned,
+      eventsFound: events.length,
+      eventsInserted: 0,
+      note:
+        events.length > 0
+          ? 'EXPERIMENTAL — Copilot Chat does not record token usage; counts estimated from text length (~4 chars/token)'
+          : undefined,
+    },
+  };
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -4,6 +4,7 @@ import { collectGeminiCli } from './gemini-cli.js';
 import { collectCodex } from './codex.js';
 import { collectCursor } from './cursor.js';
 import { collectAntigravity } from './antigravity.js';
+import { collectCopilot } from './copilot.js';
 
 export type Adapter = () => { events: UsageEvent[]; result: CollectResult };
 
@@ -19,4 +20,5 @@ export const ADAPTERS: Record<Source, Adapter> = {
   codex: collectCodex,
   cursor: collectCursor,
   antigravity: collectAntigravity,
+  copilot: collectCopilot,
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,8 @@ Usage:
   token-monitor fingerprint [--db <path>]
 
 Commands:
-  collect   Scan local agent logs (Claude Code, Gemini CLI, Codex, Cursor, Antigravity) into SQLite
+  collect   Scan local agent logs (Claude Code, Gemini CLI, Codex, Cursor,
+            Antigravity, Copilot Chat) into SQLite
   report    Activity breakdown, cost, personas, and recommendations
   analyze   Session-level deep dive; --llm asks your local agent CLI for
             prioritized recommendations (sends aggregate metrics only)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Source = 'claude-code' | 'gemini-cli' | 'codex' | 'cursor' | 'antigravity';
+export type Source = 'claude-code' | 'gemini-cli' | 'codex' | 'cursor' | 'antigravity' | 'copilot';
 
 export type Activity =
   | 'thinking'

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -7,6 +7,7 @@ import { collectGeminiCli } from '../src/adapters/gemini-cli.js';
 import { collectCodex } from '../src/adapters/codex.js';
 import { collectCursor } from '../src/adapters/cursor.js';
 import { collectAntigravity } from '../src/adapters/antigravity.js';
+import { collectCopilot } from '../src/adapters/copilot.js';
 import { makeCursorFixture, makeAntigravityFixture } from './helpers.js';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -145,8 +146,37 @@ test('cursor adapter emits turn-final token events, maps workspaces, skips abort
   assert.ok(result.note?.includes('completed turns'));
 });
 
+test('copilot adapter estimates tokens from text, parses json and jsonl sessions', () => {
+  const { events, result } = collectCopilot(join(FIXTURES, 'copilot'));
+
+  assert.equal(result.filesScanned, 3);
+  assert.equal(events.length, 3); // empty stub session yields nothing
+  assert.ok(result.note?.includes('EXPERIMENTAL'));
+  const [r1, r2, s2] = events;
+
+  assert.equal(r1.eventKey, 'cop-s1:r1');
+  assert.equal(r1.project, 'proj-cop1');
+  assert.equal(r1.model, 'copilot/gpt-4.1 (est)');
+  assert.equal(r1.timestamp, new Date(1780000050000).toISOString());
+  assert.equal(r1.inputTokens, Math.ceil('Fix the failing test in utils.spec.ts'.length / 4));
+  assert.equal(r1.outputTokens, Math.ceil('The test fails because the fixture date is wrong. Updated it.'.length / 4));
+  assert.deepEqual(r1.tools, ['copilot_runInTerminal']);
+  assert.deepEqual(r1.commands, ['npm test']);
+  assert.equal(r1.activity, 'testing');
+  assert.equal(r1.isError, false);
+
+  assert.equal(r2.isError, true); // errorDetails without cancellation
+  assert.equal(r2.activity, 'conversation');
+  assert.equal(r2.model, 'copilot (est)'); // no modelId on the request
+
+  // .jsonl: line 0 snapshot parsed, later ops ignored
+  assert.equal(s2.sessionId, 'cop-s2');
+  assert.equal(s2.project, 'proj-cop2');
+  assert.equal(s2.timestamp, new Date(1780000200000).toISOString());
+});
+
 test('adapters return a note instead of throwing when logs are absent', () => {
-  for (const collect of [collectClaudeCode, collectGeminiCli, collectCodex, collectCursor, collectAntigravity]) {
+  for (const collect of [collectClaudeCode, collectGeminiCli, collectCodex, collectCursor, collectAntigravity, collectCopilot]) {
     const { events, result } = collect('/nonexistent/path/xyz');
     assert.equal(events.length, 0);
     assert.ok(result.note);

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { makeCursorFixture, makeAntigravityFixture } from './helpers.js';
 import { cursorUserDir } from '../src/adapters/cursor.js';
+import { codeUserDir } from '../src/adapters/copilot.js';
 
 /**
  * True end-to-end: runs the built CLI as a subprocess against a synthetic
@@ -26,6 +27,7 @@ cpSync(join(FIXTURES, 'gemini'), join(HOME, '.gemini', 'tmp'), { recursive: true
 cpSync(join(FIXTURES, 'codex'), join(HOME, '.codex', 'sessions'), { recursive: true });
 makeCursorFixture(cursorUserDir(HOME));
 makeAntigravityFixture(join(HOME, '.gemini', 'antigravity-cli'));
+cpSync(join(FIXTURES, 'copilot'), codeUserDir(HOME), { recursive: true });
 
 function run(args: string[], opts: { home?: string } = {}) {
   const home = opts.home ?? HOME;
@@ -48,6 +50,7 @@ test('e2e: collect parses all sources into the default db', () => {
   assert.match(stdout, /codex\s+\d+ files\s+2 turns\s+2 new/);
   assert.match(stdout, /cursor\s+\d+ files\s+2 turns\s+2 new/);
   assert.match(stdout, /antigravity\s+\d+ files\s+3 turns\s+3 new/);
+  assert.match(stdout, /copilot\s+\d+ files\s+3 turns\s+3 new/);
   assert.ok(existsSync(join(HOME, '.token-monitor', 'token-monitor.sqlite')));
 });
 
@@ -60,7 +63,7 @@ test('e2e: collect is idempotent', () => {
 test('e2e: report renders all sections from collected data', () => {
   const { stdout, code } = run(['report', ...DAYS]);
   assert.equal(code, 0);
-  for (const expected of ['Where the tokens go', 'By project', 'By model', 'Recommendations', 'proj-alpha', 'proj-g', 'proj-c', 'proj-cur', 'proj-anti', 'gpt-5-codex']) {
+  for (const expected of ['Where the tokens go', 'By project', 'By model', 'Recommendations', 'proj-alpha', 'proj-g', 'proj-c', 'proj-cur', 'proj-anti', 'proj-cop1', 'gpt-5-codex']) {
     assert.ok(stdout.includes(expected), `report missing "${expected}"`);
   }
 });
@@ -69,7 +72,7 @@ test('e2e: report --json emits a signed v1 export; fingerprint command matches i
   const exportJson = run(['report', '--json', ...DAYS]).stdout;
   const data = JSON.parse(exportJson);
   assert.equal(data.version, 1);
-  assert.equal(data.overall.events, 12); // 3 claude + 2 gemini + 2 codex + 2 cursor + 3 antigravity
+  assert.equal(data.overall.events, 15); // 3 claude + 2 gemini + 2 codex + 2 cursor + 3 antigravity + 3 copilot
   assert.equal(data.sig.alg, 'ed25519');
 
   const fp = run(['fingerprint']).stdout.trim();

--- a/test/fixtures/copilot/workspaceStorage/ws1/chatSessions/s1.json
+++ b/test/fixtures/copilot/workspaceStorage/ws1/chatSessions/s1.json
@@ -1,0 +1,27 @@
+{
+  "version": 3,
+  "sessionId": "cop-s1",
+  "creationDate": 1780000000000,
+  "lastMessageDate": 1780000100000,
+  "requesterUsername": "dev",
+  "responderUsername": "GitHub Copilot",
+  "requests": [
+    {
+      "requestId": "r1",
+      "timestamp": 1780000050000,
+      "modelId": "copilot/gpt-4.1",
+      "message": { "text": "Fix the failing test in utils.spec.ts" },
+      "response": [
+        { "kind": "toolInvocationSerialized", "toolId": "copilot_runInTerminal", "invocationMessage": { "value": "npm test" } },
+        { "kind": "markdownContent", "content": { "value": "The test fails because the fixture date is wrong. Updated it." } }
+      ],
+      "result": { "timings": { "totalElapsed": 4000 } }
+    },
+    {
+      "requestId": "r2",
+      "message": { "text": "thanks" },
+      "response": [ { "value": "You're welcome!" } ],
+      "result": { "errorDetails": { "message": "Rate limited" } }
+    }
+  ]
+}

--- a/test/fixtures/copilot/workspaceStorage/ws1/workspace.json
+++ b/test/fixtures/copilot/workspaceStorage/ws1/workspace.json
@@ -1,0 +1,1 @@
+{ "folder": "file:///home/u/proj-cop1" }

--- a/test/fixtures/copilot/workspaceStorage/ws2/chatSessions/s2.jsonl
+++ b/test/fixtures/copilot/workspaceStorage/ws2/chatSessions/s2.jsonl
@@ -1,0 +1,2 @@
+{"kind":0,"v":{"version":3,"sessionId":"cop-s2","creationDate":1780000200000,"requests":[{"requestId":"r1","message":{"text":"Refactor the parser"},"response":[{"value":"Done — extracted tokenize() and parse()."}]}]}}
+{"kind":2,"path":["requests",0,"followups"],"v":[]}

--- a/test/fixtures/copilot/workspaceStorage/ws2/workspace.json
+++ b/test/fixtures/copilot/workspaceStorage/ws2/workspace.json
@@ -1,0 +1,1 @@
+{ "folder": "file:///home/u/proj-cop2" }

--- a/test/fixtures/copilot/workspaceStorage/ws3/chatSessions/empty.json
+++ b/test/fixtures/copilot/workspaceStorage/ws3/chatSessions/empty.json
@@ -1,0 +1,1 @@
+{ "version": 3, "sessionId": "cop-empty", "creationDate": 1780000300000, "requests": [] }


### PR DESCRIPTION
## What

VS Code Copilot Chat adapter (#11). Copilot persists chat sessions but **no token counts**, so per the issue this adapter estimates from content length and flags it everywhere:

- `src/adapters/copilot.ts` — scans `workspaceStorage/*/chatSessions/*`; handles both the older `*.json` full-session format and the newer `*.jsonl` format (line 0 `{kind: 0, v}` snapshot; later incremental ops are ignored). One UsageEvent per request.
- **Estimation, clearly flagged**: input/output ≈ chars/4 of request/response text; every model name gets an `(est)` suffix (visible in all per-model rollups) and the collect note says `EXPERIMENTAL`. No price-table match → cost stays "unknown" rather than fabricated.
- Real (not estimated): turn counts, timestamps, tool invocations (`toolInvocationSerialized`, with terminal commands harvested for test/ship classification), error linkage (`errorDetails`, cancellations excluded), workspace attribution.

## Validation

- 68 tests pass. Unit test covers both file formats, estimation math, tool/command extraction, error-vs-cancel, and the empty-session stub; e2e runs the full pipeline with the fixture workspace tree under the synthetic HOME.
- Against this machine's real VS Code dir: 4 stub sessions scanned, 0 events, no crash (the local Copilot sessions are all empty — format knowledge comes from the VS Code chat serialization, hence the experimental label, same precedent as the codex adapter).