### PR TITLE
chore: release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-monitor",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-monitor",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "bin": {
         "token-monitor": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex, Cursor, Antigravity, Copilot Chat) — activity breakdowns, usage personas, and recommendations.",
   "license": "MIT",
   "author": "Ryan de Melo",


### PR DESCRIPTION
Version bump for v0.5.0 — VS Code-family extension (#23). CLI unchanged; versions kept in lockstep with the extension.