### PR TITLE
feat: recommendations 2.0 — evidence-cited, savings-quantified

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ token-monitor analyze --llm
 
 No API key management: it reuses your existing agent CLI and its subscription. The payload is the same aggregates-only data as `report --json` (token counts, ratios, tool names, project basenames — never prompts or code). It does leave your machine via that agent's provider, so skip `--llm` if even project names are sensitive.
 
+## Recommendations: evidence + savings
+
+Every threshold-fired recommendation answers "why should I believe this and what is it worth": it cites the worst 3 sessions that triggered it (session ids, dates, token counts — aggregate-only, never content) and estimates the $/month saved if the metric hit its target, priced from **your own model mix** and the price table (`~` when estimated prices or a tier assumption are involved):
+
+```
+→ 43% of spend is premium-model tokens on exploration/conversation turns. …  ≈ $8060/mo
+    worst: db0a7d17 (procurement, 2026-05-26, 1.8M premium on exploration/chat) · …
+```
+
+These show up in `report`, `analyze`, the HTML dashboard, and ride along in signed exports (`recommendationDetails`).
+
 ## Follow-through
 
 Recommendations are tracked, not just printed. The first time one fires, its target metric is recorded as a baseline; every later report re-measures and shows the delta:

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -6,7 +6,8 @@ import { assignPersona } from './personas.js';
 import { structuredFindings } from './followthrough.js';
 import type { Activity } from './types.js';
 import { ACTIVITIES } from './types.js';
