### PR TITLE
chore: publish to npm as @ryandemelo/token-monitor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,11 @@ Requires Node.js ≥ 24 (uses built-in `node:sqlite`). No other dependencies.
 
 ```sh
 # one-off, no install
-npx github:ryandemelo/token-monitor collect
-npx github:ryandemelo/token-monitor report
+npx @ryandemelo/token-monitor collect
+npx @ryandemelo/token-monitor report
 
 # or persistent
-npm install -g github:ryandemelo/token-monitor
+npm install -g @ryandemelo/token-monitor
 token-monitor collect && token-monitor report
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Where the tokens go (activity share of input+output)
 Requires Node.js ≥ 24 (uses the built-in `node:sqlite` — zero runtime dependencies).
 
 ```sh
-npx github:ryandemelo/token-monitor collect   # scan local agent logs
-npx github:ryandemelo/token-monitor report    # activity breakdown, personas, recommendations
-npx github:ryandemelo/token-monitor html      # self-contained dashboard -> report.html
+npx @ryandemelo/token-monitor collect   # scan local agent logs
+npx @ryandemelo/token-monitor report    # activity breakdown, personas, recommendations
+npx @ryandemelo/token-monitor html      # self-contained dashboard -> report.html
 ```
 
-Persistent install: `npm install -g github:ryandemelo/token-monitor`, then `token-monitor <command>`. For development: clone, `npm install && npm test`.
+Persistent install: `npm install -g @ryandemelo/token-monitor`, then `token-monitor <command>`. For development: clone, `npm install && npm test`.
 
 ### Or let your coding agent install it
 
@@ -90,7 +90,7 @@ Adapters skip gracefully when a tool isn't installed. The Cursor adapter reads o
 The lead hosts one config file anywhere (gist, internal wiki, S3) and sends one line — pasteable by the dev, an MDM/onboarding script, or their coding agent:
 
 ```sh
-npx github:ryandemelo/token-monitor init --from https://example.com/team-config.json
+npx @ryandemelo/token-monitor init --from https://example.com/team-config.json
 ```
 
 ```jsonc
@@ -178,7 +178,7 @@ The most valuable contribution: an adapter for another agent CLI (Aider, OpenCod
 - [ ] Adapters: Aider, OpenCode, Windsurf (needs a contributor with Windsurf — #12)
 - [ ] VS Code-family extension: status-bar cost + dashboard webview (#13)
 - [ ] Org-level cross-check via provider usage APIs
-- [ ] npm publish
+- [x] npm publish: `npx @ryandemelo/token-monitor`
 
 ## Integrity & threat model
 

--- a/llms.txt
+++ b/llms.txt
@@ -5,12 +5,12 @@
 ## Install and run (requires Node.js >= 24)
 
 ```sh
-npx github:ryandemelo/token-monitor collect   # scan local agent logs into ~/.token-monitor/
-npx github:ryandemelo/token-monitor report    # terminal report
-npx github:ryandemelo/token-monitor html      # self-contained dashboard -> report.html
+npx @ryandemelo/token-monitor collect   # scan local agent logs into ~/.token-monitor/
+npx @ryandemelo/token-monitor report    # terminal report
+npx @ryandemelo/token-monitor html      # self-contained dashboard -> report.html
 ```
 
-Or persistent install: `npm install -g github:ryandemelo/token-monitor`, then use `token-monitor <command>`.
+Or persistent install: `npm install -g @ryandemelo/token-monitor`, then use `token-monitor <command>`.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,29 @@
 {
-  "name": "token-monitor",
+  "name": "@ryandemelo/token-monitor",
   "version": "0.4.0",
-  "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex) — activity breakdowns, usage personas, and recommendations.",
+  "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex, Cursor, Antigravity, Copilot Chat) — activity breakdowns, usage personas, and recommendations.",
   "license": "MIT",
-  "author": "Ryan",
+  "author": "Ryan de Melo",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ryandemelo/token-monitor.git"
+  },
+  "homepage": "https://github.com/ryandemelo/token-monitor#readme",
+  "bugs": {
+    "url": "https://github.com/ryandemelo/token-monitor/issues"
+  },
+  "keywords": [
+    "ai",
+    "tokens",
+    "claude-code",
+    "gemini-cli",
+    "codex",
+    "cursor",
+    "copilot",
+    "antigravity",
+    "cost",
+    "developer-productivity"
+  ],
   "type": "module",
   "bin": {
     "token-monitor": "dist/src/cli.js"
@@ -11,6 +31,9 @@
   "files": [
     "dist/src"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=24"
   },

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -8,7 +8,7 @@ import { DEFAULT_KEY_DIR } from './sign.js';
  * Team rollout. A lead hosts one config file; each dev (or their MDM /
  * onboarding script / coding agent) runs:
  *
- *   npx github:ryandemelo/token-monitor init --from <url>
+ *   npx @ryandemelo/token-monitor init --from <url>
  *
  * init stores the config, generates the signing keypair, runs a first
  * collect, optionally installs the collection schedule, and prints the


### PR DESCRIPTION
## What

- `package.json`: name → `@ryandemelo/token-monitor` (unscoped name is taken by an unrelated package; bin stays `token-monitor`), `publishConfig.access: public`, repository/homepage/bugs/keywords metadata, description lists all six sources.
- README / AGENTS.md / llms.txt / deploy.ts comment: `npx github:ryandemelo/token-monitor` → `npx @ryandemelo/token-monitor`; roadmap npm-publish item checked.

## Validation

- 0.4.0 is live: `npm view @ryandemelo/token-monitor` → 0.4.0; `npx -y @ryandemelo/token-monitor --help` works from a clean cache.
- 68 tests pass.