### PR TITLE
feat: org-level team rollups — two-level teams.yaml, merge --by, fingerprint identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,27 @@ token-monitor merge exports/*.json --team team.yaml
 
 The team report shows per-discipline rollups: tokens, cost, cache hit, rework, think:code ratio, dominant activity, and persona — so you can see *which discipline* needs which intervention, not just a total bill.
 
+### Org rollups (lead → org)
+
+The same machinery scales to many teams with no server: every team's `push` targets **one drop** (shared dir or HTTP endpoint), and the org lead merges the signed files that land there. The member map can group by team:
+
+```sh
+cat > teams.yaml <<'EOF'
+platform:
+  alice: frontend
+  bob: backend
+data:
+  carol: ml
+EOF
+
+token-monitor merge drop/*.json --team teams.yaml --by team   # or --by discipline
+token-monitor merge drop/*.json --team teams.yaml --by team --html org.html
+```
+
+`--by` picks the comparison axis; `--html` also writes a self-contained org dashboard. Flat `team.yaml` files keep working unchanged.
+
+Identity is the **signing fingerprint**, not the OS username: two different "ryan"s on different teams stay distinct, and when the same signer's exports show up more than once (stale files in the drop), only the newest is counted. With `--keys keys.json` the lead's pinned `user → fingerprint` map is also the naming authority — members are labeled by their enrolled name regardless of what their machine reports.
+
 ## Deep analysis & LLM-powered recommendations
 
 `token-monitor analyze` goes a level deeper than the report — which sessions and habits burn the tokens:
@@ -166,7 +187,7 @@ token-monitor collect [--source claude-code|gemini-cli|codex|cursor|antigravity|
 token-monitor report  [--days 30] [--project <name>] [--source <name>] [--json] [--db <path>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
-token-monitor merge   <export.json>... [--team team.yaml] [--json]
+token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline] [--verify] [--keys keys.json] [--json] [--html team.html]
 ```
 
 ## Contributing
@@ -176,6 +197,7 @@ The most valuable contribution: an adapter for another agent CLI (Aider, OpenCod
 ## Roadmap
 
 - [x] Team rollups: `merge` command + `team.yaml` discipline mapping
+- [x] Org rollups: two-level `teams.yaml`, `merge --by team|discipline`, fingerprint identity, org HTML dashboard
 - [x] Self-contained HTML dashboard
 - [x] Follow-through tracking: baseline on first firing, delta on every later report
 - [x] IDE coverage: Cursor, Antigravity, Copilot Chat adapters

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,15 +5,15 @@ import { ADAPTERS } from './adapters/index.js';
 import { openDb, insertEvents, loadEvents, DEFAULT_DB } from './store.js';
 import { renderReport, renderTeamReport } from './report.js';
 import { assignPersona, generalRecommendations } from './personas.js';
-import { buildExport, parseTeamConfig, mergeMetrics } from './team.js';
+import { buildExport, parseTeamConfig, mergeMetrics, dedupeExports, rollupExports, displayName, identityOf } from './team.js';
 import { syncFindings } from './followthrough.js';
 import { computeMetrics } from './metrics.js';
-import { renderHtml } from './html.js';
+import { renderHtml, renderTeamHtml } from './html.js';
 import { renderAnalysis, deepAnalysis, buildLlmPrompt, runLlm, detectAgent } from './analyze.js';
 import { signObject, verifyObject, ensureKeypair, fingerprint, loadKeyring, checkKeyring, keyDirFor, DEFAULT_KEY_DIR } from './sign.js';
 import { fetchTeamConfig, saveConfig, loadConfig, pushExport, installSchedule, removeSchedule } from './deploy.js';
 import { realpathSync } from 'node:fs';
-import type { ExportV1 } from './team.js';
+import type { SignedExport, RollupAxis } from './team.js';
 import type { Source } from './types.js';
 
 const HELP = `token-monitor — measure how effectively your team spends AI coding-agent tokens
@@ -23,7 +23,8 @@ Usage:
   token-monitor report  [--days <n>] [--project <name>] [--source <name>] [--json] [--db <path>]
   token-monitor analyze [--days <n>] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
-  token-monitor merge   <export.json>... [--team team.yaml] [--verify] [--keys keys.json] [--json]
+  token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline]
+                        [--verify] [--keys keys.json] [--json] [--html team.html]
   token-monitor init    --from <url-or-path>
   token-monitor push    [--db <path>]
   token-monitor schedule [--hours <n>] [--remove]
@@ -53,7 +54,10 @@ Options:
   --days      report window in days (default: 30)
   --project   filter to one project
   --json      machine-readable output (for team aggregation)
-  --team      username -> discipline map, flat YAML or JSON
+  --team      member map: flat (\`alice: frontend\`) or two-level YAML
+              (\`platform:\` header, indented members), or JSON
+  --by        merge rollup axis: team or discipline (default: discipline)
+  --html      also write the merged team dashboard to this path
   --db        SQLite path (default: ${DEFAULT_DB})
 `;
 
@@ -100,6 +104,8 @@ async function main() {
       agent: { type: 'string' },
       verify: { type: 'boolean', default: false },
       keys: { type: 'string' },
+      by: { type: 'string' },
+      html: { type: 'string' },
       from: { type: 'string' },
       hours: { type: 'string' },
       remove: { type: 'boolean', default: false },
@@ -120,9 +126,14 @@ async function main() {
       console.error('merge requires at least one export file (token-monitor report --json > me.json)');
       process.exit(1);
     }
+    const by = (values.by ?? 'discipline') as RollupAxis;
+    if (by !== 'team' && by !== 'discipline') {
+      console.error(`--by must be "team" or "discipline", got "${values.by}"`);
+      process.exit(1);
+    }
     const keyring = values.keys ? loadKeyring(values.keys) : undefined;
     let verifyFailed = false;
-    const exports: ExportV1[] = files.map((f) => {
+    const all: SignedExport[] = files.map((f) => {
       const data = JSON.parse(readFileSync(f, 'utf8'));
       if (data.version !== 1 || !data.overall) {
         throw new Error(`${f} is not a token-monitor v1 export`);
@@ -134,18 +145,34 @@ async function main() {
         console.error(`${mark} ${f} (${data.user})${vr.ok ? ` — signed by ${vr.fingerprint}` : ` — ${vr.reason}`}`);
         if (!vr.ok) verifyFailed = true;
       }
-      return data as ExportV1;
+      return data as SignedExport;
     });
     if (verifyFailed) {
       console.error('\nVerification failed — refusing to merge. Fix or exclude the exports above.');
       process.exit(1);
     }
+    // Identity is the signing fingerprint (user@host for unsigned exports) —
+    // the same signer pushing twice contributes only its newest export.
+    const { kept: exports, dropped } = dedupeExports(all);
+    for (const d of dropped) {
+      console.error(`⊘ skipped stale export from ${displayName(d, keyring)} (${identityOf(d)}, generated ${d.generatedAt}) — newer one present`);
+    }
     const team = values.team ? parseTeamConfig(values.team) : {};
     if (values.json) {
       const overall = mergeMetrics(exports.map((e) => e.overall));
-      console.log(JSON.stringify({ members: exports.map((e) => e.user), overall, persona: assignPersona(overall) }, null, 2));
+      console.log(JSON.stringify({
+        members: [...new Set(exports.map((e) => displayName(e, keyring)))],
+        by,
+        rollups: rollupExports(exports, team, by, keyring),
+        overall,
+        persona: assignPersona(overall),
+      }, null, 2));
     } else {
-      console.log(renderTeamReport(exports, team));
+      console.log(renderTeamReport(exports, team, { by, keyring }));
+    }
+    if (values.html) {
+      writeFileSync(values.html, renderTeamHtml(exports, team, { by, keyring }));
+      console.error(`Wrote ${values.html} (${exports.length} export(s)).`);
     }
     return;
   }

--- a/src/html.ts
+++ b/src/html.ts
@@ -6,6 +6,8 @@ import { assignPersona, generalRecommendations } from './personas.js';
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
 import { fmtTokens } from './report.js';
+import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
+import { mergeMetrics, rollupExports, displayName } from './team.js';
 
 const ACTIVITY_COLORS: Record<string, string> = {
   thinking: '#8b7ff5',
@@ -93,10 +95,36 @@ export function renderHtml(
           .join('')}</table>`
       : '';
 
+  return pageShell(
+    `token-monitor — last ${opts.days} days`,
+    `<h1>token-monitor <span class="muted">— last ${opts.days} days · generated ${new Date().toISOString().slice(0, 16).replace('T', ' ')}</span></h1>
+<div class="cards">${cards}</div>
+
+<h2>Where the tokens go</h2>
+${stackedBar(m)}
+<div class="legend">${legend}</div>
+<p class="muted">rework ${pct(m.reworkRatio)} · think:code ${m.thinkToCodeRatio.toFixed(2)} · ${m.errorEvents} turns hit tool errors</p>
+
+<h2>Projects</h2>
+<table><tr><th>Project</th><th>Activity mix</th><th>Tokens</th><th>Cost</th><th>Cache</th><th>Rework</th><th>Persona</th></tr>${projRows}</table>
+
+<h2>Models</h2>
+<table><tr><th>Model</th><th>Tokens</th><th>Cost</th></tr>${modelRows}</table>
+
+<div class="persona">
+  <h3>${persona.emoji} ${esc(persona.name)}</h3>
+  <div class="muted">${esc(persona.description)}</div>
+  <ul class="recs">${recs.map((r) => `<li>${esc(r)}</li>`).join('')}</ul>
+</div>
+${followSection}`,
+  );
+}
+
+function pageShell(title: string, body: string): string {
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>token-monitor — last ${opts.days} days</title>
+<title>${esc(title)}</title>
 <style>
   :root { color-scheme: dark; }
   body { font: 14px/1.5 -apple-system, "Segoe UI", Roboto, sans-serif; background:#14171d; color:#e6e9ef; max-width: 1080px; margin: 2rem auto; padding: 0 1rem; }
@@ -120,26 +148,55 @@ export function renderHtml(
   .st-resolved { color:#5dc98a; } .st-regressing { color:#e88f68; } .st-improving { color:#9fd45d; }
   footer { margin:2.5rem 0 1rem; font-size:.8rem; color:#717a8a; }
 </style></head><body>
-<h1>token-monitor <span class="muted">— last ${opts.days} days · generated ${new Date().toISOString().slice(0, 16).replace('T', ' ')}</span></h1>
+${body}
+<footer>Generated locally by <a href="https://github.com/ryandemelo/token-monitor">token-monitor</a>. Costs marked ~ use placeholder prices. No data leaves your machine.</footer>
+</body></html>`;
+}
+
+/** Org dashboard for merged member exports — the HTML face of `merge`. */
+export function renderTeamHtml(
+  exports: SignedExport[],
+  config: TeamConfig,
+  opts: { by?: RollupAxis; keyring?: Record<string, string> } = {},
+): string {
+  const by = opts.by ?? 'discipline';
+  const overall = mergeMetrics(exports.map((e) => e.overall));
+  const rollups = rollupExports(exports, config, by, opts.keyring);
+  const persona = assignPersona(overall);
+  const recs = [...persona.recommendations, ...generalRecommendations(overall)];
+  const members = new Set(exports.map((e) => displayName(e, opts.keyring)));
+
+  const cards = [
+    ['Members', String(members.size)],
+    ['Sessions', String(overall.sessions)],
+    ['Spend tokens', fmtTokens(overall.spendTokens)],
+    ['Cache hit', pct(overall.cacheHitRatio)],
+    ['Rework', pct(overall.reworkRatio)],
+    ['Est. cost', cost(overall)],
+  ]
+    .map(([k, v]) => `<div class="card"><div class="k">${k}</div><div class="v">${v}</div></div>`)
+    .join('');
+
+  const axisLabel = by === 'team' ? 'Team' : 'Discipline';
+  const rollupRows = rollups
+    .map(({ group, users, metrics: m }) => {
+      const p = assignPersona(m);
+      return `<tr><td>${esc(group)}</td><td>${esc(users.join(', '))}</td><td>${stackedBar(m)}</td><td class="num">${fmtTokens(m.spendTokens)}</td><td class="num">${cost(m)}</td><td class="num">${pct(m.cacheHitRatio)}</td><td class="num">${pct(m.reworkRatio)}</td><td class="num">${m.thinkToCodeRatio.toFixed(2)}</td><td>${p.emoji} ${esc(p.name)}</td></tr>`;
+    })
+    .join('');
+
+  return pageShell(
+    `token-monitor team — ${members.size} member(s)`,
+    `<h1>token-monitor team <span class="muted">— ${exports.length} export(s), ${members.size} member(s)</span></h1>
 <div class="cards">${cards}</div>
 
-<h2>Where the tokens go</h2>
-${stackedBar(m)}
-<div class="legend">${legend}</div>
-<p class="muted">rework ${pct(m.reworkRatio)} · think:code ${m.thinkToCodeRatio.toFixed(2)} · ${m.errorEvents} turns hit tool errors</p>
-
-<h2>Projects</h2>
-<table><tr><th>Project</th><th>Activity mix</th><th>Tokens</th><th>Cost</th><th>Cache</th><th>Rework</th><th>Persona</th></tr>${projRows}</table>
-
-<h2>Models</h2>
-<table><tr><th>Model</th><th>Tokens</th><th>Cost</th></tr>${modelRows}</table>
+<h2>By ${by}</h2>
+<table><tr><th>${axisLabel}</th><th>Members</th><th>Activity mix</th><th>Tokens</th><th>Cost</th><th>Cache</th><th>Rework</th><th>Think:code</th><th>Persona</th></tr>${rollupRows}</table>
 
 <div class="persona">
   <h3>${persona.emoji} ${esc(persona.name)}</h3>
   <div class="muted">${esc(persona.description)}</div>
   <ul class="recs">${recs.map((r) => `<li>${esc(r)}</li>`).join('')}</ul>
-</div>
-${followSection}
-<footer>Generated locally by <a href="https://github.com/ryandemelo/token-monitor">token-monitor</a>. Costs marked ~ use placeholder prices. No data leaves your machine.</footer>
-</body></html>`;
+</div>`,
+  );
 }

--- a/src/report.ts
+++ b/src/report.ts
@@ -3,8 +3,8 @@ import { computeMetrics, groupBy } from './metrics.js';
 import type { StoredEvent } from './store.js';
 import { ACTIVITIES } from './types.js';
 import { assignPersona, generalRecommendations } from './personas.js';
-import type { ExportV1 } from './team.js';
-import { mergeMetrics, rollupByDiscipline, dominantActivity } from './team.js';
+import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
+import { mergeMetrics, rollupExports, dominantActivity, displayName } from './team.js';
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
 
@@ -150,7 +150,13 @@ export function renderReport(
   return out.join('\n');
 }
 
-export function renderTeamReport(exports: ExportV1[], team: Record<string, string>): string {
+export function renderTeamReport(
+  exports: SignedExport[],
+  config: TeamConfig,
+  opts: { by?: RollupAxis; keyring?: Record<string, string> } = {},
+): string {
+  const by = opts.by ?? 'discipline';
+  const axisLabel = by === 'team' ? 'Team' : 'Discipline';
   const out: string[] = [];
   const overall = mergeMetrics(exports.map((e) => e.overall));
 
@@ -159,7 +165,7 @@ export function renderTeamReport(exports: ExportV1[], team: Record<string, strin
     table(
       ['Members', 'Sessions', 'Tokens', 'Cache hit', 'Rework', 'Est. cost'],
       [[
-        String(new Set(exports.map((e) => e.user)).size),
+        String(new Set(exports.map((e) => displayName(e, opts.keyring))).size),
         String(overall.sessions),
         fmtTokens(overall.spendTokens),
         (overall.cacheHitRatio * 100).toFixed(0) + '%',
@@ -169,15 +175,15 @@ export function renderTeamReport(exports: ExportV1[], team: Record<string, strin
     ),
   );
 
-  out.push(section('By discipline'));
-  const rollups = rollupByDiscipline(exports, team);
+  out.push(section(`By ${by}`));
+  const rollups = rollupExports(exports, config, by, opts.keyring);
   out.push(
     table(
-      ['Discipline', 'Members', 'Tokens', 'Cost', 'Cache', 'Rework', 'Think:code', 'Top activity', 'Persona'],
-      rollups.map(({ discipline, users, metrics: m }) => {
+      [axisLabel, 'Members', 'Tokens', 'Cost', 'Cache', 'Rework', 'Think:code', 'Top activity', 'Persona'],
+      rollups.map(({ group, users, metrics: m }) => {
         const p = assignPersona(m);
         return [
-          discipline,
+          group,
           users.join(', '),
           fmtTokens(m.spendTokens),
           (m.costEstimated ? '~' : '') + '$' + m.costUsd.toFixed(2),
@@ -191,9 +197,9 @@ export function renderTeamReport(exports: ExportV1[], team: Record<string, strin
     ),
   );
 
-  out.push(section('Activity mix by discipline'));
-  for (const { discipline, metrics: m } of rollups) {
-    out.push(`  ${BOLD}${discipline}${RESET}`);
+  out.push(section(`Activity mix by ${by}`));
+  for (const { group, metrics: m } of rollups) {
+    out.push(`  ${BOLD}${group}${RESET}`);
     for (const a of ACTIVITIES) {
       if (m.byActivity[a].tokens === 0) continue;
       out.push(`    ${a.padEnd(13)} ${bar(m.byActivity[a].share)} ${(m.byActivity[a].share * 100).toFixed(1)}%`);

--- a/src/team.ts
+++ b/src/team.ts
@@ -5,6 +5,8 @@ import { computeMetrics, groupBy } from './metrics.js';
 import type { StoredEvent } from './store.js';
 import { ACTIVITIES } from './types.js';
 import type { Activity } from './types.js';
+import { fingerprint } from './sign.js';
+import type { Signature } from './sign.js';
 
 /**
  * Mergeable per-developer export. Contains aggregate numbers only — no
@@ -35,26 +37,109 @@ export function buildExport(events: StoredEvent[], days: number): ExportV1 {
   };
 }
 
+/** An export as it arrives at the merge step — payload plus optional signature. */
+export type SignedExport = ExportV1 & { sig?: Signature };
+
+export interface MemberInfo {
+  team?: string;
+  discipline?: string;
+}
+
+/** Member name -> placement. Built from teams.yaml / team.yaml / JSON. */
+export type TeamConfig = Record<string, MemberInfo>;
+
 /**
- * Team config maps usernames to disciplines. Accepts JSON
- * (`{"alice": "frontend"}`) or flat YAML (`alice: frontend` per line,
- * `#` comments allowed). Nested YAML is intentionally unsupported.
+ * Team config maps members to disciplines, optionally grouped by team.
+ * Accepted shapes:
+ *   - flat YAML:      `alice: frontend` per line (`#` comments allowed)
+ *   - two-level YAML: `platform:` header, then indented `alice: frontend`
+ *   - JSON:           `{"alice": "frontend"}` or `{"platform": {"alice": "frontend"}}`
+ * Flat and two-level entries can mix; deeper nesting is unsupported.
  */
-export function parseTeamConfig(path: string): Record<string, string> {
+export function parseTeamConfig(path: string): TeamConfig {
   const text = readFileSync(path, 'utf8');
+  const out: TeamConfig = {};
   if (path.endsWith('.json')) {
     const data = JSON.parse(text);
     if (typeof data !== 'object' || data === null) throw new Error('team config must be an object');
-    return data as Record<string, string>;
+    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+      if (typeof value === 'string') out[key] = { discipline: value };
+      else if (typeof value === 'object' && value !== null) {
+        for (const [member, discipline] of Object.entries(value as Record<string, unknown>)) {
+          out[member] = { team: key, discipline: String(discipline) };
+        }
+      }
+    }
+    return out;
   }
-  const map: Record<string, string> = {};
+  let currentTeam: string | undefined;
   for (const raw of text.split('\n')) {
-    const line = raw.replace(/#.*$/, '').trim();
-    if (!line) continue;
-    const m = line.match(/^["']?([\w.@-]+)["']?\s*:\s*["']?([\w -]+?)["']?$/);
-    if (m) map[m[1]] = m[2].trim();
+    const line = raw.replace(/#.*$/, '').trimEnd();
+    if (!line.trim()) continue;
+    const indented = /^\s/.test(line);
+    const m = line.trim().match(/^["']?([\w.@ -]+?)["']?\s*:\s*(?:["']?([\w -]+?)["']?)?$/);
+    if (!m) continue;
+    const [, key, value] = m;
+    if (!value) {
+      // bare `team:` header — following indented members belong to it
+      currentTeam = key;
+    } else if (indented && currentTeam) {
+      out[key] = { team: currentTeam, discipline: value.trim() };
+    } else {
+      currentTeam = undefined;
+      out[key] = { discipline: value.trim() };
+    }
   }
-  return map;
+  return out;
+}
+
+/**
+ * Stable identity of an export: the signing-key fingerprint when signed,
+ * `user@host` otherwise. Survives username collisions across teams and
+ * distinguishes the same username on different machines.
+ */
+export function identityOf(ex: SignedExport): string {
+  return ex.sig?.publicKey ? fingerprint(ex.sig.publicKey) : `${ex.user}@${ex.host}`;
+}
+
+/**
+ * Human name for an export: the keyring (user -> fingerprint) is the lead's
+ * source of truth, so a reverse match on the signing fingerprint wins over
+ * the self-reported user field.
+ */
+export function displayName(ex: SignedExport, keyring?: Record<string, string>): string {
+  if (ex.sig?.publicKey && keyring) {
+    const fp = fingerprint(ex.sig.publicKey);
+    for (const [user, pinned] of Object.entries(keyring)) {
+      if (pinned === fp) return user;
+    }
+  }
+  return ex.user;
+}
+
+/**
+ * Same signer pushing repeatedly leaves stale files in the drop; keep only
+ * the newest export per identity so totals aren't double-counted.
+ */
+export function dedupeExports(exports: SignedExport[]): {
+  kept: SignedExport[];
+  dropped: SignedExport[];
+} {
+  const newest = new Map<string, SignedExport>();
+  const dropped: SignedExport[] = [];
+  for (const ex of exports) {
+    const id = identityOf(ex);
+    const seen = newest.get(id);
+    if (!seen) {
+      newest.set(id, ex);
+    } else if (ex.generatedAt > seen.generatedAt) {
+      dropped.push(seen);
+      newest.set(id, ex);
+    } else {
+      dropped.push(ex);
+    }
+  }
+  return { kept: [...newest.values()], dropped };
 }
 
 /** Recombine Metrics by summing absolutes and recomputing ratios. */
@@ -105,27 +190,32 @@ export function mergeMetrics(list: Metrics[]): Metrics {
   return out;
 }
 
-export interface DisciplineRollup {
-  discipline: string;
+export type RollupAxis = 'team' | 'discipline';
+
+export interface Rollup {
+  group: string;
   users: string[];
   metrics: Metrics;
 }
 
-export function rollupByDiscipline(
-  exports: ExportV1[],
-  team: Record<string, string>,
-): DisciplineRollup[] {
+export function rollupExports(
+  exports: SignedExport[],
+  config: TeamConfig,
+  by: RollupAxis = 'discipline',
+  keyring?: Record<string, string>,
+): Rollup[] {
   const groups = new Map<string, { users: Set<string>; metrics: Metrics[] }>();
   for (const ex of exports) {
-    const discipline = team[ex.user] ?? 'unassigned';
-    let g = groups.get(discipline);
-    if (!g) groups.set(discipline, (g = { users: new Set(), metrics: [] }));
-    g.users.add(ex.user);
+    const name = displayName(ex, keyring);
+    const group = config[name]?.[by] ?? 'unassigned';
+    let g = groups.get(group);
+    if (!g) groups.set(group, (g = { users: new Set(), metrics: [] }));
+    g.users.add(name);
     g.metrics.push(ex.overall);
   }
   return [...groups.entries()]
-    .map(([discipline, g]) => ({
-      discipline,
+    .map(([group, g]) => ({
+      group,
       users: [...g.users].sort(),
       metrics: mergeMetrics(g.metrics),
     }))

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, cpSync, writeFileSync, readFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir, userInfo } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { makeCursorFixture, makeAntigravityFixture } from './helpers.js';
 import { cursorUserDir } from '../src/adapters/cursor.js';
@@ -99,6 +99,59 @@ test('e2e: merge with team config produces discipline rollups', () => {
   assert.equal(code, 0);
   assert.ok(stdout.includes('By discipline'));
   assert.ok(stdout.includes('unassigned')); // current user not in team.yaml
+});
+
+test('e2e: multi-team merge — two-level teams.yaml, --by team, fingerprint dedup, --html', () => {
+  // Second member: same OS username, different machine (home) -> different signing key.
+  const home2 = mkdtempSync(join(tmpdir(), 'tm-e2e-member2-'));
+  cpSync(join(FIXTURES, 'claude'), join(home2, '.claude', 'projects'), { recursive: true });
+  assert.equal(run(['collect'], { home: home2 }).code, 0);
+  writeFileSync(join(HOME, 'member2.json'), run(['report', '--json', ...DAYS], { home: home2 }).stdout);
+
+  // Same signer exports twice: the older one must be dropped, not double-counted.
+  writeFileSync(join(HOME, 'me-stale.json'), readFileSync(join(HOME, 'me.json')));
+  writeFileSync(join(HOME, 'me-fresh.json'), run(['report', '--json', ...DAYS]).stdout);
+
+  const user = userInfo().username;
+  writeFileSync(
+    join(HOME, 'teams.yaml'),
+    `platform:\n  ${user}: backend\ndata:\n  someone-else: ml\n`,
+  );
+
+  const htmlOut = join(HOME, 'team.html');
+  const { stdout, stderr, code } = run([
+    'merge',
+    join(HOME, 'me-stale.json'), join(HOME, 'me-fresh.json'), join(HOME, 'member2.json'),
+    '--team', join(HOME, 'teams.yaml'), '--by', 'team', '--html', htmlOut,
+  ]);
+  assert.equal(code, 0);
+  assert.ok(stdout.includes('By team'));
+  assert.ok(stdout.includes('platform')); // user mapped via two-level config
+  assert.match(stderr, /skipped stale export/);
+
+  const html = readFileSync(htmlOut, 'utf8');
+  assert.ok(html.startsWith('<!doctype html>'));
+  assert.ok(html.includes('platform'));
+
+  // --json: stale export deduped -> 2 exports remain (one per machine), one member name
+  const json = JSON.parse(run([
+    'merge',
+    join(HOME, 'me-stale.json'), join(HOME, 'me-fresh.json'), join(HOME, 'member2.json'),
+    '--team', join(HOME, 'teams.yaml'), '--by', 'team', '--json',
+  ]).stdout);
+  assert.deepEqual(json.members, [user]);
+  assert.equal(json.by, 'team');
+  assert.equal(json.rollups[0].group, 'platform');
+  // 3 claude fixture sessions per machine, two machines, stale export excluded
+  const me = JSON.parse(readFileSync(join(HOME, 'me-fresh.json'), 'utf8'));
+  const m2 = JSON.parse(readFileSync(join(HOME, 'member2.json'), 'utf8'));
+  assert.equal(json.overall.events, me.overall.events + m2.overall.events);
+});
+
+test('e2e: merge rejects an invalid --by axis', () => {
+  const { code, stderr } = run(['merge', join(HOME, 'me.json'), '--by', 'planet']);
+  assert.equal(code, 1);
+  assert.match(stderr, /--by must be/);
 });
 
 test('e2e: html writes a self-contained dashboard', () => {

--- a/test/team.test.ts
+++ b/test/team.test.ts
@@ -4,8 +4,9 @@ import { writeFileSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { computeMetrics } from '../src/metrics.js';
-import { mergeMetrics, parseTeamConfig, rollupByDiscipline, dominantActivity } from '../src/team.js';
-import type { ExportV1 } from '../src/team.js';
+import { mergeMetrics, parseTeamConfig, rollupExports, dominantActivity, identityOf, displayName, dedupeExports } from '../src/team.js';
+import type { ExportV1, SignedExport } from '../src/team.js';
+import { signObject, fingerprint } from '../src/sign.js';
 import { makeStored } from './helpers.js';
 
 function metricsOf(...specs: Array<Parameters<typeof makeStored>[0]>) {
@@ -42,32 +43,109 @@ test('parseTeamConfig reads flat YAML and JSON', () => {
   const yamlPath = join(dir, 'team.yaml');
   writeFileSync(yamlPath, '# disciplines\nalice: frontend\nbob: backend\n"carol.x": data science\n');
   assert.deepEqual(parseTeamConfig(yamlPath), {
-    alice: 'frontend',
-    bob: 'backend',
-    'carol.x': 'data science',
+    alice: { discipline: 'frontend' },
+    bob: { discipline: 'backend' },
+    'carol.x': { discipline: 'data science' },
   });
 
   const jsonPath = join(dir, 'team.json');
   writeFileSync(jsonPath, '{"dave": "qa"}');
-  assert.deepEqual(parseTeamConfig(jsonPath), { dave: 'qa' });
+  assert.deepEqual(parseTeamConfig(jsonPath), { dave: { discipline: 'qa' } });
 });
 
-test('rollupByDiscipline groups exports and merges metrics', () => {
-  const mk = (user: string, m: ReturnType<typeof metricsOf>): ExportV1 => ({
-    version: 1, user, host: 'h', generatedAt: 'now', days: 30, overall: m, byProject: {},
-  });
-  const rollups = rollupByDiscipline(
+test('parseTeamConfig reads two-level teams.yaml and nested JSON', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tm-'));
+  const yamlPath = join(dir, 'teams.yaml');
+  writeFileSync(
+    yamlPath,
     [
-      mk('alice', metricsOf({ activity: 'coding', input_tokens: 5000, output_tokens: 0 })),
-      mk('bob', metricsOf({ activity: 'testing', input_tokens: 1000, output_tokens: 0 })),
-      mk('carol', metricsOf({ activity: 'exploration', input_tokens: 100, output_tokens: 0 })),
-    ],
-    { alice: 'frontend', bob: 'frontend' },
+      '# org map',
+      'platform:',
+      '  alice: frontend',
+      '  bob: backend   # comment',
+      'data:',
+      '  carol: ml',
+      'dave: qa  # flat entry mixed in',
+      '',
+    ].join('\n'),
   );
-  assert.equal(rollups.length, 2);
-  assert.equal(rollups[0].discipline, 'frontend'); // sorted by spend
-  assert.deepEqual(rollups[0].users, ['alice', 'bob']);
-  assert.equal(rollups[0].metrics.spendTokens, 6000);
-  assert.equal(rollups[1].discipline, 'unassigned');
-  assert.equal(dominantActivity(rollups[0].metrics), 'coding');
+  assert.deepEqual(parseTeamConfig(yamlPath), {
+    alice: { team: 'platform', discipline: 'frontend' },
+    bob: { team: 'platform', discipline: 'backend' },
+    carol: { team: 'data', discipline: 'ml' },
+    dave: { discipline: 'qa' },
+  });
+
+  const jsonPath = join(dir, 'teams.json');
+  writeFileSync(jsonPath, '{"platform": {"alice": "frontend"}, "dave": "qa"}');
+  assert.deepEqual(parseTeamConfig(jsonPath), {
+    alice: { team: 'platform', discipline: 'frontend' },
+    dave: { discipline: 'qa' },
+  });
+});
+
+function mkExport(user: string, m: ReturnType<typeof metricsOf>, generatedAt = 'now'): ExportV1 {
+  return { version: 1, user, host: 'h', generatedAt, days: 30, overall: m, byProject: {} };
+}
+
+test('rollupExports groups by discipline and by team', () => {
+  const exports = [
+    mkExport('alice', metricsOf({ activity: 'coding', input_tokens: 5000, output_tokens: 0 })),
+    mkExport('bob', metricsOf({ activity: 'testing', input_tokens: 1000, output_tokens: 0 })),
+    mkExport('carol', metricsOf({ activity: 'exploration', input_tokens: 100, output_tokens: 0 })),
+  ];
+  const config = {
+    alice: { team: 'platform', discipline: 'frontend' },
+    bob: { team: 'platform', discipline: 'frontend' },
+  };
+
+  const byDiscipline = rollupExports(exports, config, 'discipline');
+  assert.equal(byDiscipline.length, 2);
+  assert.equal(byDiscipline[0].group, 'frontend'); // sorted by spend
+  assert.deepEqual(byDiscipline[0].users, ['alice', 'bob']);
+  assert.equal(byDiscipline[0].metrics.spendTokens, 6000);
+  assert.equal(byDiscipline[1].group, 'unassigned');
+  assert.equal(dominantActivity(byDiscipline[0].metrics), 'coding');
+
+  const byTeam = rollupExports(exports, config, 'team');
+  assert.equal(byTeam[0].group, 'platform');
+  assert.equal(byTeam[0].metrics.spendTokens, 6000);
+  assert.equal(byTeam[1].group, 'unassigned');
+});
+
+test('identity comes from the signing fingerprint; keyring resolves display names', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tm-keys-'));
+  const m = metricsOf({ activity: 'coding' });
+  const signed = signObject(mkExport('ryan', m), dir);
+  const fp = fingerprint(signed.sig.publicKey);
+
+  assert.equal(identityOf(signed), fp);
+  assert.equal(identityOf(mkExport('ryan', m)), 'ryan@h'); // unsigned fallback
+
+  // keyring is the lead's source of truth: reverse fingerprint match wins
+  assert.equal(displayName(signed, { 'ryan-platform': fp }), 'ryan-platform');
+  assert.equal(displayName(signed, { other: 'deadbeef00000000' }), 'ryan');
+  assert.equal(displayName(signed), 'ryan');
+});
+
+test('dedupeExports keeps only the newest export per identity', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tm-dedup-'));
+  const m = metricsOf({ activity: 'coding' });
+  const old: SignedExport = signObject(mkExport('ryan', m, '2026-06-01T00:00:00Z'), dir);
+  const fresh: SignedExport = signObject(mkExport('ryan', m, '2026-06-02T00:00:00Z'), dir);
+  const otherDir = mkdtempSync(join(tmpdir(), 'tm-dedup2-'));
+  const otherMachine: SignedExport = signObject(mkExport('ryan', m, '2026-05-01T00:00:00Z'), otherDir);
+
+  const { kept, dropped } = dedupeExports([old, fresh, otherMachine]);
+  // same key twice -> newest wins; a different machine's key is a distinct identity
+  assert.equal(kept.length, 2);
+  assert.ok(kept.includes(fresh) && kept.includes(otherMachine));
+  assert.deepEqual(dropped, [old]);
+
+  // unsigned exports fall back to user@host identity
+  const u1 = mkExport('alice', m, '2026-06-01T00:00:00Z');
+  const u2 = mkExport('alice', m, '2026-06-03T00:00:00Z');
+  const r = dedupeExports([u2, u1]);
+  assert.deepEqual(r.kept, [u2]);
+  assert.deepEqual(r.dropped, [u1]);
 });


### PR DESCRIPTION
Closes #27 (milestone 4).

## What
- **`teams.yaml` two-level format**: `team:` header + indented `member: discipline` lines (nested JSON too). Flat `team.yaml`/JSON keep working unchanged.
- **`merge --by team|discipline`** — pick the rollup axis; comparison table + activity mix in the terminal report.
- **`merge --html org.html`** — self-contained org dashboard rendered from the merged exports (new `renderTeamHtml`, shared page shell with the local dashboard).
- **Identity = signing fingerprint**, not `whoami`: username collisions across teams stay distinct; multiple exports from the same signer are deduped to the newest `generatedAt` (warning lists what was dropped). Unsigned exports fall back to `user@host`. `keys.json` is reverse-mapped (fingerprint → enrolled name) so the lead's keyring is the naming authority.
- README: new *Org rollups* section documenting the serverless one-drop pattern.

## Tests
- Unit: two-level YAML/nested JSON parsing, `rollupExports` both axes, `identityOf`/`displayName`/`dedupeExports` (signed + unsigned).
- e2e: second synthetic machine signs its own export; merge of 3 files (one stale) asserts `By team` grouping, dedup warning on stderr, `--html` artifact, `--json` rollups + event totals; invalid `--by` exits 1.
- 76 tests pass. Validated against real data on this machine (dedup + by-team rollup verified).

