### PR TITLE
feat: optimization signals — context bloat, cold restarts, model right-sizing, retry loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,11 @@ Identity is the **signing fingerprint**, not the OS username: two different "rya
 - **Most expensive sessions** — turns, fix loops, avg context per turn, duration, dominant activity
 - **Fix-loop sessions** — testing→coding churn
 - **Context-heavy sessions** — average tokens fed per turn (context-bloat proxy)
-- **Tool error rates** — tools that keep failing
+- **Context bloat trend** — sessions whose late-half context grew ≥2× without cache reads keeping pace (start fresh / compact earlier)
+- **Cold restarts** — turns resuming after the ~5-min cache TTL that re-paid their context as fresh input (batch prompts, split idle work)
+- **Tool error rates** — tools that keep failing, plus the token cost of their retry loops
+
+The report and dashboard surface the same signals in one line (context bloat, cold restarts, premium tokens on exploration/conversation, retry-loop spend), and each one becomes a tracked recommendation when it crosses its threshold.
 
 Add `--llm` and the aggregates go to a coding agent you already have installed (`claude`, `gemini`, or `codex` — auto-detected, override with `--agent`), which returns prioritized interventions with the evidence, the workflow change, and the metric to watch:
 

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import type { StoredEvent } from './store.js';
-import { computeMetrics, groupBy } from './metrics.js';
+import { computeMetrics, groupBy, contextGrowthOf, parseTools, CACHE_TTL_MS } from './metrics.js';
 import { costOf } from './pricing.js';
 import { assignPersona } from './personas.js';
 import { structuredFindings } from './followthrough.js';
@@ -27,6 +27,11 @@ export interface SessionStat {
   fixIterations: number;
   /** Mean context fed per turn (input + cache read/creation) — bloat proxy. */
   avgContextTokens: number;
+  /** Late-half avg context / early half; 0 when the session is too short. */
+  contextGrowth: number;
+  /** Turns resuming after a gap past the cache TTL, and what they re-paid. */
+  coldRestartTurns: number;
+  coldRestartTokens: number;
   durationMin: number;
   dominant: Activity;
 }
