### PR TITLE
feat: recommendations 3.0 — personalized targets, realized savings, de-overlapped potential

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ Every threshold-fired recommendation answers "why should I believe this and what
 
 These show up in `report`, `analyze`, the HTML dashboard, and ride along in signed exports (`recommendationDetails`).
 
+Three more pieces of intelligence:
+
+- **Personalized targets** — with enough sessions, targets come from *your own* top-quartile sessions ("your best sessions already hit 92% cache") instead of static heuristics; thin data falls back to the static targets.
+- **Honest combined math** — overlapping levers are grouped into families (caching / routing / rework) and de-overlapped, giving one headline: `Potential: $18.8k/mo → $8.9k/mo (routing −$9.2k · caching −$712)`. Recommendations sort by their marginal value.
+- **Realized savings** — once a tracked recommendation's metric moves, follow-through prices the move: `Realized +$70/mo`. The advice proves (or disproves) its own worth.
+
 ## Follow-through
 
 Recommendations are tracked, not just printed. The first time one fires, its target metric is recorded as a baseline; every later report re-measures and shows the delta:

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -7,7 +7,7 @@ import { structuredFindings } from './followthrough.js';
 import type { Activity } from './types.js';
 import { ACTIVITIES } from './types.js';
 import { table, section, fmtTokens, renderEnrichedRecs } from './report.js';
-import { enrichFindings } from './recommendations.js';
+import { enrichFindings, potentialBill, fmtPotential } from './recommendations.js';
 
 /**
  * Deeper, session-level analysis. The report answers "where do tokens go";
@@ -327,6 +327,8 @@ export function renderAnalysis(events: StoredEvent[], days: number): string {
   const recs = enrichFindings(events, m, days);
   if (recs.length) {
     out.push(`\n${'\x1b[1m'}\x1b[32mRecommendations (evidence-cited)\x1b[0m`);
+    const potential = potentialBill(recs, m, days);
+    if (potential) out.push(`  ${'\x1b[1m'}${fmtPotential(potential)}\x1b[0m`);
     out.push(...renderEnrichedRecs(recs));
   }
   out.push(

--- a/src/html.ts
+++ b/src/html.ts
@@ -8,7 +8,7 @@ import { fmtMetric } from './followthrough.js';
 import { fmtTokens } from './report.js';
 import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
 import { mergeMetrics, rollupExports, displayName } from './team.js';
-import { enrichFindings, fmtSavings, fmtEvidence } from './recommendations.js';
+import { enrichFindings, fmtSavings, fmtEvidence, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
 
 const ACTIVITY_COLORS: Record<string, string> = {
@@ -119,13 +119,14 @@ export function renderHtml(
 <table><tr><th>Project</th><th>Previous</th><th>Now</th><th>Change</th></tr>${movers}</table>`;
   }
 
+  const rates = blendedRates(m);
   const followSection =
     opts.follow && opts.follow.length
-      ? `<h2>Follow-through</h2><table><tr><th>Recommendation</th><th>Metric</th><th>Baseline</th><th>Now</th><th>Since</th><th>Status</th></tr>${opts.follow
-          .map(
-            (f) =>
-              `<tr><td>${esc(f.key)}</td><td>${f.metric}</td><td class="num">${fmtMetric(f.metric, f.baseline)}</td><td class="num">${fmtMetric(f.metric, f.current)}</td><td>${f.createdAt.slice(0, 10)}</td><td class="st-${f.status}">${f.status}</td></tr>`,
-          )
+      ? `<h2>Follow-through</h2><table><tr><th>Recommendation</th><th>Metric</th><th>Baseline</th><th>Now</th><th>Realized</th><th>Since</th><th>Status</th></tr>${opts.follow
+          .map((f) => {
+            const realized = realizedMonthly(f, m, rates, opts.days);
+            return `<tr><td>${esc(f.key)}</td><td>${f.metric}</td><td class="num">${fmtMetric(f.metric, f.baseline)}</td><td class="num">${fmtMetric(f.metric, f.current)}</td><td class="num">${realized ? `<span class="save">+${fmtUsdShort(realized)}/mo</span>` : '<span class="muted">—</span>'}</td><td>${f.createdAt.slice(0, 10)}</td><td class="st-${f.status}">${f.status}</td></tr>`;
+          })
           .join('')}</table>`
       : '';
 
@@ -149,6 +150,7 @@ ${trendSection}
 <div class="persona">
   <h3>${persona.emoji} ${esc(persona.name)}</h3>
   <div class="muted">${esc(persona.description)}</div>
+  ${(() => { const p = potentialBill(enriched, m, opts.days); return p ? `<div class="potential">${esc(fmtPotential(p))}</div>` : ''; })()}
   <ul class="recs">${recItems}</ul>
 </div>
 ${followSection}`,
@@ -182,6 +184,7 @@ function pageShell(title: string, body: string): string {
   ul.recs { margin:.4rem 0 0; padding-left:1.2rem; } ul.recs li { margin:.3rem 0; }
   .save { color:#5dc98a; font-weight:600; white-space:nowrap; }
   .ev { font-size:.8rem; margin-top:.15rem; }
+  .potential { margin:.5rem 0 .2rem; font-weight:600; color:#9fd45d; }
   .st-resolved { color:#5dc98a; } .st-regressing { color:#e88f68; } .st-improving { color:#9fd45d; }
   footer { margin:2.5rem 0 1rem; font-size:.8rem; color:#717a8a; }
 </style></head><body>

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -1,8 +1,8 @@
 import type { Metrics } from './metrics.js';
 import { computeMetrics, groupBy, contextGrowthOf, BLOAT_MIN_TURNS } from './metrics.js';
 import type { StoredEvent } from './store.js';
-import type { Finding } from './followthrough.js';
-import { structuredFindings, premiumShare } from './followthrough.js';
+import type { Finding, FollowRow, MetricKey } from './followthrough.js';
+import { structuredFindings, premiumShare, fmtMetric } from './followthrough.js';
 import { PRICES, PREMIUM_MODEL_RE } from './pricing.js';
 import { fmtTokens } from './report.js';
 
@@ -31,15 +31,60 @@ export interface EnrichedRec extends Finding {
   savingsUsdPerMonth?: number;
   /** True when placeholder/estimated prices or a tier assumption fed the number. */
   savingsEstimated: boolean;