-import { table, section, fmtTokens } from './report.js';
+import { table, section, fmtTokens, renderEnrichedRecs } from './report.js';
+import { enrichFindings } from './recommendations.js';
 
 /**
  * Deeper, session-level analysis. The report answers "where do tokens go";
@@ -322,6 +323,11 @@ export function renderAnalysis(events: StoredEvent[], days: number): string {
         ]),
       ),
     );
+  }
+  const recs = enrichFindings(events, m, days);
+  if (recs.length) {
+    out.push(`\n${'\x1b[1m'}\x1b[32mRecommendations (evidence-cited)\x1b[0m`);
+    out.push(...renderEnrichedRecs(recs));
   }
   out.push(
     `\n\x1b[2mAdd --llm to get prioritized recommendations from your local agent CLI (claude/gemini/codex).\x1b[0m\n`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { renderReport, renderTeamReport } from './report.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import { buildExport, parseTeamConfig, mergeMetrics, dedupeExports, rollupExports, displayName, identityOf } from './team.js';
 import { syncFindings } from './followthrough.js';
+import { enrichFindings } from './recommendations.js';
 import { computeMetrics } from './metrics.js';
 import { renderHtml, renderTeamHtml } from './html.js';
 import { renderAnalysis, deepAnalysis, buildLlmPrompt, runLlm, detectAgent } from './analyze.js';
@@ -71,7 +72,14 @@ function buildSignedExportJson(
   const ex = buildExport(events, days);
   const persona = assignPersona(ex.overall);
   const signed = signObject(
-    { ...ex, persona, recommendations: [...persona.recommendations, ...generalRecommendations(ex.overall)] },
+    {
+      ...ex,
+      persona,
+      recommendations: [...persona.recommendations, ...generalRecommendations(ex.overall)],
+      // Evidence is aggregate-only by construction: session ids, dates, token
+      // counts and $ estimates — never prompts or code.
+      recommendationDetails: enrichFindings(events, ex.overall, days),
+    },
     keyDirFor(dbPath),
   );
   return JSON.stringify(signed, null, 2);

--- a/src/html.ts
+++ b/src/html.ts
@@ -8,6 +8,7 @@ import { fmtMetric } from './followthrough.js';
 import { fmtTokens } from './report.js';
 import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
 import { mergeMetrics, rollupExports, displayName } from './team.js';
+import { enrichFindings, fmtSavings, fmtEvidence } from './recommendations.js';
 
 const ACTIVITY_COLORS: Record<string, string> = {
   thinking: '#8b7ff5',
@@ -46,7 +47,15 @@ export function renderHtml(
 ): string {
   const m = computeMetrics(events);
   const persona = assignPersona(m);
-  const recs = [...persona.recommendations, ...generalRecommendations(m)];
+  const enriched = enrichFindings(events, m, opts.days);
+  const recItems = [
+    ...persona.recommendations.map((r) => `<li>${esc(r)}</li>`),
+    ...enriched.map((r) => {
+      const savings = fmtSavings(r);
+      const ev = fmtEvidence(r);
+      return `<li>${esc(r.message)}${savings ? ` <span class="save">${esc(savings)}</span>` : ''}${ev ? `<div class="ev muted">${esc(ev)}</div>` : ''}</li>`;
+    }),
+  ].join('');
   const projects = [...groupBy(events, 'project').entries()]
     .map(([proj, evs]) => ({ proj, m: computeMetrics(evs) }))
     .sort((a, b) => b.m.spendTokens - a.m.spendTokens)
@@ -115,7 +124,7 @@ ${stackedBar(m)}
 <div class="persona">
   <h3>${persona.emoji} ${esc(persona.name)}</h3>
   <div class="muted">${esc(persona.description)}</div>
-  <ul class="recs">${recs.map((r) => `<li>${esc(r)}</li>`).join('')}</ul>
+  <ul class="recs">${recItems}</ul>
 </div>
 ${followSection}`,
   );
@@ -146,6 +155,8 @@ function pageShell(title: string, body: string): string {
   .persona { background:#1c212b; border-radius:10px; padding:1rem 1.2rem; margin-top:1rem; }
   .persona h3 { margin:.1rem 0 .4rem; }
   ul.recs { margin:.4rem 0 0; padding-left:1.2rem; } ul.recs li { margin:.3rem 0; }
+  .save { color:#5dc98a; font-weight:600; white-space:nowrap; }
+  .ev { font-size:.8rem; margin-top:.15rem; }
   .st-resolved { color:#5dc98a; } .st-regressing { color:#e88f68; } .st-improving { color:#9fd45d; }
   footer { margin:2.5rem 0 1rem; font-size:.8rem; color:#717a8a; }
 </style></head><body>

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -1,0 +1,242 @@
+import type { Metrics } from './metrics.js';
+import { computeMetrics, groupBy, contextGrowthOf, BLOAT_MIN_TURNS } from './metrics.js';
+import type { StoredEvent } from './store.js';
+import type { Finding } from './followthrough.js';
+import { structuredFindings, premiumShare } from './followthrough.js';
+import { PRICES, PREMIUM_MODEL_RE } from './pricing.js';
+import { fmtTokens } from './report.js';
+
+/**
+ * Recommendations 2.0: every structured finding answers "why should I believe
+ * this and what is it worth" — the worst sessions that triggered it (ids,
+ * dates, token counts; aggregate-only, never content) and the estimated
+ * $/month if the metric moved to its target, priced from the user's own
+ * model mix and the price table. Finding keys are untouched, so
+ * follow-through baselines keep working.
+ */
+
+export interface RecEvidence {
+  sessionId: string;
+  project: string;
+  /** Date of the session's first turn (yyyy-mm-dd). */
+  date: string;
+  /** Human label for the session's offending number, e.g. "1.2M rework tok". */
+  label: string;
+}
+
+export interface EnrichedRec extends Finding {
+  /** Worst sessions by this finding's metric — at most 3. */
+  evidence: RecEvidence[];
+  /** Estimated savings if the metric moved to its target; absent when not quantifiable. */
+  savingsUsdPerMonth?: number;
+  /** True when placeholder/estimated prices or a tier assumption fed the number. */
+  savingsEstimated: boolean;
+}
+
+/** Improvement targets used for the savings math, per finding key. */
+const TARGETS: Record<string, number> = {
+  'low-cache-hit': 0.8, // cache hit ratio to reach
+  'high-rework': 0.1, // rework ratio to reach
+  'premium-model-overuse': 0.5, // premium share to reach
+  'cold-restarts': 0.05, // cold-restart share to reach
+};
+
+interface SessionInfo {
+  sessionId: string;
+  project: string;
+  date: string;
+  m: Metrics;
+  events: StoredEvent[];
+}
+
+/** $/token rates blended over the user's actual model mix in the window. */
+export interface BlendedRates {
+  input: number;
+  cacheRead: number;
+  /** Average realized $/spend-token across all priced usage. */
+  spend: number;
+  /** Realized $/spend-token on premium models only. */
+  premium: number;
+  /** Cheapest priced non-premium model the user already runs; tier-assumed when absent. */
+  cheap: number;
+  estimated: boolean;
+}
+
+export function blendedRates(m: Metrics): BlendedRates {
+  let wInput = 0, wCacheRead = 0, wTokens = 0;
+  let premiumCost = 0, premiumTokens = 0;
+  let cheap = Infinity;
+  let estimated = false;
+  for (const [model, v] of Object.entries(m.byModel)) {
+    if (!v.tokens) continue;
+    const row = PRICES.find((p) => p.match.test(model));
+    if (!row) {
+      estimated = true; // unpriced usage in the mix
+      continue;
+    }
+    if (row.estimated) estimated = true;
+    wInput += v.tokens * row.input;
+    wCacheRead += v.tokens * row.cacheRead;
+    wTokens += v.tokens;
+    const rate = v.costUsd / v.tokens;
+    if (PREMIUM_MODEL_RE.test(model)) {
+      premiumCost += v.costUsd;
+      premiumTokens += v.tokens;
+    } else if (v.costUsd > 0) {
+      cheap = Math.min(cheap, rate);
+    }
+  }
+  const premium = premiumTokens ? premiumCost / premiumTokens : 0;
+  if (!Number.isFinite(cheap)) {
+    // No cheaper model in the mix to price against — assume the next tier
+    // down at ~1/5 the premium rate (e.g. Opus -> Haiku input pricing).
+    cheap = premium / 5;
+    estimated = true;
+  }
+  return {
+    input: wTokens ? wInput / wTokens / 1e6 : 0,
+    cacheRead: wTokens ? wCacheRead / wTokens / 1e6 : 0,
+    spend: m.spendTokens ? m.costUsd / m.spendTokens : 0,
+    premium,
+    cheap,
+    estimated: estimated || m.costEstimated,
+  };
+}
+
+/** Fresh tokens the late half of a bloated session paid beyond the early-half rate. */
+function bloatAvoidableTokens(events: StoredEvent[]): number {
+  if (events.length < BLOAT_MIN_TURNS) return 0;
+  const half = Math.floor(events.length / 2);
+  const fresh = (e: StoredEvent) => e.input_tokens + e.cache_creation_tokens;
+  const earlyFresh = events.slice(0, half).reduce((s, e) => s + fresh(e), 0);
+  const lateFresh = events.slice(events.length - half).reduce((s, e) => s + fresh(e), 0);
+  return Math.max(0, lateFresh - earlyFresh);
+}
+
+function premiumTokensOf(m: Metrics): number {
+  return Object.entries(m.byModel)
+    .filter(([name]) => PREMIUM_MODEL_RE.test(name))
+    .reduce((s, [, v]) => s + v.tokens, 0);
+}
+
+/** Per finding key: how bad is this session (higher = worse) and its evidence label. */
+const SCORERS: Record<string, (s: SessionInfo) => { score: number; label: string }> = {
+  'low-cache-hit': (s) => ({
+    score: s.m.inputTokens,
+    label: `cache ${(s.m.cacheHitRatio * 100).toFixed(0)}% · ${fmtTokens(s.m.inputTokens)} fresh input`,
+  }),
+  'high-rework': (s) => ({
+    score: s.m.reworkTokens,
+    label: `${fmtTokens(s.m.reworkTokens)} rework tok`,
+  }),
+  'low-think-code': (s) => ({
+    score: s.m.thinkToCodeRatio < 0.15 ? s.m.byActivity.coding.tokens : 0,
+    label: `think:code ${s.m.thinkToCodeRatio.toFixed(2)} · ${fmtTokens(s.m.byActivity.coding.tokens)} coding tok`,
+  }),
+  'premium-model-overuse': (s) => ({
+    score: premiumTokensOf(s.m),
+    label: `${fmtTokens(premiumTokensOf(s.m))} premium tok`,
+  }),
+  'context-bloat': (s) => {
+    const growth = contextGrowthOf(s.events);
+    return {
+      score: growth && growth.ratio >= 2 ? bloatAvoidableTokens(s.events) : 0,
+      label: `ctx ×${growth ? growth.ratio.toFixed(1) : '?'} · ${fmtTokens(bloatAvoidableTokens(s.events))} avoidable`,
+    };
+  },
+  'cold-restarts': (s) => ({
+    score: s.m.coldRestartTokens,
+    label: `${fmtTokens(s.m.coldRestartTokens)} re-paid after gaps`,
+  }),
+  'premium-misroute': (s) => ({
+    score: s.m.premiumWasteTokens,
+    label: `${fmtTokens(s.m.premiumWasteTokens)} premium on exploration/chat`,
+  }),
+  'tool-retry-loops': (s) => ({
+    score: s.m.retryTokens,
+    label: `${fmtTokens(s.m.retryTokens)} retry tok`,
+  }),
+};
+
+/** Estimated $ saved over the report window if the finding's metric hit its target. */
+function savingsUsd(key: string, m: Metrics, rates: BlendedRates, sessions: SessionInfo[]): number | undefined {
+  const inputSide = m.cacheReadTokens + m.inputTokens + m.cacheCreationTokens;
+  switch (key) {
+    case 'low-cache-hit': {
+      // Tokens that would shift from fresh input to cache reads.
+      const moved = Math.max(0, TARGETS[key] - m.cacheHitRatio) * inputSide;
+      return moved * (rates.input - rates.cacheRead);
+    }
+    case 'high-rework':
+      return Math.max(0, m.reworkRatio - TARGETS[key]) * m.spendTokens * rates.spend;
+    case 'premium-model-overuse': {
+      const moved = Math.max(0, premiumShare(m) - TARGETS[key]) * m.spendTokens;
+      return moved * Math.max(0, rates.premium - rates.cheap);
+    }
+    case 'premium-misroute':
+      return m.premiumWasteTokens * Math.max(0, rates.premium - rates.cheap);
+    case 'cold-restarts': {
+      const saved = Math.max(0, m.coldRestartShare - TARGETS[key]) * (m.inputTokens + m.cacheCreationTokens);
+      return saved * (rates.input - rates.cacheRead);
+    }
+    case 'context-bloat': {
+      const avoidable = sessions.reduce((s, info) => {
+        const g = contextGrowthOf(info.events);
+        return g && g.ratio >= 2 ? s + bloatAvoidableTokens(info.events) : s;
+      }, 0);
+      // Conservative: avoided fresh context would have been cache reads at best.
+      return avoidable * (rates.input - rates.cacheRead);
+    }
+    case 'tool-retry-loops':
+      return m.retryTokens * rates.spend;
+    default:
+      return undefined; // e.g. low-think-code: an invest-more rec, not a savings one
+  }
+}
+
+export function enrichFindings(events: StoredEvent[], m: Metrics, days: number): EnrichedRec[] {
+  const findings = structuredFindings(m);
+  if (findings.length === 0) return [];
+  const sessions: SessionInfo[] = [...groupBy(events, 'session_id')].map(([sessionId, evs]) => ({
+    sessionId,
+    project: evs[0].project,
+    date: evs[0].ts.slice(0, 10),
+    m: computeMetrics(evs),
+    events: evs,
+  }));
+  const rates = blendedRates(m);
+  const monthly = days > 0 ? 30 / days : 1;
+
+  return findings.map((f) => {
+    const scorer = SCORERS[f.key];
+    const evidence = scorer
+      ? sessions
+          .map((s) => ({ s, ...scorer(s) }))
+          .filter((x) => x.score > 0)
+          .sort((a, b) => b.score - a.score)
+          .slice(0, 3)
+          .map(({ s, label }) => ({ sessionId: s.sessionId, project: s.project, date: s.date, label }))
+      : [];
+    const usd = savingsUsd(f.key, m, rates, sessions);
+    return {
+      ...f,
+      evidence,
+      savingsUsdPerMonth: usd !== undefined && usd > 0 ? usd * monthly : undefined,
+      savingsEstimated: rates.estimated,
+    };
+  });
+}
+
+/** "≈ ~$84/mo" — shared by the terminal report, analyze, and the dashboard. */
+export function fmtSavings(r: EnrichedRec): string | undefined {
+  if (r.savingsUsdPerMonth === undefined) return undefined;
+  const n = r.savingsUsdPerMonth;
+  return `≈ ${r.savingsEstimated ? '~' : ''}$${n >= 100 ? n.toFixed(0) : n.toFixed(2)}/mo`;
+}
+
+export function fmtEvidence(r: EnrichedRec): string | undefined {
+  if (r.evidence.length === 0) return undefined;
+  return 'worst: ' + r.evidence
+    .map((e) => `${e.sessionId.slice(0, 8)} (${e.project}, ${e.date}, ${e.label})`)
+    .join(' · ');
+}