@@ -35,14 +40,22 @@ export function computeSessionStats(events: StoredEvent[]): SessionStat[] {
   const out: SessionStat[] = [];
   for (const [sessionId, evs] of groupBy(events, 'session_id')) {
     let spend = 0, cost = 0, errors = 0, fixes = 0, context = 0;
+    let coldTurns = 0, coldTokens = 0;
     const actTokens = Object.fromEntries(ACTIVITIES.map((a) => [a, 0])) as Record<Activity, number>;
     let prev: string | undefined;
+    let prevTs: number | undefined;
     for (const e of evs) {
       spend += e.input_tokens + e.output_tokens;
       cost += costOf(e.model, e.input_tokens, e.output_tokens, e.cache_read_tokens, e.cache_creation_tokens).usd;
       if (e.is_error) errors++;
       if (prev === 'testing' && e.activity === 'coding') fixes++;
       prev = e.activity;
+      const ts = Date.parse(e.ts);
+      if (prevTs !== undefined && ts - prevTs > CACHE_TTL_MS) {
+        coldTurns++;
+        coldTokens += e.input_tokens + e.cache_creation_tokens;
+      }
+      prevTs = ts;
       context += e.input_tokens + e.cache_read_tokens + e.cache_creation_tokens;
       if (ACTIVITIES.includes(e.activity as Activity)) {
         actTokens[e.activity as Activity] += e.input_tokens + e.output_tokens;
@@ -60,6 +73,9 @@ export function computeSessionStats(events: StoredEvent[]): SessionStat[] {
       errorTurns: errors,
       fixIterations: fixes,
       avgContextTokens: Math.round(context / evs.length),
+      contextGrowth: contextGrowthOf(evs)?.ratio ?? 0,
+      coldRestartTurns: coldTurns,
+      coldRestartTokens: coldTokens,
       durationMin: Math.max(0, Math.round((last - first) / 60_000)),
       dominant: ACTIVITIES.reduce((b, a) => (actTokens[a] > actTokens[b] ? a : b)),
     });
@@ -74,22 +90,28 @@ export interface ToolStat {
   /** Share of this tool's turns that hit an error. Errors are attributed to
    *  every tool in the failing turn — an upper bound, not exact blame. */
   errorRate: number;
+  /** Tokens on turns re-running this tool right after a turn where it errored. */
+  retryTokens: number;
 }
 
 export function computeToolStats(events: StoredEvent[]): ToolStat[] {
-  const map = new Map<string, { turns: number; errorTurns: number }>();
-  for (const e of events) {
-    let tools: string[];
-    try {
-      tools = JSON.parse(e.tools);
-    } catch {
-      continue;
-    }
-    for (const t of new Set(tools)) {
-      const s = map.get(t) ?? { turns: 0, errorTurns: 0 };
-      s.turns++;
-      if (e.is_error) s.errorTurns++;
-      map.set(t, s);
+  const map = new Map<string, { turns: number; errorTurns: number; retryTokens: number }>();
+  const stat = (t: string) => {
+    let s = map.get(t);
+    if (!s) map.set(t, (s = { turns: 0, errorTurns: 0, retryTokens: 0 }));
+    return s;
+  };
+  for (const [, evs] of groupBy(events, 'session_id')) {
+    let prevErrTools: Set<string> | undefined;
+    for (const e of evs) {
+      const tools = new Set(parseTools(e.tools));
+      for (const t of tools) {
+        const s = stat(t);
+        s.turns++;
+        if (e.is_error) s.errorTurns++;
+        if (prevErrTools?.has(t)) s.retryTokens += e.input_tokens + e.output_tokens;
+      }
+      prevErrTools = e.is_error ? tools : undefined;
     }
   }
   return [...map.entries()]
@@ -101,6 +123,8 @@ export interface DeepAnalysis {
   expensiveSessions: SessionStat[];
   fixLoopSessions: SessionStat[];
   contextHeavySessions: SessionStat[];
+  bloatTrendSessions: SessionStat[];
+  coldRestartSessions: SessionStat[];
   toolStats: ToolStat[];
 }
 
@@ -115,6 +139,14 @@ export function deepAnalysis(events: StoredEvent[]): DeepAnalysis {
     contextHeavySessions: stats
       .filter((s) => s.turns >= 10)
       .sort((a, b) => b.avgContextTokens - a.avgContextTokens)
+      .slice(0, 8),
+    bloatTrendSessions: stats
+      .filter((s) => s.contextGrowth >= 2)
+      .sort((a, b) => b.contextGrowth - a.contextGrowth)
+      .slice(0, 8),
+    coldRestartSessions: stats
+      .filter((s) => s.coldRestartTurns > 0)
+      .sort((a, b) => b.coldRestartTokens - a.coldRestartTokens)
       .slice(0, 8),
     toolStats: computeToolStats(events).slice(0, 15),
   };
@@ -141,6 +173,8 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
     errorTurns: s.errorTurns,
     fixIterations: s.fixIterations,
     avgContextTokens: s.avgContextTokens,
+    contextGrowth: round(s.contextGrowth, 1),
+    coldRestartTokens: s.coldRestartTokens,
     durationMin: s.durationMin,
     dominant: s.dominant,
   });
@@ -154,6 +188,10 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
       cacheHitRatio: round(m.cacheHitRatio),
       reworkRatio: round(m.reworkRatio),
       thinkToCodeRatio: round(m.thinkToCodeRatio),
+      contextBloatShare: round(m.contextBloatShare),
+      coldRestartShare: round(m.coldRestartShare),
+      premiumWasteShare: round(m.premiumWasteShare),
+      retryShare: round(m.retryShare),
       activityShares: Object.fromEntries(
         ACTIVITIES.filter((a) => m.byActivity[a].tokens > 0).map((a) => [a, round(m.byActivity[a].share)]),
       ),
@@ -178,9 +216,11 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
     expensiveSessions: deep.expensiveSessions.map(slim),
     fixLoopSessions: deep.fixLoopSessions.map(slim),
     contextHeavySessions: deep.contextHeavySessions.map(slim),
+    bloatTrendSessions: deep.bloatTrendSessions.map(slim),
+    coldRestartSessions: deep.coldRestartSessions.map(slim),
     toolErrorRates: deep.toolStats
       .filter((t) => t.errorRate > 0.05 && t.turns >= 20)
-      .map((t) => ({ tool: t.tool, turns: t.turns, errorRate: round(t.errorRate, 2) })),
+      .map((t) => ({ tool: t.tool, turns: t.turns, errorRate: round(t.errorRate, 2), retryTokens: t.retryTokens })),
     ruleBasedFindings: structuredFindings(m).map((f) => f.key),
   };
 }
@@ -188,7 +228,7 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
 export function buildLlmPrompt(events: StoredEvent[], days: number): string {
   return `You are an engineering-efficiency analyst. The JSON below contains AGGREGATE token-usage telemetry from AI coding agents (Claude Code / Gemini CLI / Codex) for one developer or team over ${days} days. There is no prompt or code content — only counts, ratios, tool names, and project names.
 
-Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.
+Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). contextGrowth = late-half avg context / early half per session; contextBloatShare = share of long sessions growing >=2x without cache keeping pace. coldRestartTokens = input re-paid on turns resuming after the ~5-min cache TTL; coldRestartShare = that over all fresh-paid input. premiumWasteShare = premium-model tokens on exploration/conversation turns / all spend. retryShare/retryTokens = spend on turns re-running a tool right after it errored. Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.
 
 Analyze the data and respond in markdown:
 1. **Top 3 interventions**, prioritized by expected token/cost savings. For each: the evidence (cite specific numbers/projects/sessions from the data), the concrete workflow change, and which metric will move if it works.
@@ -234,13 +274,52 @@ export function renderAnalysis(events: StoredEvent[], days: number): string {
     out.push(`\n${'\x1b[1m'}Context-heavy sessions (avg tokens fed per turn)${'\x1b[0m'}`);
     out.push(table(headers, deep.contextHeavySessions.map(sessRow)));
   }
+  if (deep.bloatTrendSessions.length) {
+    out.push(`\n${'\x1b[1m'}Context bloat trend (late-half context vs early half)${'\x1b[0m'}`);
+    out.push(
+      table(
+        ['Project', 'Source', 'Turns', 'Ctx/turn', 'Growth', 'Span', 'Dominant'],
+        deep.bloatTrendSessions.map((s) => [
+          s.project.length > 24 ? s.project.slice(0, 23) + '…' : s.project,
+          s.source,
+          String(s.turns),
+          fmtTokens(s.avgContextTokens),
+          s.contextGrowth.toFixed(1) + '×',
+          s.durationMin + 'm',
+          s.dominant,
+        ]),
+      ),
+    );
+  }
+  if (deep.coldRestartSessions.length) {
+    out.push(`\n${'\x1b[1m'}Cold restarts (turns resuming after the ~5-min cache TTL)${'\x1b[0m'}`);
+    out.push(
+      table(
+        ['Project', 'Source', 'Turns', 'Cold turns', 'Re-paid tokens', 'Span'],
+        deep.coldRestartSessions.map((s) => [
+          s.project.length > 24 ? s.project.slice(0, 23) + '…' : s.project,
+          s.source,
+          String(s.turns),
+          String(s.coldRestartTurns),
+          fmtTokens(s.coldRestartTokens),
+          s.durationMin + 'm',
+        ]),
+      ),
+    );
+  }
   const failing = deep.toolStats.filter((t) => t.errorRate > 0.05 && t.turns >= 20);
   if (failing.length) {
     out.push(`\n${'\x1b[1m'}Tool error rates (errors attributed to all tools in the failing turn)${'\x1b[0m'}`);
     out.push(
       table(
-        ['Tool', 'Turns', 'Error turns', 'Error rate'],
-        failing.map((t) => [t.tool, String(t.turns), String(t.errorTurns), (t.errorRate * 100).toFixed(1) + '%']),
+        ['Tool', 'Turns', 'Error turns', 'Error rate', 'Retry cost'],
+        failing.map((t) => [
+          t.tool,
+          String(t.turns),
+          String(t.errorTurns),
+          (t.errorRate * 100).toFixed(1) + '%',
+          fmtTokens(t.retryTokens),
+        ]),
       ),
     );
   }

--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import type { Metrics } from './metrics.js';
+import { PREMIUM_MODEL_RE } from './pricing.js';
 
 /**
  * Follow-through: a recommendation is only useful if you can see whether it
@@ -15,12 +16,18 @@ export interface Finding {
   message: string;
 }
 
-export type MetricKey = 'cacheHitRatio' | 'reworkRatio' | 'thinkToCodeRatio' | 'premiumShare';
+export type MetricKey =
+  | 'cacheHitRatio'
+  | 'reworkRatio'
+  | 'thinkToCodeRatio'
+  | 'premiumShare'
+  | 'contextBloatShare'
+  | 'coldRestartShare'
+  | 'premiumWasteShare'
+  | 'retryShare';
 
 export function premiumShare(m: Metrics): number {
-  const premium = Object.entries(m.byModel).filter(([name]) =>
-    /fable|opus|gpt-5(?!.*mini)|gemini-.*pro/i.test(name),
-  );
+  const premium = Object.entries(m.byModel).filter(([name]) => PREMIUM_MODEL_RE.test(name));
   if (!premium.length) return 0;
   return premium.reduce((s, [, v]) => s + v.tokens, 0) / (m.spendTokens || 1);
 }
@@ -63,6 +70,38 @@ export function structuredFindings(m: Metrics): Finding[] {
       metric: 'premiumShare',
       direction: 'down',
       message: `${(share * 100).toFixed(0)}% of tokens on premium models. Route exploration and boilerplate turns to a cheaper tier.`,
+    });
+  }
+  if (m.contextBloatShare >= 0.3 && m.trendSessions >= 3) {
+    out.push({
+      key: 'context-bloat',
+      metric: 'contextBloatShare',
+      direction: 'down',
+      message: `${m.bloatedSessions} of ${m.trendSessions} long sessions grow their context ≥2× without cache reads keeping pace — start a fresh session or compact at task boundaries before the context balloons.`,
+    });
+  }
+  if (m.coldRestartShare >= 0.2 && m.spendTokens > 100_000) {
+    out.push({
+      key: 'cold-restarts',
+      metric: 'coldRestartShare',
+      direction: 'down',
+      message: `${(m.coldRestartShare * 100).toFixed(0)}% of fresh input tokens were re-paid on ${m.coldRestartTurns} turns that resumed after the ~5-min cache TTL. Batch prompts within the cache window, or split long-idle work into new sessions.`,
+    });
+  }
+  if (m.premiumWasteShare >= 0.3 && m.spendTokens > 100_000) {
+    out.push({
+      key: 'premium-misroute',
+      metric: 'premiumWasteShare',
+      direction: 'down',
+      message: `${(m.premiumWasteShare * 100).toFixed(0)}% of spend is premium-model tokens on exploration/conversation turns. Route reads and chat to a cheaper tier; keep the premium model for code-writing turns.`,
+    });
+  }
+  if (m.retryShare >= 0.05) {
+    out.push({
+      key: 'tool-retry-loops',
+      metric: 'retryShare',
+      direction: 'down',
+      message: `${(m.retryShare * 100).toFixed(0)}% of spend goes to turns re-running a tool right after it errored. \`analyze\` shows which tools — fix the recurring cause (flaky command, bad path, missing permission) instead of paying for retries.`,
     });
   }
   return out;

