### PR TITLE
chore: release v0.4.0 — IDE coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ npm install -g github:ryandemelo/token-monitor
 token-monitor collect && token-monitor report
 ```
 
-`collect` reads the user's local agent session logs (`~/.claude/projects/`, `~/.gemini/tmp/`, `~/.codex/sessions/`) into `~/.token-monitor/token-monitor.sqlite`. It is idempotent — safe to re-run any time. `report` prints the analysis; `html` writes a dashboard file; nothing makes network calls.
+`collect` reads the user's local agent session logs (`~/.claude/projects/`, `~/.gemini/tmp/`, `~/.codex/sessions/`, Cursor's `state.vscdb`, `~/.gemini/antigravity-cli/`, VS Code `chatSessions/`) into `~/.token-monitor/token-monitor.sqlite`. It is idempotent — safe to re-run any time. `report` prints the analysis; `html` writes a dashboard file; nothing makes network calls.
 
 After installing, run `collect` then `report` and walk the user through their activity breakdown, cache hit ratio, rework ratio, and persona.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Measure how effectively your team spends AI coding-agent tokens — locally, with zero setup.
 
-Most token dashboards tell you *how much* you spent. token-monitor tells you *what you spent it on* — separating thinking and defining from actual coding, testing, and shipping — and what to change. It parses the session logs that Claude Code, Gemini CLI, and Codex already write to your machine. No API keys, no server, no telemetry.
+Most token dashboards tell you *how much* you spent. token-monitor tells you *what you spent it on* — separating thinking and defining from actual coding, testing, and shipping — and what to change. It parses the session logs that Claude Code, Gemini CLI, Codex, Cursor, Antigravity, and Copilot Chat already write to your machine. No API keys, no server, no telemetry.
 
 ```
 Where the tokens go (activity share of input+output)
@@ -158,7 +158,7 @@ Resolved findings re-open automatically if the metric regresses.
 ## CLI
 
 ```
-token-monitor collect [--source claude-code|gemini-cli|codex] [--db <path>]
+token-monitor collect [--source claude-code|gemini-cli|codex|cursor|antigravity|copilot] [--db <path>]
 token-monitor report  [--days 30] [--project <name>] [--source <name>] [--json] [--db <path>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
@@ -174,7 +174,9 @@ The most valuable contribution: an adapter for another agent CLI (Aider, OpenCod
 - [x] Team rollups: `merge` command + `team.yaml` discipline mapping
 - [x] Self-contained HTML dashboard
 - [x] Follow-through tracking: baseline on first firing, delta on every later report
-- [ ] Adapters: Aider, OpenCode, Cursor
+- [x] IDE coverage: Cursor, Antigravity, Copilot Chat adapters
+- [ ] Adapters: Aider, OpenCode, Windsurf (needs a contributor with Windsurf — #12)
+- [ ] VS Code-family extension: status-bar cost + dashboard webview (#13)
 - [ ] Org-level cross-check via provider usage APIs
 - [ ] npm publish
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # token-monitor
 
-> Local-first CLI that measures how effectively a developer or team spends AI coding-agent tokens. Parses session logs that Claude Code, Gemini CLI, and Codex already write to disk; classifies every turn by activity (thinking / exploration / coding / testing / shipping); reports cache hit ratio, rework ratio, cost, usage personas, and tracked recommendations. Zero runtime dependencies, no API keys, no network calls — all data stays on the machine.
+> Local-first CLI that measures how effectively a developer or team spends AI coding-agent tokens. Parses session logs that Claude Code, Gemini CLI, Codex, Cursor, Antigravity, and Copilot Chat already write to disk; classifies every turn by activity (thinking / exploration / coding / testing / shipping); reports cache hit ratio, rework ratio, cost, usage personas, and tracked recommendations. Zero runtime dependencies, no API keys, no network calls — all data stays on the machine.
 
 ## Install and run (requires Node.js >= 24)
 
@@ -14,7 +14,7 @@ Or persistent install: `npm install -g github:ryandemelo/token-monitor`, then us
 
 ## Commands
 
-- `collect [--source claude-code|gemini-cli|codex] [--db <path>]` — parse local logs into SQLite (idempotent, safe to re-run)
+- `collect [--source claude-code|gemini-cli|codex|cursor|antigravity|copilot] [--db <path>]` — parse local logs into SQLite (idempotent, safe to re-run)
 - `report [--days 30] [--project <name>] [--json] [--db <path>]` — activity breakdown, personas, recommendations, follow-through deltas
 - `html [--out report.html] [--days 30]` — static dashboard, no server
 - `merge <export.json>... [--team team.yaml]` — combine member exports (`report --json`) into a per-discipline team report

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-monitor",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-monitor",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "bin": {
         "token-monitor": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-monitor",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex) — activity breakdowns, usage personas, and recommendations.",
   "license": "MIT",
   "author": "Ryan",


### PR DESCRIPTION
Version bump + doc sync for the v0.4.0 release: README intro/CLI/roadmap, llms.txt, and AGENTS.md now list the Cursor, Antigravity, and Copilot Chat sources shipped in #18/#19/#20.