### PR TITLE
chore: extension id → ryandemelo.token-monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,5 @@ jobs:
         working-directory: extension
       - uses: actions/upload-artifact@v4
         with:
-          name: token-monitor-vscode-vsix
+          name: token-monitor-extension-vsix
           path: extension/*.vsix

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "token-monitor-vscode",
+  "name": "token-monitor",
   "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "token-monitor-vscode",
+      "name": "token-monitor",
       "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "token-monitor-vscode",
+  "name": "token-monitor",
   "displayName": "Token Monitor",
   "description": "Status-bar token/cost for the current project plus the token-monitor dashboard, for VS Code, Cursor, Windsurf, and Antigravity.",
   "version": "0.5.0",


### PR DESCRIPTION
Drops the redundant `-vscode` suffix from the extension package name before first marketplace publish (ids are permanent after). `.vsix` now packages as `token-monitor-0.5.0.vsix`; CI artifact renamed. Extension suite 5/5; reinstalled in VS Code under the new id, old id uninstalled.