--- a/src/html.ts
+++ b/src/html.ts
@@ -104,6 +104,7 @@ export function renderHtml(
 ${stackedBar(m)}
 <div class="legend">${legend}</div>
 <p class="muted">rework ${pct(m.reworkRatio)} · think:code ${m.thinkToCodeRatio.toFixed(2)} · ${m.errorEvents} turns hit tool errors</p>
+<p class="muted">signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions · cold restarts ${pct(m.coldRestartShare)} of fresh input · premium on exploration/chat ${pct(m.premiumWasteShare)} · retry loops ${pct(m.retryShare)}</p>
 
 <h2>Projects</h2>
 <table><tr><th>Project</th><th>Activity mix</th><th>Tokens</th><th>Cost</th><th>Cache</th><th>Rework</th><th>Persona</th></tr>${projRows}</table>

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,7 +1,14 @@
 import type { StoredEvent } from './store.js';
 import type { Activity } from './types.js';
 import { ACTIVITIES } from './types.js';
-import { costOf } from './pricing.js';
+import { costOf, PREMIUM_MODEL_RE } from './pricing.js';
+
+/** Anthropic's default prompt-cache TTL — gaps past this re-pay the context. */
+export const CACHE_TTL_MS = 5 * 60_000;
+/** Sessions need this many turns before a context-bloat trend is measurable. */
+export const BLOAT_MIN_TURNS = 8;
+const BLOAT_GROWTH = 2; // late-half avg context ≥ 2× early half
+const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-paid fresh
 
 export interface Metrics {
   events: number;
@@ -25,6 +32,22 @@ export interface Metrics {
   byActivity: Record<Activity, { tokens: number; share: number; events: number }>;
   byModel: Record<string, { tokens: number; costUsd: number }>;
   thinkToCodeRatio: number;
+  /** Sessions long enough (≥ BLOAT_MIN_TURNS) to measure a context trend. */
+  trendSessions: number;
+  /** Trend sessions whose late-half context grew ≥2× without cache keeping pace. */
+  bloatedSessions: number;
+  contextBloatShare: number;
+  /** Turns arriving after a gap past the cache TTL, and the input-side tokens they re-paid. */
+  coldRestartTurns: number;
+  coldRestartTokens: number;
+  /** Re-paid tokens as a share of all fresh-paid input (input + cache writes). */
+  coldRestartShare: number;
+  /** Premium-model tokens spent on exploration/conversation turns. */
+  premiumWasteTokens: number;
+  premiumWasteShare: number;
+  /** Tokens on turns re-running a tool that errored in the immediately previous turn. */
+  retryTokens: number;
+  retryShare: number;
 }
 
 export function computeMetrics(events: StoredEvent[]): Metrics {
@@ -36,6 +59,7 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
 
   let input = 0, output = 0, cacheRead = 0, cacheCreate = 0, thinking = 0;
   let costUsd = 0, costEstimated = false, unpriced = 0, errorEvents = 0;
+  let premiumWasteTokens = 0;
 
   // Rework: group by session, walk chronologically, count spend after first failed event.
   const bySession = new Map<string, StoredEvent[]>();
@@ -53,6 +77,9 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
     const act = (ACTIVITIES.includes(e.activity as Activity) ? e.activity : 'conversation') as Activity;
     byActivity[act].tokens += spend;
     byActivity[act].events++;
+    if ((act === 'exploration' || act === 'conversation') && PREMIUM_MODEL_RE.test(e.model)) {
+      premiumWasteTokens += spend;
+    }
 
     const cost = costOf(e.model, e.input_tokens, e.output_tokens, e.cache_read_tokens, e.cache_creation_tokens);
     if (cost.priced) {
@@ -76,14 +103,44 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
   }
 
   let reworkTokens = 0;
+  let trendSessions = 0, bloatedSessions = 0;
+  let coldRestartTurns = 0, coldRestartTokens = 0;
+  let retryTokens = 0;
   for (const arr of bySession.values()) {
     const firstFail = arr.findIndex((e) => e.is_error && (e.activity === 'testing' || e.activity === 'coding'));
-    if (firstFail === -1) continue;
-    for (let i = firstFail + 1; i < arr.length; i++) {
-      const e = arr[i];
-      if (e.activity === 'coding' || e.activity === 'testing') {
-        reworkTokens += e.input_tokens + e.output_tokens;
+    if (firstFail !== -1) {
+      for (let i = firstFail + 1; i < arr.length; i++) {
+        const e = arr[i];
+        if (e.activity === 'coding' || e.activity === 'testing') {
+          reworkTokens += e.input_tokens + e.output_tokens;
+        }
       }
+    }
+
+    // Session hygiene: a gap past the cache TTL means this turn re-paid its
+    // context as fresh input / a new cache write instead of a cheap read.
+    for (let i = 1; i < arr.length; i++) {
+      if (Date.parse(arr[i].ts) - Date.parse(arr[i - 1].ts) > CACHE_TTL_MS) {
+        coldRestartTurns++;
+        coldRestartTokens += arr[i].input_tokens + arr[i].cache_creation_tokens;
+      }
+    }
+
+    // Context bloat trend: late-half avg context vs early half.
+    const growth = contextGrowthOf(arr);
+    if (growth !== undefined) {
+      trendSessions++;
+      if (growth.ratio >= BLOAT_GROWTH && growth.lateFreshShare >= BLOAT_FRESH_SHARE) bloatedSessions++;
+    }
+
+    // Retry loops: a turn re-running a tool that just errored is paying for a retry.
+    let prevErrTools: Set<string> | undefined;
+    for (const e of arr) {
+      const tools = parseTools(e.tools);
+      if (prevErrTools !== undefined && tools.some((t) => prevErrTools!.has(t))) {
+        retryTokens += e.input_tokens + e.output_tokens;
+      }
+      prevErrTools = e.is_error ? new Set(tools) : undefined;
     }
   }
 
@@ -107,7 +164,46 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
     byActivity,
     byModel,
     thinkToCodeRatio: (byActivity.thinking.tokens + byActivity.exploration.tokens) / codingTokens,
+    trendSessions,
+    bloatedSessions,
+    contextBloatShare: trendSessions ? bloatedSessions / trendSessions : 0,
+    coldRestartTurns,
+    coldRestartTokens,
+    coldRestartShare: input + cacheCreate ? coldRestartTokens / (input + cacheCreate) : 0,
+    premiumWasteTokens,
+    premiumWasteShare: spendTokens ? premiumWasteTokens / spendTokens : 0,
+    retryTokens,
+    retryShare: spendTokens ? retryTokens / spendTokens : 0,
   };
+}
+
+export function parseTools(tools: string): string[] {
+  try {
+    const arr = JSON.parse(tools);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Late-half vs early-half context per turn for one session, plus how much of
+ * the late context is paid fresh (input + cache writes) rather than read from
+ * cache. Undefined when the session is too short to show a trend.
+ */
+export function contextGrowthOf(
+  arr: StoredEvent[],
+): { ratio: number; lateFreshShare: number } | undefined {
+  if (arr.length < BLOAT_MIN_TURNS) return undefined;
+  const ctx = (e: StoredEvent) => e.input_tokens + e.cache_read_tokens + e.cache_creation_tokens;
+  const half = Math.floor(arr.length / 2);
+  const early = arr.slice(0, half);
+  const late = arr.slice(arr.length - half);
+  const earlyCtx = early.reduce((s, e) => s + ctx(e), 0) / half;
+  const lateCtxTotal = late.reduce((s, e) => s + ctx(e), 0);
+  if (!earlyCtx || !lateCtxTotal) return undefined;
+  const lateFresh = late.reduce((s, e) => s + e.input_tokens + e.cache_creation_tokens, 0);
+  return { ratio: lateCtxTotal / half / earlyCtx, lateFreshShare: lateFresh / lateCtxTotal };
 }
 
 export function groupBy<K extends keyof StoredEvent>(events: StoredEvent[], key: K): Map<string, StoredEvent[]> {

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -48,6 +48,9 @@ export const PRICES: ModelPrice[] = [
   { match: /gpt-5|codex/, input: 1.75, output: 14, cacheRead: 0.18, cacheWrite: 0, estimated: true },
 ];
 
+/** Models billed at a premium tier — drives right-sizing signals. */
+export const PREMIUM_MODEL_RE = /fable|mythos|opus|gpt-5(?!.*mini)|gemini-.*pro/i;
+
 export interface Cost {
   usd: number;
   estimated: boolean;

--- a/src/report.ts
+++ b/src/report.ts
@@ -97,6 +97,9 @@ export function renderReport(
   out.push(
     `\n  ${DIM}rework ratio ${(m.reworkRatio * 100).toFixed(1)}%  ·  think:code ${m.thinkToCodeRatio.toFixed(2)}  ·  ${m.errorEvents} turns hit tool errors${RESET}`,
   );
+  out.push(
+    `  ${DIM}signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions  ·  cold restarts ${(m.coldRestartShare * 100).toFixed(0)}% of fresh input  ·  premium on exploration/chat ${(m.premiumWasteShare * 100).toFixed(0)}%  ·  retry loops ${(m.retryShare * 100).toFixed(1)}%${RESET}`,
+  );
 
   out.push(section('By project'));
   const projRows = [...groupBy(events, 'project').entries()]

--- a/src/team.ts
+++ b/src/team.ts
@@ -154,6 +154,10 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     spendTokens: 0, costUsd: 0, costEstimated: false, costUnpricedTokens: 0,
     cacheHitRatio: 0, reworkTokens: 0, reworkRatio: 0, errorEvents: 0,
     byActivity, byModel, thinkToCodeRatio: 0,
+    trendSessions: 0, bloatedSessions: 0, contextBloatShare: 0,
+    coldRestartTurns: 0, coldRestartTokens: 0, coldRestartShare: 0,
+    premiumWasteTokens: 0, premiumWasteShare: 0,
+    retryTokens: 0, retryShare: 0,
   };
   for (const m of list) {
     out.events += m.events;
@@ -169,6 +173,13 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.costUnpricedTokens += m.costUnpricedTokens;
     out.reworkTokens += m.reworkTokens ?? 0;
     out.errorEvents += m.errorEvents;
+    // `?? 0` throughout: pre-0.6 exports don't carry the signal fields.
+    out.trendSessions += m.trendSessions ?? 0;
+    out.bloatedSessions += m.bloatedSessions ?? 0;
+    out.coldRestartTurns += m.coldRestartTurns ?? 0;
+    out.coldRestartTokens += m.coldRestartTokens ?? 0;
+    out.premiumWasteTokens += m.premiumWasteTokens ?? 0;
+    out.retryTokens += m.retryTokens ?? 0;
     for (const a of ACTIVITIES) {
       byActivity[a].tokens += m.byActivity[a]?.tokens ?? 0;
       byActivity[a].events += m.byActivity[a]?.events ?? 0;
@@ -185,6 +196,11 @@ export function mergeMetrics(list: Metrics[]): Metrics {
   const denom = out.cacheReadTokens + out.inputTokens + out.cacheCreationTokens;
   out.cacheHitRatio = denom ? out.cacheReadTokens / denom : 0;
   out.reworkRatio = out.spendTokens ? out.reworkTokens / out.spendTokens : 0;
+  out.contextBloatShare = out.trendSessions ? out.bloatedSessions / out.trendSessions : 0;
+  const freshPaid = out.inputTokens + out.cacheCreationTokens;
+  out.coldRestartShare = freshPaid ? out.coldRestartTokens / freshPaid : 0;
+  out.premiumWasteShare = out.spendTokens ? out.premiumWasteTokens / out.spendTokens : 0;
+  out.retryShare = out.spendTokens ? out.retryTokens / out.spendTokens : 0;
   out.thinkToCodeRatio =
     (byActivity.thinking.tokens + byActivity.exploration.tokens) / (byActivity.coding.tokens || 1);
   return out;

--- a/test/analyze.test.ts
+++ b/test/analyze.test.ts
@@ -37,6 +37,35 @@ test('computeToolStats attributes errors to tools in failing turns', () => {
   assert.equal(read?.errorRate, 0.5);
 });
 
+test('computeToolStats: retry cost accrues to the tool that re-ran after its error', () => {
+  const stats = computeToolStats([
+    makeStored({ session_id: 'r', ts: '2026-06-01T00:00:01Z', tools: '["Bash"]', is_error: 1, input_tokens: 100, output_tokens: 0 }),
+    makeStored({ session_id: 'r', ts: '2026-06-01T00:00:02Z', tools: '["Bash","Read"]', input_tokens: 500, output_tokens: 100 }),
+    // new session: no carry-over from the error above
+    makeStored({ session_id: 'other', ts: '2026-06-01T00:00:03Z', tools: '["Bash"]', input_tokens: 900, output_tokens: 0 }),
+  ]);
+  assert.equal(stats.find((t) => t.tool === 'Bash')?.retryTokens, 600);
+  assert.equal(stats.find((t) => t.tool === 'Read')?.retryTokens, 0);
+});
+
+test('computeSessionStats: context growth and cold restarts per session', () => {
+  const evs = Array.from({ length: 8 }, (_, i) =>
+    makeStored({
+      session_id: 'g',
+      // 10-minute gaps: every turn after the first is a cold restart
+      ts: `2026-06-01T0${Math.floor((i * 10) / 60)}:${String((i * 10) % 60).padStart(2, '0')}:00Z`,
+      input_tokens: i < 4 ? 100 : 5000,
+      output_tokens: 0,
+    }),
+  );
+  const [s] = computeSessionStats(evs);
+  assert.ok(Math.abs(s.contextGrowth - 50) < 1e-9);
+  assert.equal(s.coldRestartTurns, 7);
+  assert.equal(s.coldRestartTokens, 100 * 3 + 5000 * 4);
+  // the 5-min-apart fix-loop session has no cold restarts (gap must exceed the TTL)
+  assert.equal(computeSessionStats(fixLoopSession)[0].coldRestartTurns, 0);
+});
+
 test('deepAnalysis surfaces fix-loop sessions and sorts expensive first', () => {
   const events = [
     ...fixLoopSession,

--- a/test/followthrough.test.ts
+++ b/test/followthrough.test.ts
@@ -59,6 +59,64 @@ test('still-bad metric stays tracking, small moves are not noise-flagged', () =>
   assert.equal(rows.find((r) => r.key === 'low-cache-hit')?.status, 'tracking');
 });
 
+test('context-bloat finding needs ≥3 measurable sessions and ≥30% bloated', () => {
+  const bloated = (id: string) =>
+    Array.from({ length: 8 }, (_, i) =>
+      makeStored({
+        session_id: id,
+        ts: `2026-06-01T00:0${i}:00Z`,
+        input_tokens: i < 4 ? 100 : 5000,
+        output_tokens: 0,
+      }),
+    );
+  const m = computeMetrics([...bloated('a'), ...bloated('b'), ...bloated('c')]);
+  assert.ok(structuredFindings(m).some((f) => f.key === 'context-bloat'));
+
+  // only one measurable session -> too thin to conclude
+  const thin = computeMetrics(bloated('a'));
+  assert.ok(!structuredFindings(thin).some((f) => f.key === 'context-bloat'));
+});
+
+test('cold-restarts finding fires on TTL-gap re-payment share', () => {
+  const m = computeMetrics([
+    makeStored({ ts: '2026-06-01T00:00:00Z', input_tokens: 50_000, output_tokens: 0 }),
+    makeStored({ ts: '2026-06-01T00:20:00Z', input_tokens: 150_000, output_tokens: 0 }),
+  ]);
+  assert.ok(structuredFindings(m).some((f) => f.key === 'cold-restarts'));
+
+  const warm = computeMetrics([
+    makeStored({ ts: '2026-06-01T00:00:00Z', input_tokens: 50_000, output_tokens: 0 }),
+    makeStored({ ts: '2026-06-01T00:01:00Z', input_tokens: 150_000, output_tokens: 0 }),
+  ]);
+  assert.ok(!structuredFindings(warm).some((f) => f.key === 'cold-restarts'));
+});
+
+test('premium-misroute finding fires when premium tokens go to exploration/chat', () => {
+  const m = computeMetrics([
+    makeStored({ model: 'claude-opus-4-7', activity: 'exploration', input_tokens: 80_000, output_tokens: 0 }),
+    makeStored({ model: 'claude-opus-4-7', activity: 'coding', input_tokens: 40_000, output_tokens: 0 }),
+  ]);
+  assert.ok(structuredFindings(m).some((f) => f.key === 'premium-misroute'));
+
+  const codingHeavy = computeMetrics([
+    makeStored({ model: 'claude-opus-4-7', activity: 'coding', input_tokens: 120_000, output_tokens: 0 }),
+  ]);
+  assert.ok(!structuredFindings(codingHeavy).some((f) => f.key === 'premium-misroute'));
+});
+
+test('tool-retry-loops finding fires when retry spend passes 5%', () => {
+  const m = computeMetrics([
+    makeStored({ ts: '2026-06-01T00:00:01Z', tools: '["Bash"]', is_error: 1, input_tokens: 1000, output_tokens: 0 }),
+    makeStored({ ts: '2026-06-01T00:00:02Z', tools: '["Bash"]', input_tokens: 1000, output_tokens: 0 }),
+  ]);
+  assert.ok(structuredFindings(m).some((f) => f.key === 'tool-retry-loops'));
+
+  const clean = computeMetrics([
+    makeStored({ tools: '["Bash"]', input_tokens: 1000, output_tokens: 0 }),
+  ]);
+  assert.ok(!structuredFindings(clean).some((f) => f.key === 'tool-retry-loops'));
+});
+
 test('premiumShare measures premium-model token share', () => {
   const m = computeMetrics([
     makeStored({ model: 'claude-opus-4-7', input_tokens: 900, output_tokens: 0 }),

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -1,7 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { computeMetrics } from '../src/metrics.js';
+import { computeMetrics, contextGrowthOf } from '../src/metrics.js';
 import { makeStored } from './helpers.js';
+import type { StoredEvent } from '../src/store.js';
 
 test('totals, sessions and cache hit ratio', () => {
   const m = computeMetrics([
@@ -43,6 +44,87 @@ test('activity shares sum to 1 over spend tokens', () => {
   ]);
   assert.ok(Math.abs(m.byActivity.coding.share - 0.75) < 1e-9);
   assert.ok(Math.abs(m.byActivity.exploration.share - 0.25) < 1e-9);
+});
+
+// 8-turn session: tiny early context, late context fresh-paid (no cache reads).
+function bloatedSession(id: string): StoredEvent[] {
+  return Array.from({ length: 8 }, (_, i) =>
+    makeStored({
+      session_id: id,
+      ts: `2026-06-01T00:0${i}:00Z`,
+      input_tokens: i < 4 ? 100 : 5000,
+      output_tokens: 0,
+    }),
+  );
+}
+
+test('context bloat: flags late context growth paid fresh, not growth served from cache', () => {
+  const m = computeMetrics(bloatedSession('s1'));
+  assert.equal(m.trendSessions, 1);
+  assert.equal(m.bloatedSessions, 1);
+  assert.equal(m.contextBloatShare, 1);
+
+  // Same growth, but the late context is almost all cache reads — cache keeps pace.
+  const cached = computeMetrics(
+    Array.from({ length: 8 }, (_, i) =>
+      makeStored({
+        session_id: 'c',
+        ts: `2026-06-01T00:0${i}:00Z`,
+        input_tokens: 100,
+        cache_read_tokens: i < 4 ? 0 : 5000,
+        output_tokens: 0,
+      }),
+    ),
+  );
+  assert.equal(cached.trendSessions, 1);
+  assert.equal(cached.bloatedSessions, 0);
+
+  // Short sessions are not measurable.
+  const short = computeMetrics([makeStored({}), makeStored({})]);
+  assert.equal(short.trendSessions, 0);
+  assert.equal(short.contextBloatShare, 0);
+});
+
+test('contextGrowthOf reports the late/early ratio', () => {
+  const g = contextGrowthOf(bloatedSession('s1'));
+  assert.ok(g);
+  assert.ok(Math.abs(g.ratio - 50) < 1e-9); // 5000 avg late / 100 avg early
+  assert.equal(g.lateFreshShare, 1);
+  assert.equal(contextGrowthOf(bloatedSession('s1').slice(0, 4)), undefined);
+});
+
+test('cold restarts: turns past the ~5-min cache TTL re-pay input + cache writes', () => {
+  const m = computeMetrics([
+    makeStored({ ts: '2026-06-01T00:00:00Z', input_tokens: 1000, cache_creation_tokens: 500, output_tokens: 0 }),
+    makeStored({ ts: '2026-06-01T00:01:00Z', input_tokens: 1000, output_tokens: 0 }), // warm
+    makeStored({ ts: '2026-06-01T00:11:00Z', input_tokens: 2000, cache_creation_tokens: 1000, output_tokens: 0 }), // 10-min gap
+  ]);
+  assert.equal(m.coldRestartTurns, 1);
+  assert.equal(m.coldRestartTokens, 3000);
+  // 3000 / (4000 input + 1500 cache writes)
+  assert.ok(Math.abs(m.coldRestartShare - 3000 / 5500) < 1e-9);
+});
+
+test('premium waste: premium-model tokens on exploration/conversation turns only', () => {
+  const m = computeMetrics([
+    makeStored({ model: 'claude-opus-4-7', activity: 'exploration', input_tokens: 600, output_tokens: 0 }),
+    makeStored({ model: 'claude-opus-4-7', activity: 'coding', input_tokens: 300, output_tokens: 0 }),
+    makeStored({ model: 'claude-haiku-4-5', activity: 'conversation', input_tokens: 100, output_tokens: 0 }),
+  ]);
+  assert.equal(m.premiumWasteTokens, 600);
+  assert.ok(Math.abs(m.premiumWasteShare - 0.6) < 1e-9);
+});
+
+test('retry loops: spend on turns re-running the tool that just errored', () => {
+  const m = computeMetrics([
+    makeStored({ ts: '2026-06-01T00:00:01Z', tools: '["Bash"]', is_error: 1, input_tokens: 100, output_tokens: 0 }),
+    makeStored({ ts: '2026-06-01T00:00:02Z', tools: '["Bash"]', input_tokens: 400, output_tokens: 0 }), // retry
+    makeStored({ ts: '2026-06-01T00:00:03Z', tools: '["Bash"]', input_tokens: 300, output_tokens: 0 }), // previous turn clean
+    makeStored({ ts: '2026-06-01T00:00:04Z', tools: '["Read"]', is_error: 1, input_tokens: 100, output_tokens: 0 }),
+    makeStored({ ts: '2026-06-01T00:00:05Z', tools: '["Bash"]', input_tokens: 200, output_tokens: 0 }), // different tool
+  ]);
+  assert.equal(m.retryTokens, 400);
+  assert.ok(Math.abs(m.retryShare - 400 / 1100) < 1e-9);
 });
 
 test('anthropic models are priced exactly, unknown models counted as unpriced', () => {


### PR DESCRIPTION
Closes #29 (milestone 4).

## Signals
| Signal | Metric | Finding (threshold) |
|---|---|---|
| Context bloat trend | `contextBloatShare` — sessions (≥8 turns) whose late-half context grew ≥2× with ≥30% of it paid fresh | `context-bloat` (≥30% of ≥3 measurable sessions) |
| Session hygiene | `coldRestartShare` — input + cache writes re-paid on turns resuming after the ~5-min cache TTL | `cold-restarts` (≥20% of fresh input, >100k spend) |
| Model right-sizing | `premiumWasteShare` — premium-model tokens on exploration/conversation turns | `premium-misroute` (≥30% of spend, >100k) |
| Tool-error hotspots | `retryShare` / per-tool `retryTokens` — spend on turns re-running a tool right after it errored | `tool-retry-loops` (≥5% of spend) |

## Surfacing
- `report` + HTML dashboard: one-line signals summary; threshold-gated messages join the recommendations and are tracked by follow-through (4 new `MetricKey`s, stable keys).
- `analyze`: new *Context bloat trend* and *Cold restarts* tables; *Retry cost* column on tool error rates; signals + per-session growth/cold tokens in the `--llm` payload and definitions.
- `mergeMetrics` carries the new absolutes and recomputes shares; `?? 0` guards keep pre-0.6 exports mergeable.
- Premium-model regex centralized in `pricing.ts` (`PREMIUM_MODEL_RE`, now also matches mythos).

## Tests
Unit fixtures trip and clear each threshold (bloat fresh-vs-cached growth, TTL gap vs warm, premium exploration vs coding, retry vs clean), plus per-session stats and per-tool retry attribution. 87 tests pass.

Validated on real data: cold restarts 23% of fresh input, premium-on-exploration 43% — consistent with the earlier `analyze --llm` findings.

