### PR TITLE
feat: trend reports — current window vs previous, with project movers

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ token-monitor analyze --llm
 
 No API key management: it reuses your existing agent CLI and its subscription. The payload is the same aggregates-only data as `report --json` (token counts, ratios, tool names, project basenames — never prompts or code). It does leave your machine via that agent's provider, so skip `--llm` if even project names are sensitive.
 
+## Trends
+
+`report --trend` compares the window against the previous same-length one — spend, cost, cache hit, rework, and the optimization signals, each with a direction arrow (green = improving, red = regressing), plus the top project movers by spend change. The HTML dashboard includes the trend automatically when two windows of data exist.
+
 ## Recommendations: evidence + savings
 
 Every threshold-fired recommendation answers "why should I believe this and what is it worth": it cites the worst 3 sessions that triggered it (session ids, dates, token counts — aggregate-only, never content) and estimates the $/month saved if the metric hit its target, priced from **your own model mix** and the price table (`~` when estimated prices or a tier assumption are involved):
@@ -199,7 +203,7 @@ Resolved findings re-open automatically if the metric regresses.
 
 ```
 token-monitor collect [--source claude-code|gemini-cli|codex|cursor|antigravity|copilot] [--db <path>]
-token-monitor report  [--days 30] [--project <name>] [--source <name>] [--json] [--db <path>]
+token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>] [--json] [--db <path>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
 token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline] [--verify] [--keys keys.json] [--json] [--html team.html]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,8 @@ import { parseArgs } from 'node:util';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { ADAPTERS } from './adapters/index.js';
 import { openDb, insertEvents, loadEvents, DEFAULT_DB } from './store.js';
-import { renderReport, renderTeamReport } from './report.js';
+import { renderReport, renderTeamReport, renderTrend } from './report.js';
+import { splitWindow } from './trends.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import { buildExport, parseTeamConfig, mergeMetrics, dedupeExports, rollupExports, displayName, identityOf } from './team.js';
 import { syncFindings } from './followthrough.js';
@@ -21,7 +22,7 @@ const HELP = `token-monitor — measure how effectively your team spends AI codi
 
 Usage:
   token-monitor collect [--source <name>] [--db <path>]
-  token-monitor report  [--days <n>] [--project <name>] [--source <name>] [--json] [--db <path>]
+  token-monitor report  [--days <n>] [--trend] [--project <name>] [--source <name>] [--json] [--db <path>]
   token-monitor analyze [--days <n>] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline]
@@ -53,6 +54,8 @@ Integrity:
 Options:
   --source    one of: ${Object.keys(ADAPTERS).join(', ')} (default: all)
   --days      report window in days (default: 30)