+  /** The improvement target the savings assume; personal = user's own top quartile. */
+  target?: Target;
 }
 
-/** Improvement targets used for the savings math, per finding key. */
+/** Static fallback targets for the savings math, per finding key. */
 const TARGETS: Record<string, number> = {
   'low-cache-hit': 0.8, // cache hit ratio to reach
   'high-rework': 0.1, // rework ratio to reach
   'premium-model-overuse': 0.5, // premium share to reach
   'cold-restarts': 0.05, // cold-restart share to reach
 };
+
+/**
+ * Session-skill metrics get personalized targets: with enough qualifying
+ * sessions, the target is the top quartile of the user's OWN sessions —
+ * "your best sessions prove this is reachable". Model-routing targets stay
+ * static (model choice isn't a per-session skill).
+ */
+const PERSONAL_TARGET: Record<string, { metric: (m: Metrics) => number; direction: 'up' | 'down' }> = {
+  'low-cache-hit': { metric: (m) => m.cacheHitRatio, direction: 'up' },
+  'high-rework': { metric: (m) => m.reworkRatio, direction: 'down' },
+  'cold-restarts': { metric: (m) => m.coldRestartShare, direction: 'down' },
+};
+
+const PERSONAL_MIN_SESSIONS = 8;
+const PERSONAL_MIN_SPEND = 10_000; // ignore trivial sessions when benchmarking
+
+export interface Target {
+  value: number;
+  /** True when derived from the user's own top-quartile sessions. */
+  personal: boolean;
+}
+
+function quantile(sorted: number[], q: number): number {
+  const pos = (sorted.length - 1) * q;
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo);
+}
+
+export function targetFor(key: string, sessions: SessionInfo[]): Target | undefined {
+  const spec = PERSONAL_TARGET[key];
+  if (spec) {
+    const values = sessions
+      .filter((s) => s.m.spendTokens >= PERSONAL_MIN_SPEND)
+      .map((s) => spec.metric(s.m))
+      .sort((a, b) => a - b);
+    if (values.length >= PERSONAL_MIN_SESSIONS) {
+      // best quartile in the metric's good direction
+      return { value: quantile(values, spec.direction === 'up' ? 0.75 : 0.25), personal: true };
+    }
+  }
+  return key in TARGETS ? { value: TARGETS[key], personal: false } : undefined;
+}
 
 interface SessionInfo {
   sessionId: string;
@@ -159,24 +204,30 @@ const SCORERS: Record<string, (s: SessionInfo) => { score: number; label: string
 };
 
 /** Estimated $ saved over the report window if the finding's metric hit its target. */
-function savingsUsd(key: string, m: Metrics, rates: BlendedRates, sessions: SessionInfo[]): number | undefined {
+function savingsUsd(
+  key: string,
+  m: Metrics,
+  rates: BlendedRates,
+  sessions: SessionInfo[],
+  target?: Target,
+): number | undefined {
   const inputSide = m.cacheReadTokens + m.inputTokens + m.cacheCreationTokens;
   switch (key) {
     case 'low-cache-hit': {
       // Tokens that would shift from fresh input to cache reads.
-      const moved = Math.max(0, TARGETS[key] - m.cacheHitRatio) * inputSide;
+      const moved = Math.max(0, (target?.value ?? 0) - m.cacheHitRatio) * inputSide;
       return moved * (rates.input - rates.cacheRead);
     }
     case 'high-rework':
-      return Math.max(0, m.reworkRatio - TARGETS[key]) * m.spendTokens * rates.spend;
+      return Math.max(0, m.reworkRatio - (target?.value ?? 0)) * m.spendTokens * rates.spend;
     case 'premium-model-overuse': {
-      const moved = Math.max(0, premiumShare(m) - TARGETS[key]) * m.spendTokens;
+      const moved = Math.max(0, premiumShare(m) - (target?.value ?? 0)) * m.spendTokens;
       return moved * Math.max(0, rates.premium - rates.cheap);
     }
     case 'premium-misroute':
       return m.premiumWasteTokens * Math.max(0, rates.premium - rates.cheap);
     case 'cold-restarts': {
-      const saved = Math.max(0, m.coldRestartShare - TARGETS[key]) * (m.inputTokens + m.cacheCreationTokens);
+      const saved = Math.max(0, m.coldRestartShare - (target?.value ?? 0)) * (m.inputTokens + m.cacheCreationTokens);
       return saved * (rates.input - rates.cacheRead);
     }
     case 'context-bloat': {
@@ -207,24 +258,121 @@ export function enrichFindings(events: StoredEvent[], m: Metrics, days: number):
   const rates = blendedRates(m);
   const monthly = days > 0 ? 30 / days : 1;
 
-  return findings.map((f) => {
-    const scorer = SCORERS[f.key];
-    const evidence = scorer
-      ? sessions
-          .map((s) => ({ s, ...scorer(s) }))
-          .filter((x) => x.score > 0)
-          .sort((a, b) => b.score - a.score)
-          .slice(0, 3)
-          .map(({ s, label }) => ({ sessionId: s.sessionId, project: s.project, date: s.date, label }))
-      : [];
-    const usd = savingsUsd(f.key, m, rates, sessions);
-    return {
-      ...f,
-      evidence,
-      savingsUsdPerMonth: usd !== undefined && usd > 0 ? usd * monthly : undefined,
-      savingsEstimated: rates.estimated,
-    };
-  });
+  return findings
+    .map((f) => {
+      const scorer = SCORERS[f.key];
+      const evidence = scorer
+        ? sessions
+            .map((s) => ({ s, ...scorer(s) }))
+            .filter((x) => x.score > 0)
+            .sort((a, b) => b.score - a.score)
+            .slice(0, 3)
+            .map(({ s, label }) => ({ sessionId: s.sessionId, project: s.project, date: s.date, label }))
+        : [];
+      const target = targetFor(f.key, sessions);
+      const usd = savingsUsd(f.key, m, rates, sessions, target);
+      const message = target?.personal
+        ? `${f.message} Your own top-quartile sessions already run at ${fmtMetric(f.metric, target.value)} — the target below assumes only that.`
+        : f.message;
+      return {
+        ...f,
+        message,
+        evidence,
+        target,
+        savingsUsdPerMonth: usd !== undefined && usd > 0 ? usd * monthly : undefined,
+        savingsEstimated: rates.estimated,
+      };
+    })
+    // biggest lever first; unquantified recs keep their firing order at the end
+    .sort((a, b) => (b.savingsUsdPerMonth ?? -1) - (a.savingsUsdPerMonth ?? -1));
+}
+
+/**
+ * Per-rec savings overlap (misroute tokens are a subset of overuse tokens;
+ * cold-restart tokens overlap the cache-hit gap). Group levers into families,
+ * take the max within each, sum across — an honest combined number.
+ */
+const FAMILIES: Array<{ family: string; keys: string[] }> = [
+  { family: 'caching', keys: ['low-cache-hit', 'cold-restarts', 'context-bloat'] },
+  { family: 'routing', keys: ['premium-model-overuse', 'premium-misroute'] },
+  { family: 'rework', keys: ['high-rework', 'tool-retry-loops'] },
+];
+
+export interface PotentialBill {
+  currentUsdPerMonth: number;
+  potentialUsdPerMonth: number;
+  families: Array<{ family: string; usdPerMonth: number }>;
+  estimated: boolean;
+}
+
+export function potentialBill(recs: EnrichedRec[], m: Metrics, days: number): PotentialBill | undefined {
+  const families = FAMILIES.map(({ family, keys }) => ({
+    family,
+    usdPerMonth: Math.max(
+      0,
+      ...recs.filter((r) => keys.includes(r.key)).map((r) => r.savingsUsdPerMonth ?? 0),
+    ),
+  })).filter((f) => f.usdPerMonth > 0);
+  if (families.length === 0) return undefined;
+  const currentUsdPerMonth = m.costUsd * (days > 0 ? 30 / days : 1);
+  const saved = families.reduce((s, f) => s + f.usdPerMonth, 0);
+  return {
+    currentUsdPerMonth,
+    potentialUsdPerMonth: Math.max(0, currentUsdPerMonth - saved),
+    families: families.sort((a, b) => b.usdPerMonth - a.usdPerMonth),
+    estimated: recs.some((r) => r.savingsEstimated) || m.costEstimated,
+  };
+}
+
+export function fmtUsdShort(n: number): string {
+  if (n >= 1_000) return '$' + (n / 1000).toFixed(1) + 'k';
+  if (n >= 100) return '$' + n.toFixed(0);
+  return '$' + n.toFixed(2);
+}
+
+/** One-line headline: "~$18.7k/mo → ~$7.0k/mo (routing −$9.2k · caching −$581)". */
+export function fmtPotential(p: PotentialBill): string {
+  const t = p.estimated ? '~' : '';
+  const parts = p.families.map((f) => `${f.family} −${fmtUsdShort(f.usdPerMonth)}`).join(' · ');
+  return `Potential: ${t}${fmtUsdShort(p.currentUsdPerMonth)}/mo → ${t}${fmtUsdShort(p.potentialUsdPerMonth)}/mo (${parts})`;
+}
+
+/**
+ * Realized $/month for a tracked recommendation: the baseline→current metric
+ * move priced at the CURRENT mix and volume — an approximation (the baseline
+ * window had different volume), but it answers "was the advice worth taking".
+ */
+export function realizedMonthly(
+  row: FollowRow,
+  m: Metrics,
+  rates: BlendedRates,
+  days: number,
+): number | undefined {
+  const improvement = row.direction === 'up' ? row.current - row.baseline : row.baseline - row.current;
+  if (improvement <= 0.02) return undefined; // below follow-through's own noise threshold
+  const perPoint = unitValuePerPoint(row.metric, m, rates);
+  if (perPoint === undefined) return undefined;
+  const usd = improvement * perPoint * (days > 0 ? 30 / days : 1);
+  return usd > 0 ? usd : undefined;
+}
+
+/** $ value of a full 1.0 move in the metric, at the current window's volumes. */
+function unitValuePerPoint(metric: MetricKey, m: Metrics, rates: BlendedRates): number | undefined {
+  const inputSide = m.cacheReadTokens + m.inputTokens + m.cacheCreationTokens;
+  switch (metric) {
+    case 'cacheHitRatio':
+      return inputSide * (rates.input - rates.cacheRead);
+    case 'reworkRatio':
+    case 'retryShare':
+      return m.spendTokens * rates.spend;
+    case 'premiumShare':
+    case 'premiumWasteShare':
+      return m.spendTokens * Math.max(0, rates.premium - rates.cheap);
+    case 'coldRestartShare':
+      return (m.inputTokens + m.cacheCreationTokens) * (rates.input - rates.cacheRead);
+    default:
+      return undefined; // thinkToCodeRatio, contextBloatShare: not $-translatable
+  }
 }
 
 /** "≈ ~$84/mo" — shared by the terminal report, analyze, and the dashboard. */

--- a/src/report.ts
+++ b/src/report.ts
@@ -8,7 +8,7 @@ import { mergeMetrics, rollupExports, dominantActivity, displayName } from './te
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
 import type { EnrichedRec } from './recommendations.js';
-import { enrichFindings, fmtSavings, fmtEvidence } from './recommendations.js';
+import { enrichFindings, fmtSavings, fmtEvidence, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
 import type { TrendRow, TrendVerdict } from './trends.js';
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
 
@@ -134,22 +134,30 @@ export function renderReport(
   out.push(section(`Overall persona: ${persona.emoji} ${persona.name}`));
   out.push(`  ${persona.description}\n`);
   out.push(`${BOLD}${GREEN}Recommendations${RESET}`);
+  const enriched = enrichFindings(events, m, opts.days);
+  const potential = potentialBill(enriched, m, opts.days);
+  if (potential) out.push(`  ${BOLD}${fmtPotential(potential)}${RESET}`);
   for (const r of persona.recommendations) out.push(`  ${YELLOW}→${RESET} ${r}`);
-  out.push(...renderEnrichedRecs(enrichFindings(events, m, opts.days)));
+  out.push(...renderEnrichedRecs(enriched));
 
   if (opts.follow && opts.follow.length > 0) {
+    const rates = blendedRates(m);
     out.push(section('Follow-through (recommendation → measured change)'));
     out.push(
       table(
-        ['Recommendation', 'Metric', 'Baseline', 'Now', 'Since', 'Status'],
-        opts.follow.map((f) => [
-          f.key,
-          f.metric,
-          fmtMetric(f.metric, f.baseline),
-          fmtMetric(f.metric, f.current),
-          f.createdAt.slice(0, 10),
-          STATUS_LABEL[f.status],
-        ]),
+        ['Recommendation', 'Metric', 'Baseline', 'Now', 'Realized', 'Since', 'Status'],
+        opts.follow.map((f) => {
+          const realized = realizedMonthly(f, m, rates, opts.days);
+          return [
+            f.key,
+            f.metric,
+            fmtMetric(f.metric, f.baseline),
+            fmtMetric(f.metric, f.current),
+            realized ? `${GREEN}+${fmtUsdShort(realized)}/mo${RESET}` : `${DIM}—${RESET}`,
+            f.createdAt.slice(0, 10),
+            STATUS_LABEL[f.status],
+          ];
+        }),
       ),
     );
   }

--- a/test/recommendations.test.ts
+++ b/test/recommendations.test.ts
@@ -1,9 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { computeMetrics } from '../src/metrics.js';
-import { blendedRates, enrichFindings, fmtSavings, fmtEvidence } from '../src/recommendations.js';
+import { blendedRates, enrichFindings, fmtSavings, fmtEvidence, potentialBill, fmtPotential, realizedMonthly, fmtUsdShort } from '../src/recommendations.js';
 import { makeStored } from './helpers.js';
 import type { StoredEvent } from '../src/store.js';
+import type { FollowRow } from '../src/followthrough.js';
 
 test('blendedRates: mix-weighted prices, cheap tier from the user\'s own mix', () => {
   const m = computeMetrics([
@@ -80,6 +81,100 @@ test('fmtSavings marks estimated prices with ~; fmtEvidence truncates session id
   assert.equal(rec.savingsEstimated, true); // cheap tier assumed (premium-only mix)
   assert.match(fmtSavings(rec)!, /^≈ ~\$/);
   assert.match(fmtEvidence(rec)!, /^worst: a-very-l \(proj, 2026-06-01/);
+});
+
+// 12 sessions, no cache reads anywhere except 4 strong sessions at ~90% —
+// enough data for a personalized cache-hit target at the top quartile.
+function selfBenchmarkEvents(): StoredEvent[] {
+  const out: StoredEvent[] = [];
+  for (let i = 0; i < 12; i++) {
+    const strong = i < 4;
+    out.push(
+      makeStored({
+        session_id: `s${i}`,
+        ts: `2026-06-0${(i % 9) + 1}T00:00:00Z`,
+        activity: 'coding',
+        input_tokens: 50_000,
+        output_tokens: 0,
+        // strong sessions hit ~67%; overall stays at 40% so the finding fires
+        cache_read_tokens: strong ? 100_000 : 0,
+      }),
+    );
+  }
+  return out;
+}
+
+test('personalized target: enough sessions -> own top quartile, message cites it', () => {
+  const events = selfBenchmarkEvents();
+  const m = computeMetrics(events);
+  const rec = enrichFindings(events, m, 30).find((r) => r.key === 'low-cache-hit');
+  assert.ok(rec); // overall hit ratio is well below 50%
+  assert.ok(rec.target?.personal);
+  // p75 of [0×8, 0.9×4] sits between the cold mass and the strong sessions
+  assert.ok(rec.target!.value > 0.5 && rec.target!.value <= 0.9);
+  assert.match(rec.message, /top-quartile sessions already run at/);
+});
+
+test('personalized target: thin data falls back to the static target', () => {
+  const events = [
+    makeStored({ session_id: 'only', activity: 'coding', input_tokens: 200_000, output_tokens: 0 }),
+  ];
+  const m = computeMetrics(events);
+  const rec = enrichFindings(events, m, 30).find((r) => r.key === 'low-cache-hit');
+  assert.ok(rec);
+  assert.equal(rec.target?.personal, false);
+  assert.equal(rec.target?.value, 0.8);
+  assert.ok(!rec.message.includes('top-quartile'));
+});
+
+test('enriched recs sort by savings, biggest lever first', () => {
+  const events = misrouteEvents();
+  const recs = enrichFindings(events, computeMetrics(events), 30);
+  const quantified = recs.filter((r) => r.savingsUsdPerMonth !== undefined);
+  for (let i = 1; i < quantified.length; i++) {
+    assert.ok(quantified[i - 1].savingsUsdPerMonth! >= quantified[i].savingsUsdPerMonth!);
+  }
+  // unquantified recs come last
+  const firstUnq = recs.findIndex((r) => r.savingsUsdPerMonth === undefined);
+  if (firstUnq !== -1) assert.ok(recs.slice(firstUnq).every((r) => r.savingsUsdPerMonth === undefined));
+});
+
+test('potentialBill de-overlaps within families instead of summing', () => {
+  const events = misrouteEvents();
+  const m = computeMetrics(events);
+  const recs = enrichFindings(events, m, 30);
+  const overuse = recs.find((r) => r.key === 'premium-model-overuse')!.savingsUsdPerMonth!;
+  const misroute = recs.find((r) => r.key === 'premium-misroute')!.savingsUsdPerMonth!;
+  const p = potentialBill(recs, m, 30)!;
+  const routing = p.families.find((f) => f.family === 'routing')!;
+  // family takes the max of the overlapping levers, never the sum
+  assert.ok(Math.abs(routing.usdPerMonth - Math.max(overuse, misroute)) < 1e-9);
+  assert.ok(routing.usdPerMonth < overuse + misroute);
+  assert.ok(p.potentialUsdPerMonth < p.currentUsdPerMonth);
+  assert.match(fmtPotential(p), /^Potential: .*\/mo → .*\/mo \(/);
+});
+
+test('realizedMonthly prices the baseline->current move; flat rows stay blank', () => {
+  const events = misrouteEvents();
+  const m = computeMetrics(events);
+  const rates = blendedRates(m);
+  const row = (current: number): FollowRow => ({
+    key: 'low-cache-hit', metric: 'cacheHitRatio', direction: 'up',
+    baseline: 0.4, current, createdAt: '2026-06-01', status: 'improving',
+  });
+  const realized = realizedMonthly(row(0.6), m, rates, 30)!;
+  // 0.2 move × inputSide × (input − cacheRead)
+  const inputSide = m.cacheReadTokens + m.inputTokens + m.cacheCreationTokens;
+  assert.ok(Math.abs(realized - 0.2 * inputSide * (rates.input - rates.cacheRead)) < 1e-9);
+  assert.equal(realizedMonthly(row(0.41), m, rates, 30), undefined); // within noise
+  assert.equal(realizedMonthly(row(0.3), m, rates, 30), undefined); // regression
+});
+
+test('fmtUsdShort scales units', () => {
+  assert.equal(fmtUsdShort(18_700), '$18.7k');
+  assert.equal(fmtUsdShort(8_882), '$8.9k');
+  assert.equal(fmtUsdShort(581), '$581');
+  assert.equal(fmtUsdShort(2.4), '$2.40');
 });
 
 test('low-think-code stays unquantified but keeps its message and key', () => {


### PR DESCRIPTION
Closes #40 (milestone 5).

## Personalized targets (self-benchmarking)
For session-skill metrics (cache hit, rework, cold restarts), the savings target is now the **user's own top-quartile session value** (p75 for up-metrics, p25 for down) when ≥8 sessions of ≥10k spend exist — "your own top-quartile sessions already run at 1%". Falls back to the static targets on thin data; routing targets stay static (model choice isn't per-session skill).

## De-overlapped potential bill
Per-rec savings overlapped (misroute tokens ⊂ overuse tokens; cold-restart tokens overlap the cache-hit gap). Levers now group into **families** — caching, routing, rework — taking the max within each and summing across:

> Potential: $18.8k/mo → $8.9k/mo (routing −$9.2k · caching −$712)

Headline shows in report, analyze, and the dashboard; recommendations sort by marginal $.

## Realized savings (accountability)
Follow-through gains a **Realized** column: the baseline→current metric move priced at the current mix and volume (+$X/mo, green). Flat/regressing rows stay blank; thinkToCode and contextBloat are not $-translatable and stay blank by design.

## Tests
Personal-vs-static target selection (incl. a fixture where strong sessions must not mask the firing threshold), savings ordering, family de-overlap vs naive sum, realized math + noise threshold + regression blank, USD formatting. 104 tests pass. Real-data validated: headline above is this machine's actual output.

Rec keys unchanged throughout — existing follow-through baselines keep working.