### PR TITLE
chore: marketplace publish — publisher ryan653133, CI publish job on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
 
 jobs:
@@ -41,3 +42,24 @@ jobs:
         with:
           name: token-monitor-extension-vsix
           path: extension/*.vsix
+
+  # Publishes to the VS Code Marketplace on version tags (vX.Y.Z).
+  # Needs the VSCE_PAT repo secret (Azure DevOps PAT, Marketplace -> Manage).
+  marketplace:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [test, extension]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm ci
+        working-directory: extension
+      - run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        working-directory: extension
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Adapters skip gracefully when a tool isn't installed. The Cursor adapter reads o
 
 ## IDE extension
 
-[`extension/`](extension/) ships a VS Code-family extension (works in VS Code, Cursor, Windsurf, Antigravity): status-bar tokens/cost for the current project and the dashboard in a webview, both powered by the CLI. Grab the `.vsix` from the latest release (or CI artifacts) and install via *Extensions: Install from VSIX…*
+[`extension/`](extension/) ships a VS Code-family extension (works in VS Code, Cursor, Windsurf, Antigravity): status-bar tokens/cost for the current project and the dashboard in a webview, both powered by the CLI. Install **[Token Monitor](https://marketplace.visualstudio.com/items?itemName=ryan653133.token-monitor)** from the VS Code Marketplace (search "token-monitor"), or grab the `.vsix` from the latest release and use *Extensions: Install from VSIX…*
 
 ## Team usage
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -4,6 +4,8 @@ Status-bar token/cost for the current project plus the full [token-monitor](http
 
 The extension is a thin UI over the CLI — all parsing, storage, and privacy guarantees are the CLI's. Data never leaves your machine.
 
+**Install:** [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ryan653133.token-monitor) (search "token-monitor"), or the `.vsix` from the [latest release](https://github.com/ryandemelo/token-monitor/releases). Requires Node ≥ 24 on PATH.
+
 ## What you get
 
 - **Status bar**: `1.2M · ~$45` — work tokens and estimated cost for the workspace's project over the configured window (falls back to overall when the project has no data). Hover for cache hit and rework ratios; click to open the dashboard.

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Token Monitor",
   "description": "Status-bar token/cost for the current project plus the token-monitor dashboard, for VS Code, Cursor, Windsurf, and Antigravity.",
   "version": "0.7.0",
-  "publisher": "ryandemelo",
+  "publisher": "ryan653133",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Marketplace publish wiring.

- Extension publisher set to `ryan653133` — the Azure DevOps account that owns the marketplace publisher. Extension ID is now **ryan653133.token-monitor**; 0.7.0 is [live on the marketplace](https://marketplace.visualstudio.com/items?itemName=ryan653133.token-monitor) (published manually to validate PAT + publisher).
- CI: `marketplace` job runs `vsce publish` on `v*` tags using the `VSCE_PAT` repo secret, gated on the test + extension jobs — future releases publish automatically when tagged.
- READMEs link the marketplace listing first, `.vsix` from releases as fallback.

Note: anyone with the old sideloaded `ryandemelo.token-monitor` .vsix should uninstall it and install from the marketplace — the ID changed, so it won't auto-update.