### PR TITLE
feat: reconcile — cross-check local totals against provider usage APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
 token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline] [--verify] [--keys keys.json] [--json] [--html team.html]
+token-monitor reconcile [--provider anthropic|openai] [--days 30] [--db <path>]
 ```
 
 ## Contributing
@@ -228,7 +229,7 @@ The most valuable contribution: an adapter for another agent CLI (Aider, OpenCod
 - [x] IDE coverage: Cursor, Antigravity, Copilot Chat adapters
 - [ ] Adapters: Aider, OpenCode, Windsurf (needs a contributor with Windsurf — #12)
 - [x] VS Code-family extension: status-bar cost + dashboard webview
-- [ ] Org-level cross-check via provider usage APIs
+- [x] Org-level cross-check via provider usage APIs: `reconcile`
 - [x] npm publish: `npx @ryandemelo/token-monitor`
 
 ## Integrity & threat model
@@ -246,7 +247,18 @@ token-monitor merge exports/*.json --verify --keys keys.json
 
 `--verify` rejects any export modified after signing or unsigned; `--keys` additionally rejects exports signed by a key not enrolled for that username (impersonation).
 
-**What this does not cover — read before relying on it:** a developer controls their own machine, so someone determined to game metrics could edit the *source logs* before collection. Signing detects tampering after export, not dishonest inputs. The planned mitigation is reconciling team totals against the provider's billing/usage APIs (roadmap) — gamed numbers won't reconcile. Treat these metrics as a coaching instrument, not a performance-review weapon; the latter invites exactly the gaming this can't stop.
+**What this does not cover — read before relying on it:** a developer controls their own machine, so someone determined to game metrics could edit the *source logs* before collection. Signing detects tampering after export, not dishonest inputs. The mitigation is `reconcile` (below) — gamed numbers won't reconcile against the provider's billing data. Treat these metrics as a coaching instrument, not a performance-review weapon; the latter invites exactly the gaming this can't stop.
+
+### Reconcile against provider usage APIs
+
+`reconcile` cross-checks the local database against the provider's own usage report:
+
+```sh
+ANTHROPIC_ADMIN_KEY=sk-ant-admin... token-monitor reconcile --provider anthropic
+OPENAI_ADMIN_KEY=...               token-monitor reconcile --provider openai
+```
+
+Per model it shows local tokens, org-billed tokens, and a coverage %. The local db covers one machine while the API covers the whole org, so **local ≤ API is the expected state** — a model whose local total *exceeds* what the org was billed is the red flag (inflated or double-counted logs; exit code 1, so it's CI-able). The admin key is org-lead-only, read from the environment for that one run, and never stored, logged, or exported. Window is capped at 31 days (the APIs' daily-bucket limit). Supported: the Anthropic Admin API and the OpenAI Usage API. Both follow the providers' documented schemas and are exercised against mock servers in the test suite; live-org runs need an admin key, so report any schema drift you hit in an issue.
 
 ## Privacy
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { assignPersona, generalRecommendations } from './personas.js';
 import { buildExport, parseTeamConfig, mergeMetrics, dedupeExports, rollupExports, displayName, identityOf } from './team.js';
 import { syncFindings } from './followthrough.js';
 import { enrichFindings } from './recommendations.js';
+import { reconcile, renderReconcile, PROVIDERS } from './reconcile.js';
 import { computeMetrics } from './metrics.js';
 import { renderHtml, renderTeamHtml } from './html.js';
 import { renderAnalysis, deepAnalysis, buildLlmPrompt, runLlm, detectAgent } from './analyze.js';
@@ -30,6 +31,7 @@ Usage:
   token-monitor init    --from <url-or-path>
   token-monitor push    [--db <path>]
   token-monitor schedule [--hours <n>] [--remove]
+  token-monitor reconcile [--provider anthropic|openai] [--days <n>] [--db <path>]
   token-monitor fingerprint [--db <path>]
 
 Commands:
@@ -44,6 +46,9 @@ Commands:
             and (if configured) install the collection schedule
   push      Sign and deliver an export to the team destination from config
   schedule  Install/remove a recurring collect+push job (launchd/cron)
+  reconcile Cross-check local totals against the provider's usage API (org
+            lead only — needs ANTHROPIC_ADMIN_KEY or OPENAI_ADMIN_KEY in the
+            environment; the key is never stored). Local > API = red flag.
   fingerprint  Print this machine's signing-key fingerprint (for keyring enrollment)
 
 Integrity:
@@ -118,6 +123,7 @@ async function main() {
       keys: { type: 'string' },
       by: { type: 'string' },
       html: { type: 'string' },
+      provider: { type: 'string' },
       from: { type: 'string' },
       hours: { type: 'string' },
       remove: { type: 'boolean', default: false },
@@ -288,6 +294,22 @@ Signing fingerprint (send to your team lead for keys.json):
       }
       process.exit(runLlm(buildLlmPrompt(events, days), agent));
     }
+  } else if (cmd === 'reconcile') {
+    const provider = values.provider ?? 'anthropic';
+    if (!PROVIDERS[provider]) {
+      console.error(`Unknown provider "${provider}". Supported: ${Object.keys(PROVIDERS).join(', ')}`);
+      process.exit(1);
+    }
+    // Daily buckets cap the usage APIs at 31 days per request.
+    let days = Number(values.days) || 30;
+    if (days > 31) {
+      console.error(`--days capped at 31 (the usage APIs report at most 31 daily buckets); using 31.`);
+      days = 31;
+    }
+    const events = loadEvents(db, { days });
+    const { rows, breach } = await reconcile(provider, events, days);
+    console.log(renderReconcile(provider, rows, days));
+    if (breach) process.exit(1);
   } else if (cmd === 'html') {
     const days = Number(values.days) || 30;
     const { current: events, previous } = splitWindow(loadEvents(db, { days: days * 2 }), days);

--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -1,0 +1,235 @@
+import type { StoredEvent } from './store.js';
+import { table, section, fmtTokens } from './report.js';
+
+/**
+ * Cross-check local totals against the provider's usage API — the threat-model
+ * mitigation for "a developer can edit their own source logs": gamed numbers
+ * won't reconcile against billing data.
+ *
+ * The admin/usage key is read from an env var only. It is never stored, never
+ * written to config, and never included in exports. The API reports org-level
+ * usage while the local db covers one machine, so local ≤ API is the expected
+ * state; local > API is the red flag.
+ */
+
+export interface ProviderUsage {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+
+interface ProviderSpec {
+  keyEnv: string;
+  /** Test/self-host override for the API origin. */
+  urlEnv: string;
+  defaultUrl: string;
+  fetchUsage(baseUrl: string, key: string, startMs: number, endMs: number): Promise<ProviderUsage[]>;
+}
+
+async function getJson(url: string, headers: Record<string, string>): Promise<Record<string, unknown>> {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`${url.split('?')[0]} responded ${res.status}: ${body.slice(0, 300)}`);
+  }
+  return (await res.json()) as Record<string, unknown>;
+}
+
+const num = (v: unknown): number => (typeof v === 'number' ? v : 0);
+
+export const PROVIDERS: Record<string, ProviderSpec> = {
+  anthropic: {
+    keyEnv: 'ANTHROPIC_ADMIN_KEY',
+    urlEnv: 'TOKEN_MONITOR_ANTHROPIC_URL',
+    defaultUrl: 'https://api.anthropic.com',
+    // Admin API: GET /v1/organizations/usage_report/messages — grouped by
+    // model, daily buckets (max 31), paginated via has_more/next_page.
+    async fetchUsage(baseUrl, key, startMs, endMs) {
+      const byModel = new Map<string, ProviderUsage>();
+      let page: string | undefined;
+      do {
+        const params = new URLSearchParams({
+          starting_at: new Date(startMs).toISOString(),
+          ending_at: new Date(endMs).toISOString(),
+          bucket_width: '1d',
+          limit: '31',
+        });
+        params.append('group_by[]', 'model');
+        if (page) params.set('page', page);
+        const data = await getJson(`${baseUrl}/v1/organizations/usage_report/messages?${params}`, {
+          'x-api-key': key,
+          'anthropic-version': '2023-06-01',
+        });
+        for (const bucket of (data.data as Array<Record<string, unknown>>) ?? []) {
+          for (const r of (bucket.results as Array<Record<string, unknown>>) ?? []) {
+            const model = String(r.model ?? 'unknown');
+            const u = byModel.get(model) ?? {
+              model, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0,
+            };
+            u.inputTokens += num(r.uncached_input_tokens);
+            u.outputTokens += num(r.output_tokens);
+            u.cacheReadTokens += num(r.cache_read_input_tokens);
+            const cc = (r.cache_creation ?? {}) as Record<string, unknown>;
+            u.cacheCreationTokens += num(cc.ephemeral_5m_input_tokens) + num(cc.ephemeral_1h_input_tokens);
+            byModel.set(model, u);
+          }
+        }
+        page = data.has_more ? String(data.next_page) : undefined;
+      } while (page);
+      return [...byModel.values()];
+    },
+  },
+  openai: {
+    keyEnv: 'OPENAI_ADMIN_KEY',
+    urlEnv: 'TOKEN_MONITOR_OPENAI_URL',
+    defaultUrl: 'https://api.openai.com',
+    // Usage API: GET /v1/organization/usage/completions — unix-second range,
+    // grouped by model, paginated via has_more/next_page.
+    async fetchUsage(baseUrl, key, startMs, endMs) {
+      const byModel = new Map<string, ProviderUsage>();
+      let page: string | undefined;
+      do {
+        const params = new URLSearchParams({
+          start_time: String(Math.floor(startMs / 1000)),
+          end_time: String(Math.floor(endMs / 1000)),
+          bucket_width: '1d',
+          group_by: 'model',
+          limit: '31',
+        });
+        if (page) params.set('page', page);
+        const data = await getJson(`${baseUrl}/v1/organization/usage/completions?${params}`, {
+          authorization: `Bearer ${key}`,
+        });
+        for (const bucket of (data.data as Array<Record<string, unknown>>) ?? []) {
+          for (const r of (bucket.results as Array<Record<string, unknown>>) ?? []) {
+            const model = String(r.model ?? 'unknown');
+            const u = byModel.get(model) ?? {
+              model, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0,
+            };
+            // OpenAI's input_tokens INCLUDES cached tokens; split them out so
+            // the columns line up with the local fresh/cached separation.
+            u.inputTokens += num(r.input_tokens) - num(r.input_cached_tokens);
+            u.cacheReadTokens += num(r.input_cached_tokens);
+            u.outputTokens += num(r.output_tokens);
+            byModel.set(model, u);
+          }
+        }
+        page = data.has_more ? String(data.next_page) : undefined;
+      } while (page);
+      return [...byModel.values()];
+    },
+  },
+};
+
+export interface ReconcileRow {
+  model: string;
+  localTokens: number;
+  apiTokens: number;
+  /** local / api — how much of the org's usage this machine accounts for. */
+  coverage: number;
+  verdict: 'ok' | 'local-exceeds-api' | 'local-only';
+}
+
+/** Local > API beyond this tolerance = the red flag (clock skew, bucket snapping). */
+const TOLERANCE = 1.05;
+
+export function compareUsage(events: StoredEvent[], api: ProviderUsage[]): ReconcileRow[] {
+  const localByModel = new Map<string, number>();
+  for (const e of events) {
+    const t = e.input_tokens + e.output_tokens + e.cache_read_tokens + e.cache_creation_tokens;
+    localByModel.set(e.model, (localByModel.get(e.model) ?? 0) + t);
+  }
+  const total = (u: ProviderUsage) =>
+    u.inputTokens + u.outputTokens + u.cacheReadTokens + u.cacheCreationTokens;
+
+  const rows: ReconcileRow[] = [];
+  for (const u of api) {
+    const local = localByModel.get(u.model) ?? 0;
+    localByModel.delete(u.model);
+    const apiTokens = total(u);
+    rows.push({
+      model: u.model,
+      localTokens: local,
+      apiTokens,
+      coverage: apiTokens ? local / apiTokens : 0,
+      verdict: apiTokens && local > apiTokens * TOLERANCE ? 'local-exceeds-api' : 'ok',
+    });
+  }
+  // Models collected locally that the API doesn't report at all.
+  for (const [model, local] of localByModel) {
+    rows.push({ model, localTokens: local, apiTokens: 0, coverage: 0, verdict: 'local-only' });
+  }
+  return rows.sort((a, b) => b.apiTokens - a.apiTokens);
+}
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+
+const VERDICT_LABEL: Record<ReconcileRow['verdict'], string> = {
+  ok: `${GREEN}✓ reconciles${RESET}`,
+  'local-exceeds-api': `${RED}✗ local exceeds org usage — investigate${RESET}`,
+  'local-only': `${DIM}— not in API report${RESET}`,
+};
+
+export function renderReconcile(provider: string, rows: ReconcileRow[], days: number): string {
+  const out: string[] = [];
+  out.push(section(`Reconcile — local db vs ${provider} usage API, last ${days} days`));
+  if (rows.length === 0) {
+    out.push('  No usage on either side in the window.');
+    return out.join('\n');
+  }
+  out.push(
+    table(
+      ['Model', 'Local', 'Org API', 'Coverage', 'Verdict'],
+      rows.map((r) => [
+        r.model,
+        fmtTokens(r.localTokens),
+        r.apiTokens ? fmtTokens(r.apiTokens) : '—',
+        r.apiTokens ? (r.coverage * 100).toFixed(1) + '%' : '—',
+        VERDICT_LABEL[r.verdict],
+      ]),
+    ),
+  );
+  out.push(
+    `\n  ${DIM}Local covers this machine; the API covers the whole org — local ≤ API is expected.` +
+      `\n  Local > API means the local logs claim more than the org was billed for: tampered or` +
+      `\n  double-counted data. "Not in API report" can be other vendors' models or pre-window usage.${RESET}\n`,
+  );
+  return out.join('\n');
+}
+
+export interface ReconcileResult {
+  rows: ReconcileRow[];
+  /** True when any model's local total exceeds the org's billed usage. */
+  breach: boolean;
+}
+
+export async function reconcile(
+  provider: string,
+  events: StoredEvent[],
+  days: number,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ReconcileResult> {
+  const spec = PROVIDERS[provider];
+  if (!spec) {
+    throw new Error(`Unknown provider "${provider}". Supported: ${Object.keys(PROVIDERS).join(', ')}`);
+  }
+  const key = env[spec.keyEnv];
+  if (!key) {
+    throw new Error(
+      `${spec.keyEnv} is not set. Reconcile needs an admin/usage API key (org lead only) — ` +
+        `export it for this run, e.g. \`${spec.keyEnv}=... token-monitor reconcile --provider ${provider}\`. ` +
+        `The key is read from the environment only and never stored.`,
+    );
+  }
+  const endMs = Date.now();
+  const startMs = endMs - days * 86_400_000;
+  const baseUrl = (env[spec.urlEnv] || spec.defaultUrl).replace(/\/$/, '');
+  const usage = await spec.fetchUsage(baseUrl, key, startMs, endMs);
+  const rows = compareUsage(events, usage);
+  return { rows, breach: rows.some((r) => r.verdict === 'local-exceeds-api') };
+}

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -208,6 +208,95 @@ test('e2e: init from local config + push delivers a verifiable export', () => {
   assert.equal(verify.code, 0);
 });
 
+test('e2e: reconcile verifies local totals against a mock usage API', async () => {
+  const { createServer } = await import('node:http');
+  const { spawn } = await import('node:child_process');
+  // The mock server runs in THIS process — the CLI must run async (spawn, not
+  // spawnSync) or the blocked event loop can never serve the request.
+  const runAsync = (args: string[], env: NodeJS.ProcessEnv) =>
+    new Promise<{ stdout: string; stderr: string; status: number | null }>((resolve) => {
+      const child = spawn(process.execPath, [CLI, ...args], { env: { ...process.env, ...env } });
+      let stdout = '', stderr = '';
+      child.stdout.on('data', (d) => (stdout += d));
+      child.stderr.on('data', (d) => (stderr += d));
+      child.on('close', (status) => resolve({ stdout, stderr, status }));
+    });
+  // Fixture claude events: 3 turns of claude-opus-4-7. Org API reports more
+  // than local (normal) first, then less than local (tamper flag).
+  const mkBody = (uncached: number) => JSON.stringify({
+    data: [{
+      starting_at: '2026-06-01T00:00:00Z',
+      ending_at: '2026-06-02T00:00:00Z',
+      results: [{
+        model: 'claude-opus-4-7',
+        uncached_input_tokens: uncached,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+      }],
+    }],
+    has_more: false,
+  });
+  let body = mkBody(100_000_000);
+  const server = createServer((_req, res) => {
+    res.setHeader('content-type', 'application/json');
+    res.end(body);
+  });
+  const url: string = await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve(`http://127.0.0.1:${(server.address() as { port: number }).port}`);
+    });
+  });
+  try {
+    const runReconcile = (home: string) =>
+      runAsync(['reconcile', '--days', '31'], {
+        HOME: home, USERPROFILE: home,
+        ANTHROPIC_ADMIN_KEY: 'e2e-test-key',
+        TOKEN_MONITOR_ANTHROPIC_URL: url,
+      });
+
+    // Org reports far more than this machine collected — normal, reconciles.
+    const ok = await runReconcile(HOME);
+    assert.equal(ok.status, 0, ok.stderr);
+    assert.ok(ok.stdout.includes('Reconcile'));
+    assert.ok(ok.stdout.includes('claude-opus-4-7'));
+    assert.ok(ok.stdout.includes('reconciles'));
+
+    // Tamper case: a db whose local totals exceed what the org was billed.
+    const home3 = mkdtempSync(join(tmpdir(), 'tm-e2e-reconcile-'));
+    const { openDb, insertEvents } = await import('../src/store.js');
+    const db = openDb(join(home3, '.token-monitor', 'token-monitor.sqlite'));
+    insertEvents(db, [{
+      source: 'claude-code', eventKey: 'tamper-1', sessionId: 's', project: 'p',
+      timestamp: new Date().toISOString(), model: 'claude-opus-4-7',
+      inputTokens: 5000, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0,
+      thinkingTokens: 0, tools: [], commands: [], hasThinking: false, isError: false,
+    }]);
+    body = mkBody(1);
+    const tampered = await runReconcile(home3);
+    assert.equal(tampered.status, 1, tampered.stderr);
+    assert.ok(tampered.stdout.includes('investigate'));
+
+    // Missing key fails with the env-var instruction, exit 1.
+    const noKey = spawnSync(process.execPath, [CLI, 'reconcile'], {
+      encoding: 'utf8',
+      env: { ...process.env, HOME, USERPROFILE: HOME, ANTHROPIC_ADMIN_KEY: '' },
+    });
+    assert.equal(noKey.status, 1);
+    assert.match(noKey.stderr, /ANTHROPIC_ADMIN_KEY is not set/);
+
+    // Unknown provider exits 1.
+    const bad = spawnSync(process.execPath, [CLI, 'reconcile', '--provider', 'grok'], {
+      encoding: 'utf8',
+      env: { ...process.env, HOME, USERPROFILE: HOME, ANTHROPIC_ADMIN_KEY: 'x' },
+    });
+    assert.equal(bad.status, 1);
+    assert.match(bad.stderr, /Unknown provider/);
+  } finally {
+    server.close();
+  }
+});
+
 test('e2e: unknown command and bare invocation fail with help', () => {
   assert.equal(run(['definitely-not-a-command']).code, 1);
   const bare = run([]);

--- a/test/reconcile.test.ts
+++ b/test/reconcile.test.ts
@@ -1,0 +1,142 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import type { Server } from 'node:http';
+import { compareUsage, reconcile, renderReconcile } from '../src/reconcile.js';
+import { makeStored } from './helpers.js';
+
+test('compareUsage: coverage, tamper flag, local-only models', () => {
+  const events = [
+    makeStored({ model: 'claude-opus-4-7', input_tokens: 800, output_tokens: 200 }), // 1000 local
+    makeStored({ model: 'claude-haiku-4-5', input_tokens: 5000, output_tokens: 0 }), // exceeds api
+    makeStored({ model: 'gemini-2.5-flash', input_tokens: 100, output_tokens: 0 }), // other vendor
+  ];
+  const rows = compareUsage(events, [
+    { model: 'claude-opus-4-7', inputTokens: 3000, outputTokens: 1000, cacheReadTokens: 0, cacheCreationTokens: 0 },
+    { model: 'claude-haiku-4-5', inputTokens: 1000, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+  ]);
+
+  const opus = rows.find((r) => r.model === 'claude-opus-4-7')!;
+  assert.equal(opus.verdict, 'ok');
+  assert.ok(Math.abs(opus.coverage - 0.25) < 1e-9); // 1000 / 4000
+
+  const haiku = rows.find((r) => r.model === 'claude-haiku-4-5')!;
+  assert.equal(haiku.verdict, 'local-exceeds-api'); // 5000 local vs 1000 billed
+
+  const gemini = rows.find((r) => r.model === 'gemini-2.5-flash')!;
+  assert.equal(gemini.verdict, 'local-only');
+  assert.equal(gemini.apiTokens, 0);
+});
+
+test('compareUsage: small overshoot stays within tolerance', () => {
+  const events = [makeStored({ model: 'm', input_tokens: 1030, output_tokens: 0 })];
+  const rows = compareUsage(events, [
+    { model: 'm', inputTokens: 1000, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+  ]);
+  assert.equal(rows[0].verdict, 'ok'); // 1.03x < 1.05 tolerance (bucket snapping / clock skew)
+});
+
+function serve(handler: (url: string) => object): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(handler(req.url ?? '')));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number };
+      resolve({ server, url: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+}
+
+test('reconcile: anthropic shape parsed, paginated, env-keyed', async () => {
+  let calls = 0;
+  const { server, url } = await serve((reqUrl) => {
+    calls++;
+    assert.match(reqUrl, /\/v1\/organizations\/usage_report\/messages/);
+    const paged = reqUrl.includes('page=p2');
+    return {
+      data: [
+        {
+          starting_at: '2026-06-12T00:00:00Z',
+          ending_at: '2026-06-13T00:00:00Z',
+          results: [
+            {
+              model: 'claude-opus-4-7',
+              uncached_input_tokens: paged ? 500 : 1000,
+              output_tokens: paged ? 100 : 200,
+              cache_read_input_tokens: 0,
+              cache_creation: { ephemeral_5m_input_tokens: paged ? 0 : 300, ephemeral_1h_input_tokens: 0 },
+            },
+          ],
+        },
+      ],
+      has_more: !paged,
+      next_page: paged ? null : 'p2',
+    };
+  });
+  try {
+    const events = [makeStored({ model: 'claude-opus-4-7', input_tokens: 900, output_tokens: 100 })];
+    const { rows, breach } = await reconcile('anthropic', events, 7, {
+      ANTHROPIC_ADMIN_KEY: 'test-key',
+      TOKEN_MONITOR_ANTHROPIC_URL: url,
+    } as NodeJS.ProcessEnv);
+    assert.equal(calls, 2); // pagination followed
+    assert.equal(breach, false);
+    const row = rows[0];
+    assert.equal(row.model, 'claude-opus-4-7');
+    assert.equal(row.apiTokens, 1500 + 300 + 300); // both pages: input+output+cacheCreate
+    assert.equal(row.localTokens, 1000);
+    assert.ok(renderReconcile('anthropic', rows, 7).includes('✓ reconciles'));
+  } finally {
+    server.close();
+  }
+});
+
+test('reconcile: openai shape splits cached tokens out of input', async () => {
+  const { server, url } = await serve((reqUrl) => {
+    assert.match(reqUrl, /\/v1\/organization\/usage\/completions/);
+    return {
+      data: [
+        {
+          results: [
+            { model: 'gpt-5-codex', input_tokens: 1000, input_cached_tokens: 400, output_tokens: 100 },
+          ],
+        },
+      ],
+      has_more: false,
+    };
+  });
+  try {
+    const { rows } = await reconcile('openai', [], 7, {
+      OPENAI_ADMIN_KEY: 'k',
+      TOKEN_MONITOR_OPENAI_URL: url,
+    } as NodeJS.ProcessEnv);
+    // 600 fresh input + 400 cache read + 100 output
+    assert.equal(rows[0].apiTokens, 1100);
+  } finally {
+    server.close();
+  }
+});
+
+test('reconcile: missing key and unknown provider fail with clear messages', async () => {
+  await assert.rejects(() => reconcile('anthropic', [], 7, {} as NodeJS.ProcessEnv), /ANTHROPIC_ADMIN_KEY is not set/);
+  await assert.rejects(() => reconcile('grok', [], 7, {} as NodeJS.ProcessEnv), /Unknown provider/);
+});
+
+test('reconcile: HTTP errors surface the status, not a crash', async () => {
+  const { server, url } = await serve(() => ({}));
+  server.removeAllListeners('request');
+  server.on('request', (_req, res) => {
+    res.statusCode = 401;
+    res.end('{"error": "unauthorized"}');
+  });
+  try {
+    await assert.rejects(
+      () => reconcile('anthropic', [], 7, { ANTHROPIC_ADMIN_KEY: 'bad', TOKEN_MONITOR_ANTHROPIC_URL: url } as NodeJS.ProcessEnv),
+      /responded 401/,
+    );
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Closes #36 (milestone 5).

## What
New `reconcile` command — the threat-model mitigation the docs have promised since v0.3: a developer can edit their own source logs, but gamed numbers won't reconcile against the provider's billing data.

- **Anthropic Admin API** (`/v1/organizations/usage_report/messages`): grouped by model, daily buckets, pagination followed; `uncached_input + output + cache_read + cache_creation(5m+1h)` per model.
- **OpenAI Usage API** (`/v1/organization/usage/completions`): OpenAI's `input_tokens` includes cached — split out so columns match the local fresh/cached separation.
- **Key handling**: `ANTHROPIC_ADMIN_KEY` / `OPENAI_ADMIN_KEY` read from the environment for that run only — never stored, never in config, never in exports. Org-lead-only by design.
- **Verdicts**: the API covers the whole org, the local db one machine, so local ≤ API reconciles (5% tolerance for clock skew/bucket snapping). **Local > API exits 1** — inflated or double-counted logs. Local-only models (other vendors) are listed, not flagged.
- `--days` capped at 31 (the APIs' daily-bucket limit). Plain `fetch` — zero-deps constraint holds.
- README: reconcile section + threat-model paragraph updated from 'planned mitigation (roadmap)' to delivered.

## Tests
Unit: verdict matrix (ok / tamper / local-only / tolerance), both provider parsers against in-process mock HTTP (incl. pagination and the OpenAI cached-token split), 401 surfacing, missing-key and unknown-provider errors. e2e: CLI subprocess against a mock server — reconcile pass, seeded-tamper db exits 1 with the investigate verdict, missing key exits 1 with the env-var instruction, unknown provider exits 1. (Found and fixed a real e2e pitfall: `spawnSync` blocks the event loop that serves the in-test mock — the reconcile e2e uses async `spawn`.) 111 tests pass.

API shapes pinned against the official docs (platform.claude.com usage-cost API reference) as of 2026-06-13. No live-org run yet (needs an admin key) — schema drift would surface as a clear HTTP/parse error, fail-soft.