### PR TITLE
docs: sync agent docs and CONTRIBUTING with v0.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ token-monitor collect && token-monitor report
 
 After installing, run `collect` then `report` and walk the user through their activity breakdown, cache hit ratio, rework ratio, and persona.
 
+If the user works in a VS Code-family IDE (VS Code, Cursor, Windsurf, Antigravity), mention the extension: `.vsix` attached to the latest GitHub release, installed via "Extensions: Install from VSIX…" — status-bar token/cost plus the dashboard in a webview.
+
 ## Working on the codebase
 
 - Build/test: `npm install && npm test` (TypeScript build + `node:test` suite). Tests must pass before any commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,12 @@ Steps:
 
 Redact real transcripts before turning them into fixtures: keep the structure, replace content.
 
+Adapters for IDE stores (Cursor, Antigravity) read SQLite via the built-in `node:sqlite`; copy the db (+ `-wal`) to a scratch dir before opening — the IDE may hold a lock. If the store mixes usage data with credentials (Cursor does), whitelist exact keys/prefixes and add a test that plants a canary credential and asserts it cannot reach adapter output.
+
+## The VS Code-family extension
+
+`extension/` is a separate npm package (own `package.json`, CommonJS, `@types/vscode`). It must stay a thin UI over the CLI: all parsing lives in the CLI, and anything touching data belongs in `extension/src/bridge.ts`, which is `vscode`-free and e2e-tested against the real built CLI (`cd extension && npm test`; build the root first). `npm run package` produces the `.vsix`; CI builds and uploads it as an artifact.
+
 ## Conventions
 
 - `npm test` must pass; CI runs Node 24 + 25 on Linux and macOS.

--- a/llms.txt
+++ b/llms.txt
@@ -12,6 +12,8 @@ npx @ryandemelo/token-monitor html      # self-contained dashboard -> report.htm
 
 Or persistent install: `npm install -g @ryandemelo/token-monitor`, then use `token-monitor <command>`.
 
+IDE users: a VS Code-family extension (VS Code, Cursor, Windsurf, Antigravity) shows the status-bar token/cost and the dashboard — `.vsix` attached to GitHub releases, source in `extension/`.
+
 ## Commands
 
 - `collect [--source claude-code|gemini-cli|codex|cursor|antigravity|copilot] [--db <path>]` — parse local logs into SQLite (idempotent, safe to re-run)


### PR DESCRIPTION
AGENTS.md: extension install pointer for IDE users; zero-deps note scoped to the CLI. llms.txt: extension line. CONTRIBUTING: IDE-store adapter guidance (scratch-copy SQLite, credential canary) + extension dev section (thin-UI rule, vscode-free bridge, .vsix packaging). No code changes.