--- a/src/report.ts
+++ b/src/report.ts
@@ -7,6 +7,8 @@ import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
 import { mergeMetrics, rollupExports, dominantActivity, displayName } from './team.js';
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
+import type { EnrichedRec } from './recommendations.js';
+import { enrichFindings, fmtSavings, fmtEvidence } from './recommendations.js';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -128,9 +130,9 @@ export function renderReport(
   const persona = assignPersona(m);
   out.push(section(`Overall persona: ${persona.emoji} ${persona.name}`));
   out.push(`  ${persona.description}\n`);
-  const recs = [...persona.recommendations, ...generalRecommendations(m)];
   out.push(`${BOLD}${GREEN}Recommendations${RESET}`);
-  for (const r of recs) out.push(`  ${YELLOW}→${RESET} ${r}`);
+  for (const r of persona.recommendations) out.push(`  ${YELLOW}→${RESET} ${r}`);
+  out.push(...renderEnrichedRecs(enrichFindings(events, m, opts.days)));
 
   if (opts.follow && opts.follow.length > 0) {
     out.push(section('Follow-through (recommendation → measured change)'));
@@ -151,6 +153,18 @@ export function renderReport(
 
   out.push(`\n${DIM}Cost figures marked ~ use placeholder prices — edit src/pricing.ts.${RESET}\n`);
   return out.join('\n');
+}
+
+/** Finding lines with savings + worst-session evidence — shared with `analyze`. */
+export function renderEnrichedRecs(recs: EnrichedRec[]): string[] {
+  const out: string[] = [];
+  for (const r of recs) {
+    const savings = fmtSavings(r);
+    out.push(`  ${YELLOW}→${RESET} ${r.message}${savings ? `  ${GREEN}${savings}${RESET}` : ''}`);
+    const ev = fmtEvidence(r);
+    if (ev) out.push(`    ${DIM}${ev}${RESET}`);
+  }
+  return out;
 }
 
 export function renderTeamReport(

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -74,6 +74,12 @@ test('e2e: report --json emits a signed v1 export; fingerprint command matches i
   assert.equal(data.version, 1);
   assert.equal(data.overall.events, 15); // 3 claude + 2 gemini + 2 codex + 2 cursor + 3 antigravity + 3 copilot
   assert.equal(data.sig.alg, 'ed25519');
+  // recommendations 2.0: enriched details ride along, aggregate-only
+  assert.ok(Array.isArray(data.recommendationDetails));
+  for (const rec of data.recommendationDetails) {
+    assert.ok(Array.isArray(rec.evidence));
+    assert.ok(typeof rec.key === 'string');
+  }
 
   const fp = run(['fingerprint']).stdout.trim();
   assert.match(fp, /^[0-9a-f]{16}$/);

--- a/test/recommendations.test.ts
+++ b/test/recommendations.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeMetrics } from '../src/metrics.js';
+import { blendedRates, enrichFindings, fmtSavings, fmtEvidence } from '../src/recommendations.js';
+import { makeStored } from './helpers.js';
+import type { StoredEvent } from '../src/store.js';
+
+test('blendedRates: mix-weighted prices, cheap tier from the user\'s own mix', () => {
+  const m = computeMetrics([
+    makeStored({ model: 'claude-opus-4-7', input_tokens: 900_000, output_tokens: 0 }),
+    makeStored({ model: 'claude-haiku-4-5', input_tokens: 100_000, output_tokens: 0 }),
+  ]);
+  const r = blendedRates(m);
+  // input $/tok: (0.9*5 + 0.1*1)/1e6
+  assert.ok(Math.abs(r.input - 4.6e-6) < 1e-12);
+  assert.ok(Math.abs(r.cacheRead - 0.46e-6) < 1e-12);
+  assert.ok(Math.abs(r.premium - 5e-6) < 1e-12); // opus input-only usage
+  assert.ok(Math.abs(r.cheap - 1e-6) < 1e-12); // haiku is the cheap tier in the mix
+  assert.equal(r.estimated, false);
+});
+
+test('blendedRates: premium-only mix assumes a cheaper tier and flags the estimate', () => {
+  const m = computeMetrics([
+    makeStored({ model: 'claude-opus-4-7', input_tokens: 1_000_000, output_tokens: 0 }),
+  ]);
+  const r = blendedRates(m);
+  assert.ok(Math.abs(r.cheap - r.premium / 5) < 1e-15);
+  assert.equal(r.estimated, true);
+});
+
+// Premium spend routed to exploration: trips premium-misroute (and overuse needs >1 model).
+function misrouteEvents(): StoredEvent[] {
+  return [
+    makeStored({ session_id: 'big', ts: '2026-06-01T00:00:00Z', model: 'claude-opus-4-7', activity: 'exploration', input_tokens: 300_000, output_tokens: 0 }),
+    makeStored({ session_id: 'mid', ts: '2026-06-02T00:00:00Z', model: 'claude-opus-4-7', activity: 'exploration', input_tokens: 200_000, output_tokens: 0 }),
+    makeStored({ session_id: 'sml', ts: '2026-06-03T00:00:00Z', model: 'claude-opus-4-7', activity: 'exploration', input_tokens: 100_000, output_tokens: 0 }),
+    makeStored({ session_id: 'tiny', ts: '2026-06-04T00:00:00Z', model: 'claude-haiku-4-5', activity: 'coding', input_tokens: 1_000, output_tokens: 0 }),
+  ];
+}
+
+test('enrichFindings: evidence cites the worst 3 sessions, sorted, aggregate-only', () => {
+  const events = misrouteEvents();
+  const recs = enrichFindings(events, computeMetrics(events), 30);
+  const rec = recs.find((r) => r.key === 'premium-misroute');
+  assert.ok(rec);
+  assert.equal(rec.evidence.length, 3);
+  assert.deepEqual(rec.evidence.map((e) => e.sessionId), ['big', 'mid', 'sml']);
+  assert.equal(rec.evidence[0].date, '2026-06-01');
+  assert.match(rec.evidence[0].label, /300\.0k premium on exploration\/chat/);
+  // export safety: only ids, dates, labels — no transcript-shaped fields
+  for (const banned of ['content', 'message', 'prompt', 'command']) {
+    assert.ok(!Object.keys(rec.evidence[0]).includes(banned));
+  }
+});
+
+test('enrichFindings: savings priced from the user\'s own mix, scaled to $/month', () => {
+  const events = misrouteEvents();
+  const m = computeMetrics(events);
+  const recs = enrichFindings(events, m, 30);
+  const rec = recs.find((r) => r.key === 'premium-misroute')!;
+  // 600k tokens moved from opus input ($5/M) to haiku ($1/M) = $2.40 over 30 days
+  assert.ok(rec.savingsUsdPerMonth);
+  assert.ok(Math.abs(rec.savingsUsdPerMonth! - 600_000 * 4e-6) < 1e-9);
+  assert.equal(rec.savingsEstimated, false);
+  assert.equal(fmtSavings(rec), '≈ $2.40/mo');
+
+  // half the window -> double the monthly figure
+  const recs15 = enrichFindings(events, m, 15);
+  const rec15 = recs15.find((r) => r.key === 'premium-misroute')!;
+  assert.ok(Math.abs(rec15.savingsUsdPerMonth! - rec.savingsUsdPerMonth! * 2) < 1e-9);
+});
+
+test('fmtSavings marks estimated prices with ~; fmtEvidence truncates session ids', () => {
+  const events = [
+    makeStored({ session_id: 'a-very-long-session-id', ts: '2026-06-01T00:00:00Z', model: 'claude-opus-4-7', activity: 'exploration', input_tokens: 200_000, output_tokens: 0 }),
+  ];
+  const m = computeMetrics(events);
+  const recs = enrichFindings(events, m, 30);
+  const rec = recs.find((r) => r.key === 'premium-misroute')!;
+  assert.equal(rec.savingsEstimated, true); // cheap tier assumed (premium-only mix)
+  assert.match(fmtSavings(rec)!, /^≈ ~\$/);
+  assert.match(fmtEvidence(rec)!, /^worst: a-very-l \(proj, 2026-06-01/);
+});
+
+test('low-think-code stays unquantified but keeps its message and key', () => {
+  const events = [
+    makeStored({ activity: 'coding', input_tokens: 60_000, output_tokens: 0 }),
+  ];
+  const m = computeMetrics(events);
+  const rec = enrichFindings(events, m, 30).find((r) => r.key === 'low-think-code');
+  assert.ok(rec);
+  assert.equal(rec.savingsUsdPerMonth, undefined);
+  assert.equal(fmtSavings(rec), undefined);
+});


### PR DESCRIPTION
Closes #28 (milestone 4).

## What
New `src/recommendations.ts` — `enrichFindings(events, metrics, days)` upgrades each structured finding (keys unchanged, so follow-through baselines keep working):

- **Evidence**: worst 3 sessions by the finding's own metric, via per-session `computeMetrics` — session id, date, project, and the offending number (e.g. `db0a7d17 (procurement, 2026-05-26, 1.8M premium on exploration/chat)`). Aggregate-only by construction.
- **Quantified impact**: estimated $/month if the metric moved to its per-finding target (cache hit → 80%, rework → 10%, premium share → 50%, cold restarts → 5%, misroute/retry → eliminated), priced from the user's **own model mix**: blended input/cache-read rates from the price table, realized $/token on premium models, and the cheapest priced model already in the mix as the cheap tier (assumed at premium/5 and marked `~` when there isn't one). `~` also when estimated price rows or unpriced usage are involved. `low-think-code` stays unquantified — it's an invest-more rec.

## Surfacing
`report` (savings tag + dim worst-session line per rec), `analyze` (new *Recommendations (evidence-cited)* section), HTML dashboard (savings badge + evidence sub-line), and signed exports (`recommendationDetails` rides along; signature covers it).

## Tests
`blendedRates` mix math + premium-only fallback, evidence ordering/truncation/export-safety, $/month scaling by window, `~` marker, unquantified path; e2e asserts `recommendationDetails` in the signed export. 93 tests pass.

Real-data check: premium-overuse ≈ $9.2k/mo and misroute ≈ $8.1k/mo on this machine's mix — consistent with the earlier `analyze --llm` estimate.

