### PR TITLE
chore: pin Gemini/GPT prices to dated vendor sources

### DIFF
--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,8 +1,10 @@
 /**
  * Prices in USD per million tokens. Anthropic prices are current as of
  * 2026-06 (cache read ≈ 0.1× input, cache write ≈ 1.25× input for the
- * default 5-minute TTL). Entries with `estimated: true` are placeholders —
- * edit them to match your vendor's current price sheet.
+ * default 5-minute TTL); Gemini and OpenAI rows pinned 2026-06-12 against
+ * the official price pages (sources in the table comment). Entries with
+ * `estimated: true` are placeholders or assumptions — edit them to match
+ * your vendor's current price sheet or contract.
  */
 export interface ModelPrice {
   match: RegExp;
@@ -13,15 +15,37 @@ export interface ModelPrice {
   estimated?: boolean;
 }
 
+// Order matters: first matching row wins, so generation-specific rows come
+// before the catch-alls. Gemini/OpenAI rows pinned 2026-06-12 from
+// https://ai.google.dev/gemini-api/docs/pricing and
+// https://developers.openai.com/api/docs/pricing (standard tier, ≤200k
+// context where vendors price by tier). Gemini bills cache *storage* per
+// hour rather than per write-token, and OpenAI doesn't bill cache writes —
+// cacheWrite is 0 for both (their adapters report cacheCreationTokens 0).
 export const PRICES: ModelPrice[] = [
   { match: /claude-fable-5|claude-mythos-5/, input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
   { match: /claude-opus-4/, input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   { match: /claude-sonnet-4/, input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   { match: /claude-haiku-4/, input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
-  // Placeholders — verify against the vendor price sheet before trusting cost figures.
-  { match: /gemini-.*-pro/, input: 2.5, output: 15, cacheRead: 0.31, cacheWrite: 2.5, estimated: true },
-  { match: /gemini-.*-flash/, input: 0.5, output: 3, cacheRead: 0.05, cacheWrite: 0.5, estimated: true },
-  { match: /gpt-5|codex/, input: 1.75, output: 14, cacheRead: 0.18, cacheWrite: 1.75, estimated: true },
+
+  { match: /gemini-3\.5-flash/, input: 1.5, output: 9, cacheRead: 0.15, cacheWrite: 0 },
+  { match: /gemini-3.*-pro/, input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0 },
+  // Also matches Antigravity's internal ids (gemini-3-flash-a) and previews.
+  { match: /gemini-3-flash/, input: 0.5, output: 3, cacheRead: 0.05, cacheWrite: 0 },
+  { match: /gemini-2\.5-pro/, input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0 },
+  { match: /gemini-2\.5-flash-lite/, input: 0.1, output: 0.4, cacheRead: 0.01, cacheWrite: 0 },
+  { match: /gemini-2\.5-flash/, input: 0.3, output: 2.5, cacheRead: 0.03, cacheWrite: 0 },
+
+  { match: /gpt-5\.5-pro/, input: 30, output: 180, cacheRead: 3, cacheWrite: 0, estimated: true }, // cacheRead unpublished, 10% assumed
+  { match: /gpt-5\.5/, input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+  // Original gpt-5-codex (2025-09): delisted from the official page; last published rate.
+  { match: /gpt-5-codex/, input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0, estimated: true },
+  { match: /gpt-5\.\d+-codex/, input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+
+  // Catch-alls for generations not listed above — placeholders, verify before trusting.
+  { match: /gemini-.*-pro/, input: 2.5, output: 15, cacheRead: 0.31, cacheWrite: 0, estimated: true },
+  { match: /gemini-.*-flash/, input: 0.5, output: 3, cacheRead: 0.05, cacheWrite: 0, estimated: true },
+  { match: /gpt-5|codex/, input: 1.75, output: 14, cacheRead: 0.18, cacheWrite: 0, estimated: true },
 ];
 
 export interface Cost {

--- a/test/pricing.test.ts
+++ b/test/pricing.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { costOf, PRICES } from '../src/pricing.js';
+
+test('generation-specific rows win over catch-alls (order-dependent)', () => {
+  // Antigravity's internal flash id hits the pinned gemini-3-flash row, not the catch-all.
+  const flash = costOf('gemini-3-flash-a', 1_000_000, 0, 0, 0);
+  assert.equal(flash.usd, 0.5);
+  assert.equal(flash.estimated, false);
+
+  // flash-lite must match before the broader 2.5-flash row.
+  const lite = costOf('gemini-2.5-flash-lite', 1_000_000, 0, 0, 0);
+  assert.equal(lite.usd, 0.1);
+
+  // gpt-5.5 hits its pinned row, not the gpt-5 catch-all.
+  const gpt55 = costOf('gpt-5.5', 1_000_000, 0, 0, 0);
+  assert.equal(gpt55.usd, 5);
+  assert.equal(gpt55.estimated, false);
+
+  // versioned codex (5.3) is pinned; original gpt-5-codex stays estimated.
+  assert.equal(costOf('gpt-5.3-codex', 1_000_000, 0, 0, 0).estimated, false);
+  assert.equal(costOf('gpt-5-codex', 1_000_000, 0, 0, 0).estimated, true);
+  assert.equal(costOf('gpt-5-codex', 1_000_000, 0, 0, 0).usd, 1.25);
+});
+
+test('unknown models are unpriced, not zero-cost-estimated', () => {
+  const c = costOf('cursor-auto', 1_000_000, 1_000_000, 0, 0);
+  assert.equal(c.priced, false);
+  assert.equal(c.usd, 0);
+});
+
+test('every model seen by the adapters resolves to some row or is knowingly unpriced', () => {
+  // Guards against future row reordering silently orphaning known model ids.
+  for (const model of ['gemini-3.5-flash', 'gemini-3.1-pro-preview', 'gemini-3-flash-preview', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gpt-5.5-pro', 'gpt-5.2-codex', 'claude-opus-4-7']) {
+    assert.ok(PRICES.some((p) => p.match.test(model)), `${model} has no price row`);
+  }
+  for (const knowinglyUnpriced of ['cursor-auto', 'copilot/gpt-4.1 (est)', 'antigravity']) {
+    // Cursor/Copilot can't be priced (no resolved model / subscription) — must stay unpriced.
+    assert.ok(!PRICES.some((p) => p.match.test(knowinglyUnpriced)), `${knowinglyUnpriced} unexpectedly priced`);
+  }
+});


### PR DESCRIPTION
## What (#30)

- Pinned 2026-06-12 against the official pages ([Gemini](https://ai.google.dev/gemini-api/docs/pricing), [OpenAI](https://developers.openai.com/api/docs/pricing)), standard tier, ≤200k-context tier where vendors split:
  - gemini-3.5-flash 1.50/9 (cache read 0.15), gemini-3.x-pro 2/12, gemini-3-flash 0.50/3 (covers Antigravity's `gemini-3-flash-a`), gemini-2.5-pro 1.25/10, 2.5-flash 0.30/2.50, 2.5-flash-lite 0.10/0.40
  - gpt-5.5 5/30 (cache 0.50), gpt-5.x-codex 1.75/14 (cache 0.175)
- `cacheWrite: 0` for both vendors with rationale in comment (Gemini bills storage/hour, OpenAI doesn't bill writes; both adapters report 0 cache-creation anyway).
- Still `estimated: true`, deliberately: gpt-5-codex original (delisted from the official page — last published 1.25/10), gpt-5.5-pro cacheRead (unpublished, 10% assumed), and the generation catch-alls.
- New `test/pricing.test.ts`: row precedence (specific before catch-all, flash-lite before flash), known adapter model ids all resolve, Cursor/Copilot pseudo-models (`cursor-auto`, `(est)` models) stay **unpriced** rather than mispriced.

71/71 tests.

This makes cost figures trustworthy ahead of #28 (savings-quantified recommendations), where price accuracy becomes load-bearing.