### PR TITLE
chore: release 0.6.0 — org rollups & optimization insights

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-monitor",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-monitor",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "token-monitor",
   "displayName": "Token Monitor",
   "description": "Status-bar token/cost for the current project plus the token-monitor dashboard, for VS Code, Cursor, Windsurf, and Antigravity.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "ryandemelo",
   "license": "MIT",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "token-monitor",
-  "version": "0.5.0",
+  "name": "@ryandemelo/token-monitor",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "token-monitor",
-      "version": "0.5.0",
+      "name": "@ryandemelo/token-monitor",
+      "version": "0.6.0",
       "license": "MIT",
       "bin": {
-        "token-monitor": "dist/cli.js"
+        "token-monitor": "dist/src/cli.js"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex, Cursor, Antigravity, Copilot Chat) — activity breakdowns, usage personas, and recommendations.",
   "license": "MIT",
   "author": "Ryan de Melo",


### PR DESCRIPTION
Milestone 4 wrap-up: bump CLI + extension to 0.6.0 (lockfiles synced; root lockfile also picks up the 0.5-era scoped-name/bin fix it had missed).

Ships #27 (org rollups, PR #32), #29 (optimization signals, PR #33), #28 (recommendations 2.0, PR #34).