+  --trend     compare against the previous same-length window (terminal report;
+              the HTML dashboard always includes the trend when data exists)
   --project   filter to one project
   --json      machine-readable output (for team aggregation)
   --team      member map: flat (\`alice: frontend\`) or two-level YAML
@@ -106,6 +109,7 @@ async function main() {
       days: { type: 'string', default: '30' },
       project: { type: 'string' },
       json: { type: 'boolean', default: false },
+      trend: { type: 'boolean', default: false },
       team: { type: 'string' },
       out: { type: 'string', default: 'report.html' },
       llm: { type: 'boolean', default: false },
@@ -245,17 +249,24 @@ Signing fingerprint (send to your team lead for keys.json):
     }
   } else if (cmd === 'report') {
     const days = Number(values.days) || 30;
-    const events = loadEvents(db, { days, project: values.project, source: values.source });
+    const filters = { project: values.project, source: values.source };
     if (values.json) {
-      console.log(buildSignedExportJson(db, days, values.db, { project: values.project, source: values.source }));
+      console.log(buildSignedExportJson(db, days, values.db, filters));
     } else {
+      // With --trend, load both windows in one query and partition, so the
+      // current slice and the comparison share the same boundary.
+      const { current: events, previous } = values.trend
+        ? splitWindow(loadEvents(db, { days: days * 2, ...filters }), days)
+        : { current: loadEvents(db, { days, ...filters }), previous: [] };
       // Follow-through baselines only on unfiltered runs, so --project/--source
       // slices can't pollute them.
       const follow =
         !values.project && !values.source && events.length > 0
           ? syncFindings(db, computeMetrics(events))
           : undefined;
-      console.log(renderReport(events, { days, follow }));
+      let out = renderReport(events, { days, follow });
+      if (values.trend && events.length > 0) out += '\n' + renderTrend(events, previous, days);
+      console.log(out);
     }
   } else if (cmd === 'analyze') {
     const days = Number(values.days) || 30;
@@ -279,9 +290,9 @@ Signing fingerprint (send to your team lead for keys.json):
     }
   } else if (cmd === 'html') {
     const days = Number(values.days) || 30;
-    const events = loadEvents(db, { days });
+    const { current: events, previous } = splitWindow(loadEvents(db, { days: days * 2 }), days);
     const follow = events.length > 0 ? syncFindings(db, computeMetrics(events)) : undefined;
-    writeFileSync(values.out, renderHtml(events, { days, follow }));
+    writeFileSync(values.out, renderHtml(events, { days, follow, previousEvents: previous }));
     console.log(`Wrote ${values.out} (${events.length} turns, last ${days} days). Open it in a browser.`);
   } else {
     console.error(`Unknown command "${cmd}"\n`);

--- a/src/html.ts
+++ b/src/html.ts
@@ -9,6 +9,7 @@ import { fmtTokens } from './report.js';
 import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
 import { mergeMetrics, rollupExports, displayName } from './team.js';
 import { enrichFindings, fmtSavings, fmtEvidence } from './recommendations.js';
+import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
 
 const ACTIVITY_COLORS: Record<string, string> = {
   thinking: '#8b7ff5',
@@ -43,7 +44,7 @@ function stackedBar(m: Metrics): string {
 
 export function renderHtml(
   events: StoredEvent[],
-  opts: { days: number; follow?: FollowRow[] },
+  opts: { days: number; follow?: FollowRow[]; previousEvents?: StoredEvent[] },
 ): string {
   const m = computeMetrics(events);
   const persona = assignPersona(m);
@@ -94,6 +95,30 @@ export function renderHtml(
     )
     .join('');
 
+  let trendSection = '';
+  if (opts.previousEvents && opts.previousEvents.length) {
+    const rows = trendRows(m, computeMetrics(opts.previousEvents));
+    const cls = { better: 'st-improving', worse: 'st-regressing', neutral: '', flat: 'muted' } as const;
+    const trendRowsHtml = rows
+      .map((r) => {
+        const d = r.now - r.prev;
+        const v = verdictOf(r);
+        const arrow = v === 'flat' ? '→' : d > 0 ? '↑' : '↓';
+        return `<tr><td>${esc(r.label)}</td><td class="num">${fmtTrendValue(r, r.prev)}</td><td class="num">${fmtTrendValue(r, r.now)}</td><td class="num ${cls[v]}">${arrow} ${d >= 0 ? '+' : '−'}${fmtTrendValue(r, Math.abs(d))}</td></tr>`;
+      })
+      .join('');
+    const movers = projectMovers(events, opts.previousEvents)
+      .map(
+        (p) =>
+          `<tr><td>${esc(p.project)}</td><td class="num">${fmtTokens(p.prev)}</td><td class="num">${fmtTokens(p.now)}</td><td class="num">${p.delta >= 0 ? '+' : '−'}${fmtTokens(Math.abs(p.delta))}</td></tr>`,
+      )
+      .join('');
+    trendSection = `<h2>Trend — vs the previous ${opts.days} days</h2>
+<table><tr><th>Metric</th><th>Previous</th><th>Now</th><th>Change</th></tr>${trendRowsHtml}</table>
+<h2>Top project movers</h2>
+<table><tr><th>Project</th><th>Previous</th><th>Now</th><th>Change</th></tr>${movers}</table>`;
+  }
+
   const followSection =
     opts.follow && opts.follow.length
       ? `<h2>Follow-through</h2><table><tr><th>Recommendation</th><th>Metric</th><th>Baseline</th><th>Now</th><th>Since</th><th>Status</th></tr>${opts.follow
@@ -120,7 +145,7 @@ ${stackedBar(m)}
 
 <h2>Models</h2>
 <table><tr><th>Model</th><th>Tokens</th><th>Cost</th></tr>${modelRows}</table>
-
+${trendSection}
 <div class="persona">
   <h3>${persona.emoji} ${esc(persona.name)}</h3>
   <div class="muted">${esc(persona.description)}</div>

--- a/src/report.ts
+++ b/src/report.ts
@@ -9,6 +9,8 @@ import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
 import type { EnrichedRec } from './recommendations.js';
 import { enrichFindings, fmtSavings, fmtEvidence } from './recommendations.js';
+import type { TrendRow, TrendVerdict } from './trends.js';
+import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -16,6 +18,7 @@ const RESET = '\x1b[0m';
 const CYAN = '\x1b[36m';
 const YELLOW = '\x1b[33m';
 const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
 
 export function fmtTokens(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
@@ -152,6 +155,56 @@ export function renderReport(
   }
 
   out.push(`\n${DIM}Cost figures marked ~ use placeholder prices — edit src/pricing.ts.${RESET}\n`);
+  return out.join('\n');
+}
+
+const TREND_COLOR: Record<TrendVerdict, string> = {
+  better: GREEN,
+  worse: RED,
+  neutral: '',
+  flat: DIM,
+};
+
+function trendDelta(r: TrendRow): string {
+  const d = r.now - r.prev;
+  const arrow = verdictOf(r) === 'flat' ? '→' : d > 0 ? '↑' : '↓';
+  const color = TREND_COLOR[verdictOf(r)];
+  return `${color}${arrow} ${d >= 0 ? '+' : '−'}${fmtTrendValue(r, Math.abs(d))}${color ? RESET : ''}`;
+}
+
+export function renderTrend(
+  current: StoredEvent[],
+  previous: StoredEvent[],
+  days: number,
+): string {
+  const out: string[] = [];
+  out.push(section(`Trend — last ${days} days vs the ${days} before`));
+  if (previous.length === 0) {
+    out.push(`  ${DIM}No events in the previous window — trends appear once two windows of data exist.${RESET}`);
+    return out.join('\n');
+  }
+  const rows = trendRows(computeMetrics(current), computeMetrics(previous));
+  out.push(
+    table(
+      ['Metric', 'Previous', 'Now', 'Change'],
+      rows.map((r) => [r.label, fmtTrendValue(r, r.prev), fmtTrendValue(r, r.now), trendDelta(r)]),
+    ),
+  );
+  const movers = projectMovers(current, previous);
+  if (movers.length) {
+    out.push(`\n  ${BOLD}Top project movers (spend)${RESET}`);
+    out.push(
+      table(
+        ['Project', 'Previous', 'Now', 'Change'],
+        movers.map((p) => [
+          p.project.length > 28 ? p.project.slice(0, 27) + '…' : p.project,
+          fmtTokens(p.prev),
+          fmtTokens(p.now),
+          `${p.delta >= 0 ? '+' : '−'}${fmtTokens(Math.abs(p.delta))}`,
+        ]),
+      ),
+    );
+  }
   return out.join('\n');
 }
 

--- a/src/trends.ts
+++ b/src/trends.ts
@@ -1,0 +1,107 @@
+import type { Metrics } from './metrics.js';
+import { computeMetrics, groupBy } from './metrics.js';
+import type { StoredEvent } from './store.js';
+
+/**
+ * Week-over-week direction: the report answers "where do tokens go",
+ * trends answer "is it getting better". Current window vs the previous
+ * same-length window, straight from stored events — no new state.
+ */
+
+export interface TrendRow {
+  label: string;
+  prev: number;
+  now: number;
+  fmt: 'tokens' | 'usd' | 'pct' | 'ratio' | 'int';
+  /** Direction that counts as an improvement; undefined = neutral (volume). */
+  good?: 'up' | 'down';
+}
+
+/** Partition events loaded over a 2×days window at the days boundary. */
+export function splitWindow(
+  events: StoredEvent[],
+  days: number,
+  nowMs: number = Date.now(),
+): { current: StoredEvent[]; previous: StoredEvent[] } {
+  const cutoff = new Date(nowMs - days * 86_400_000).toISOString();
+  const current: StoredEvent[] = [];
+  const previous: StoredEvent[] = [];
+  for (const e of events) (e.ts >= cutoff ? current : previous).push(e);
+  return { current, previous };
+}
+
+export function trendRows(now: Metrics, prev: Metrics): TrendRow[] {
+  return [
+    { label: 'Spend tokens', prev: prev.spendTokens, now: now.spendTokens, fmt: 'tokens' },
+    { label: 'Est. cost', prev: prev.costUsd, now: now.costUsd, fmt: 'usd' },
+    { label: 'Sessions', prev: prev.sessions, now: now.sessions, fmt: 'int' },
+    { label: 'Cache hit', prev: prev.cacheHitRatio, now: now.cacheHitRatio, fmt: 'pct', good: 'up' },
+    { label: 'Rework', prev: prev.reworkRatio, now: now.reworkRatio, fmt: 'pct', good: 'down' },
+    { label: 'Think:code', prev: prev.thinkToCodeRatio, now: now.thinkToCodeRatio, fmt: 'ratio' },
+    { label: 'Context bloat', prev: prev.contextBloatShare, now: now.contextBloatShare, fmt: 'pct', good: 'down' },
+    { label: 'Cold restarts', prev: prev.coldRestartShare, now: now.coldRestartShare, fmt: 'pct', good: 'down' },
+    { label: 'Premium on exploration/chat', prev: prev.premiumWasteShare, now: now.premiumWasteShare, fmt: 'pct', good: 'down' },
+    { label: 'Retry loops', prev: prev.retryShare, now: now.retryShare, fmt: 'pct', good: 'down' },
+  ];
+}
+
+/** Flat-change tolerance so rounding noise doesn't get an arrow. */
+const FLAT = 0.005;
+
+export type TrendVerdict = 'better' | 'worse' | 'flat' | 'neutral';
+
+export function verdictOf(r: TrendRow): TrendVerdict {
+  const d = r.now - r.prev;
+  // Flat when the change wouldn't even show at display precision.
+  if (r.fmt === 'pct' && Math.abs(d) < 0.0005) return 'flat';
+  if (r.fmt === 'ratio' && Math.abs(d) < 0.005) return 'flat';
+  const base = Math.max(Math.abs(r.prev), Math.abs(r.now), 1e-9);
+  if (Math.abs(d / base) < FLAT) return 'flat';
+  if (!r.good) return 'neutral';
+  return (d > 0) === (r.good === 'up') ? 'better' : 'worse';
+}
+
+export function fmtTrendValue(r: TrendRow, v: number): string {
+  switch (r.fmt) {
+    case 'usd':
+      return '$' + v.toFixed(2);
+    case 'pct':
+      return (v * 100).toFixed(1) + '%';
+    case 'ratio':
+      return v.toFixed(2);
+    case 'int':
+      return String(Math.round(v));
+    case 'tokens':
+      if (v >= 1_000_000) return (v / 1_000_000).toFixed(1) + 'M';
+      if (v >= 1_000) return (v / 1_000).toFixed(1) + 'k';
+      return String(Math.round(v));
+  }
+}
+
+export interface ProjectMove {
+  project: string;
+  prev: number;
+  now: number;
+  delta: number;
+}
+
+/** Top projects by absolute spend-token change between the windows. */
+export function projectMovers(
+  current: StoredEvent[],
+  previous: StoredEvent[],
+  top = 5,
+): ProjectMove[] {
+  const spend = (evs: StoredEvent[]) =>
+    new Map([...groupBy(evs, 'project')].map(([p, e]) => [p, computeMetrics(e).spendTokens]));
+  const nowBy = spend(current);
+  const prevBy = spend(previous);
+  const projects = new Set([...nowBy.keys(), ...prevBy.keys()]);
+  return [...projects]
+    .map((project) => {
+      const now = nowBy.get(project) ?? 0;
+      const prev = prevBy.get(project) ?? 0;
+      return { project, prev, now, delta: now - prev };
+    })
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+    .slice(0, top);
+}

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -160,6 +160,13 @@ test('e2e: merge rejects an invalid --by axis', () => {
   assert.match(stderr, /--by must be/);
 });
 
+test('e2e: report --trend renders the trend section (empty previous window)', () => {
+  const { stdout, code } = run(['report', '--trend', ...DAYS]);
+  assert.equal(code, 0);
+  assert.ok(stdout.includes('Trend — last 36500 days vs the 36500 before'));
+  assert.ok(stdout.includes('No events in the previous window'));
+});
+
 test('e2e: html writes a self-contained dashboard', () => {
   const out = join(HOME, 'dash.html');
   const { code } = run(['html', '--out', out, ...DAYS]);

--- a/test/trends.test.ts
+++ b/test/trends.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { splitWindow, trendRows, verdictOf, fmtTrendValue, projectMovers } from '../src/trends.js';
+import { computeMetrics } from '../src/metrics.js';
+import { makeStored } from './helpers.js';
+
+const NOW = Date.parse('2026-06-13T00:00:00Z');
+const daysAgo = (n: number) => new Date(NOW - n * 86_400_000).toISOString();
+
+test('splitWindow partitions at the days boundary', () => {
+  const events = [
+    makeStored({ ts: daysAgo(40) }), // previous window
+    makeStored({ ts: daysAgo(31) }), // previous window
+    makeStored({ ts: daysAgo(29) }), // current window
+    makeStored({ ts: daysAgo(1) }), // current window
+  ];
+  const { current, previous } = splitWindow(events, 30, NOW);
+  assert.equal(current.length, 2);
+  assert.equal(previous.length, 2);
+  assert.ok(current.every((e) => e.ts >= daysAgo(30)));
+});
+
+test('verdictOf: improvement direction per metric, flat tolerance, neutral volumes', () => {
+  const prev = computeMetrics([
+    makeStored({ activity: 'coding', input_tokens: 1000, output_tokens: 0 }),
+  ]);
+  const now = computeMetrics([
+    makeStored({ activity: 'coding', input_tokens: 1000, output_tokens: 0, cache_read_tokens: 4000 }),
+  ]);
+  const rows = trendRows(now, prev);
+  const by = (label: string) => rows.find((r) => r.label === label)!;
+
+  assert.equal(verdictOf(by('Cache hit')), 'better'); // up + good:up
+  assert.equal(verdictOf(by('Spend tokens')), 'flat'); // unchanged
+  assert.equal(verdictOf(by('Rework')), 'flat'); // 0 -> 0
+
+  // rework rising = worse; spend rising = neutral
+  assert.equal(verdictOf({ label: 'Rework', prev: 0.1, now: 0.3, fmt: 'pct', good: 'down' }), 'worse');
+  assert.equal(verdictOf({ label: 'Spend tokens', prev: 1000, now: 5000, fmt: 'tokens' }), 'neutral');
+});
+
+test('fmtTrendValue formats by kind', () => {
+  assert.equal(fmtTrendValue({ label: '', prev: 0, now: 0, fmt: 'tokens' }, 1_234_000), '1.2M');
+  assert.equal(fmtTrendValue({ label: '', prev: 0, now: 0, fmt: 'usd' }, 12.345), '$12.35');
+  assert.equal(fmtTrendValue({ label: '', prev: 0, now: 0, fmt: 'pct' }, 0.123), '12.3%');
+  assert.equal(fmtTrendValue({ label: '', prev: 0, now: 0, fmt: 'ratio' }, 1.234), '1.23');
+  assert.equal(fmtTrendValue({ label: '', prev: 0, now: 0, fmt: 'int' }, 7), '7');
+});
+
+test('projectMovers ranks by absolute spend delta and includes vanished projects', () => {
+  const current = [
+    makeStored({ project: 'grew', input_tokens: 10_000, output_tokens: 0 }),
+    makeStored({ project: 'steady', input_tokens: 1000, output_tokens: 0 }),
+  ];
+  const previous = [
+    makeStored({ project: 'grew', input_tokens: 1000, output_tokens: 0 }),
+    makeStored({ project: 'steady', input_tokens: 1000, output_tokens: 0 }),
+    makeStored({ project: 'gone', input_tokens: 5000, output_tokens: 0 }),
+  ];
+  const movers = projectMovers(current, previous);
+  assert.equal(movers[0].project, 'grew');
+  assert.equal(movers[0].delta, 9000);
+  assert.equal(movers[1].project, 'gone');
+  assert.equal(movers[1].delta, -5000);
+  assert.equal(movers[2].project, 'steady');
+  assert.equal(movers[2].delta, 0);
+});


### PR DESCRIPTION
Closes #37 (milestone 5).

- `report --trend`: compares the last N days against the N before — spend, cost, sessions, cache hit, rework, think:code, and the four v0.6 signals. Direction arrows colored by whether the move is an improvement (volumes stay neutral); changes below display precision render as flat (`→`), never as a red `+0.0%`.
- **Top project movers** by absolute spend delta, including projects that vanished or appeared.
- HTML dashboard includes the trend section automatically when the previous window has data.
- One `2×days` query partitioned at the boundary (`splitWindow`), so the report slice and comparison share the same cutoff. No schema change, no new state.

Tests: window partition, verdict directions + flat tolerances, value formats, mover ranking; e2e exercises `--trend` with an empty previous window. 98 tests pass. Validated on real data (15d vs 15d): rework up 7pt flagged red, premium-on-exploration down 3.9pt flagged green, movers match known projects.