### PR TITLE
feat: cause decomposition — recommendations diagnose, not just flag

### DIFF
--- a/src/causes.ts
+++ b/src/causes.ts
@@ -1,0 +1,153 @@
+import type { StoredEvent } from './store.js';
+import { groupBy, contextGrowthOf, CACHE_TTL_MS, BLOAT_GROWTH, BLOAT_FRESH_SHARE } from './metrics.js';
+
+/**
+ * Cause decomposition (#41): a finding names a symptom ("cache hit low") but
+ * not the dominant cause behind it. Each decomposer partitions the symptom's
+ * tokens — already collected per session — into candidate causes so the
+ * recommendation can name the biggest one with its share, e.g.
+ * "low cache hit — dominant cause: cold restarts after idle gaps (52%)".
+ *
+ * Buckets are disjoint by construction (every token lands in exactly one
+ * bucket), so the shares are an honest partition rather than overlapping
+ * estimates. A "baseline" bucket (steady-state, mixed) absorbs the tokens with
+ * no actionable cause; it is never reported as the dominant lever.
+ */
+
+export interface Cause {
+  /** Stable id, e.g. 'cold-restarts'. */
+  key: string;
+  /** Human phrase for the recommendation line. */
+  label: string;
+  /** Tokens attributed to this cause. */
+  tokens: number;
+  /** tokens / total symptom tokens (0..1). */
+  share: number;
+}
+
+export interface CauseBreakdown {
+  /** Finding key this explains. */
+  findingKey: string;
+  /** Highest-share actionable cause. */
+  dominant: Cause;
+  /** All non-empty causes incl. the baseline bucket, sorted desc by share. */
+  causes: Cause[];
+}
+
+/** Below this turn count a session never builds reusable cache. */
+const SHORT_SESSION_TURNS = 4;
+/** A cause has to own at least this share before it is named the dominant lever. */
+const DOMINANT_FLOOR = 0.15;
+/** Buckets that capture "nothing actionable" — never reported as dominant. */
+const BASELINE_KEYS = new Set(['steady-state', 'other-rework']);
+
+const freshOf = (e: StoredEvent) => e.input_tokens + e.cache_creation_tokens;
+const spendOf = (e: StoredEvent) => e.input_tokens + e.output_tokens;
+
+/**
+ * Where did the fresh-paid input (input + cache writes) actually go? Each turn
+ * lands in exactly one bucket, precedence cold-restart > short-session >
+ * context-churn > steady-state.
+ */
+function decomposeCacheHit(sessions: StoredEvent[][]): Cause[] {
+  const b = { cold: 0, short: 0, churn: 0, steady: 0 };
+  for (const arr of sessions) {
+    const short = arr.length < SHORT_SESSION_TURNS;
+    const growth = contextGrowthOf(arr);
+    // Mirror metrics.ts exactly: late-half growth only counts as churn when it
+    // is re-paid FRESH, not served from cache. Otherwise a well-cached session
+    // would be mislabelled, contradicting the tool's own contextBloatShare.
+    const bloated =
+      growth !== undefined && growth.ratio >= BLOAT_GROWTH && growth.lateFreshShare >= BLOAT_FRESH_SHARE;
+    const lateStart = arr.length - Math.floor(arr.length / 2);
+    for (let i = 0; i < arr.length; i++) {
+      const f = freshOf(arr[i]);
+      if (f === 0) continue;
+      if (i > 0 && Date.parse(arr[i].ts) - Date.parse(arr[i - 1].ts) > CACHE_TTL_MS) {
+        b.cold += f;
+      } else if (short) {
+        b.short += f;
+      } else if (bloated && i >= lateStart) {
+        b.churn += f;
+      } else {
+        b.steady += f;
+      }
+    }
+  }
+  return [
+    { key: 'cold-restarts', label: 'cold restarts after idle gaps (>5-min cache TTL)', tokens: b.cold, share: 0 },
+    { key: 'short-sessions', label: 'sessions too short to build reusable cache', tokens: b.short, share: 0 },
+    { key: 'context-churn', label: 'context churn — late-session growth re-paid fresh', tokens: b.churn, share: 0 },
+    { key: 'steady-state', label: 'steady-state context (first loads, necessary writes)', tokens: b.steady, share: 0 },
+  ];
+}
+
+/**
+ * Rework tokens are coding/testing spend after a session's first failure. Each
+ * such session is classified once by its dominant profile, and its whole
+ * rework contribution attributed there.
+ */
+function decomposeRework(sessions: StoredEvent[][]): Cause[] {
+  const b = { noGate: 0, broad: 0, stacked: 0, other: 0 };
+  for (const arr of sessions) {
+    const firstFail = arr.findIndex(
+      (e) => e.is_error && (e.activity === 'testing' || e.activity === 'coding'),
+    );
+    if (firstFail === -1) continue;
+    let rework = 0;
+    for (let i = firstFail + 1; i < arr.length; i++) {
+      if (arr[i].activity === 'coding' || arr[i].activity === 'testing') rework += spendOf(arr[i]);
+    }
+    if (rework === 0) continue;
+
+    // Profile the whole session to pick the most likely root cause.
+    let testingTok = 0, sessSpend = 0, errors = 0, fixes = 0;
+    let prev: string | undefined;
+    for (const e of arr) {
+      sessSpend += spendOf(e);
+      if (e.activity === 'testing') testingTok += spendOf(e);
+      if (e.is_error) errors++;
+      if (prev === 'testing' && e.activity === 'coding') fixes++;
+      prev = e.activity;
+    }
+    const testingShare = sessSpend ? testingTok / sessSpend : 0;
+    const errorRate = arr.length ? errors / arr.length : 0;
+    if (testingShare < 0.02) b.noGate += rework;
+    else if (errorRate > 0.3) b.broad += rework;
+    else if (fixes >= 3) b.stacked += rework;
+    else b.other += rework;
+  }
+  return [
+    { key: 'no-test-gate', label: 'code written without a test gate (failures surface late)', tokens: b.noGate, share: 0 },
+    { key: 'broad-failures', label: 'broad test failures (suite failing widely)', tokens: b.broad, share: 0 },
+    { key: 'stacked-corrections', label: 'stacked correction loops (repeated fix attempts)', tokens: b.stacked, share: 0 },
+    { key: 'other-rework', label: 'mixed — no single dominant pattern', tokens: b.other, share: 0 },
+  ];
+}
+
+const DECOMPOSERS: Record<string, (sessions: StoredEvent[][]) => Cause[]> = {
+  'low-cache-hit': decomposeCacheHit,
+  'high-rework': decomposeRework,
+};
+
+/**
+ * Partition a finding's symptom tokens into candidate causes and name the
+ * dominant actionable one. Returns undefined when the finding has no
+ * decomposer, has no symptom tokens, or has no cause clearing DOMINANT_FLOOR
+ * (better to stay silent than over-claim a 4%-of-the-problem "cause").
+ */
+export function decomposeCause(findingKey: string, events: StoredEvent[]): CauseBreakdown | undefined {
+  const fn = DECOMPOSERS[findingKey];
+  if (!fn) return undefined;
+  const sessions = [...groupBy(events, 'session_id').values()];
+  const raw = fn(sessions);
+  const total = raw.reduce((s, c) => s + c.tokens, 0);
+  if (total <= 0) return undefined;
+  const causes = raw
+    .map((c) => ({ ...c, share: c.tokens / total }))
+    .filter((c) => c.tokens > 0)
+    .sort((a, b) => b.share - a.share);
+  const dominant = causes.find((c) => !BASELINE_KEYS.has(c.key) && c.share >= DOMINANT_FLOOR);
+  if (!dominant) return undefined;
+  return { findingKey, dominant, causes };
+}

--- a/src/html.ts
+++ b/src/html.ts
@@ -8,7 +8,7 @@ import { fmtMetric } from './followthrough.js';
 import { fmtTokens } from './report.js';
 import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
 import { mergeMetrics, rollupExports, displayName } from './team.js';
-import { enrichFindings, fmtSavings, fmtEvidence, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
+import { enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
 
 const ACTIVITY_COLORS: Record<string, string> = {
@@ -53,8 +53,9 @@ export function renderHtml(
     ...persona.recommendations.map((r) => `<li>${esc(r)}</li>`),
     ...enriched.map((r) => {
       const savings = fmtSavings(r);
+      const cause = fmtCause(r);
       const ev = fmtEvidence(r);
-      return `<li>${esc(r.message)}${savings ? ` <span class="save">${esc(savings)}</span>` : ''}${ev ? `<div class="ev muted">${esc(ev)}</div>` : ''}</li>`;
+      return `<li>${esc(r.message)}${savings ? ` <span class="save">${esc(savings)}</span>` : ''}${cause ? `<div class="ev muted">${esc(cause)}</div>` : ''}${ev ? `<div class="ev muted">${esc(ev)}</div>` : ''}</li>`;
     }),
   ].join('');
   const projects = [...groupBy(events, 'project').entries()]

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -7,8 +7,8 @@ import { costOf, PREMIUM_MODEL_RE } from './pricing.js';
 export const CACHE_TTL_MS = 5 * 60_000;
 /** Sessions need this many turns before a context-bloat trend is measurable. */
 export const BLOAT_MIN_TURNS = 8;
-const BLOAT_GROWTH = 2; // late-half avg context ≥ 2× early half
-const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-paid fresh
+export const BLOAT_GROWTH = 2; // late-half avg context ≥ 2× early half
+export const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-paid fresh
 
 export interface Metrics {
   events: number;

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -5,6 +5,8 @@ import type { Finding, FollowRow, MetricKey } from './followthrough.js';
 import { structuredFindings, premiumShare, fmtMetric } from './followthrough.js';
 import { PRICES, PREMIUM_MODEL_RE } from './pricing.js';
 import { fmtTokens } from './report.js';
+import type { CauseBreakdown } from './causes.js';
+import { decomposeCause } from './causes.js';
 
 /**
  * Recommendations 2.0: every structured finding answers "why should I believe
@@ -33,6 +35,8 @@ export interface EnrichedRec extends Finding {
   savingsEstimated: boolean;
   /** The improvement target the savings assume; personal = user's own top quartile. */
   target?: Target;
+  /** The dominant cause behind the symptom, when decomposable (#41). */
+  cause?: CauseBreakdown;
 }
 
 /** Static fallback targets for the savings math, per finding key. */
@@ -279,6 +283,7 @@ export function enrichFindings(events: StoredEvent[], m: Metrics, days: number):
         message,
         evidence,
         target,
+        cause: decomposeCause(f.key, events),
         savingsUsdPerMonth: usd !== undefined && usd > 0 ? usd * monthly : undefined,
         savingsEstimated: rates.estimated,
       };
@@ -387,4 +392,11 @@ export function fmtEvidence(r: EnrichedRec): string | undefined {
   return 'worst: ' + r.evidence
     .map((e) => `${e.sessionId.slice(0, 8)} (${e.project}, ${e.date}, ${e.label})`)
     .join(' · ');
+}
+
+/** "cause: cold restarts after idle gaps (52%)" — the dominant driver, when known. */
+export function fmtCause(r: EnrichedRec): string | undefined {
+  if (!r.cause) return undefined;
+  const d = r.cause.dominant;
+  return `cause: ${d.label} (${(d.share * 100).toFixed(0)}%)`;
 }

--- a/src/report.ts
+++ b/src/report.ts
@@ -8,7 +8,7 @@ import { mergeMetrics, rollupExports, dominantActivity, displayName } from './te
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
 import type { EnrichedRec } from './recommendations.js';
-import { enrichFindings, fmtSavings, fmtEvidence, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
+import { enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
 import type { TrendRow, TrendVerdict } from './trends.js';
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
 
@@ -222,6 +222,8 @@ export function renderEnrichedRecs(recs: EnrichedRec[]): string[] {
   for (const r of recs) {
     const savings = fmtSavings(r);
     out.push(`  ${YELLOW}→${RESET} ${r.message}${savings ? `  ${GREEN}${savings}${RESET}` : ''}`);
+    const cause = fmtCause(r);
+    if (cause) out.push(`    ${DIM}${cause}${RESET}`);
     const ev = fmtEvidence(r);
     if (ev) out.push(`    ${DIM}${ev}${RESET}`);
   }

--- a/test/causes.test.ts
+++ b/test/causes.test.ts
@@ -1,0 +1,182 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { decomposeCause } from '../src/causes.js';
+import { computeMetrics } from '../src/metrics.js';
+import { makeStored } from './helpers.js';
+import type { StoredEvent } from '../src/store.js';
+
+test('low-cache-hit: a TTL-gap turn pins the cause to cold restarts', () => {
+  const events: StoredEvent[] = [
+    makeStored({ session_id: 's1', ts: '2026-06-01T00:00:00Z', input_tokens: 10_000, output_tokens: 0 }),
+    makeStored({ session_id: 's1', ts: '2026-06-01T00:20:00Z', input_tokens: 200_000, output_tokens: 0 }),
+  ];
+  const cb = decomposeCause('low-cache-hit', events)!;
+  assert.ok(cb);
+  assert.equal(cb.dominant.key, 'cold-restarts');
+  // shares are normalised and sorted desc (the true token partition is asserted
+  // in the mixed-session reconciliation test below, not by this sum).
+  assert.ok(Math.abs(cb.causes.reduce((s, c) => s + c.share, 0) - 1) < 1e-9);
+  for (let i = 1; i < cb.causes.length; i++) assert.ok(cb.causes[i - 1].share >= cb.causes[i].share);
+  assert.ok(cb.dominant.tokens === 200_000);
+});
+
+test('low-cache-hit: single-turn sessions can never warm the cache', () => {
+  const events: StoredEvent[] = [];
+  for (let i = 0; i < 5; i++) {
+    events.push(makeStored({ session_id: `s${i}`, ts: `2026-06-0${i + 1}T00:00:00Z`, input_tokens: 50_000, output_tokens: 0 }));
+  }
+  const cb = decomposeCause('low-cache-hit', events)!;
+  assert.equal(cb.dominant.key, 'short-sessions');
+  assert.ok(Math.abs(cb.dominant.share - 1) < 1e-9);
+});
+
+test('low-cache-hit: late-session growth attributes to context churn', () => {
+  // 8-turn session, early turns tiny, late turns large, no idle gaps.
+  const events = Array.from({ length: 8 }, (_, i) =>
+    makeStored({
+      session_id: 'big',
+      ts: `2026-06-01T00:0${i}:00Z`,
+      input_tokens: i < 4 ? 100 : 5_000,
+      output_tokens: 0,
+    }),
+  );
+  const cb = decomposeCause('low-cache-hit', events)!;
+  assert.equal(cb.dominant.key, 'context-churn');
+  // late half (4 turns × 5000) dwarfs the steady early half
+  assert.equal(cb.dominant.tokens, 20_000);
+});
+
+test('high-rework: rework with no testing pins the cause to a missing test gate', () => {
+  const events: StoredEvent[] = [
+    makeStored({ session_id: 'r1', ts: '2026-06-01T00:00:00Z', activity: 'coding', is_error: 1, input_tokens: 1_000, output_tokens: 1_000 }),
+    makeStored({ session_id: 'r1', ts: '2026-06-01T00:00:30Z', activity: 'coding', input_tokens: 50_000, output_tokens: 5_000 }),
+    makeStored({ session_id: 'r1', ts: '2026-06-01T00:01:00Z', activity: 'coding', input_tokens: 50_000, output_tokens: 5_000 }),
+  ];
+  const cb = decomposeCause('high-rework', events)!;
+  assert.equal(cb.dominant.key, 'no-test-gate');
+  assert.equal(cb.dominant.tokens, 110_000); // the two coding turns after the failure
+});
+
+test('high-rework: heavy test failures pin the cause to broad failures', () => {
+  const events: StoredEvent[] = [
+    makeStored({ session_id: 'r2', ts: '2026-06-01T00:00:00Z', activity: 'testing', is_error: 1, input_tokens: 5_000, output_tokens: 0 }),
+    makeStored({ session_id: 'r2', ts: '2026-06-01T00:00:10Z', activity: 'testing', is_error: 1, input_tokens: 5_000, output_tokens: 0 }),
+    makeStored({ session_id: 'r2', ts: '2026-06-01T00:00:20Z', activity: 'coding', input_tokens: 5_000, output_tokens: 0 }),
+    makeStored({ session_id: 'r2', ts: '2026-06-01T00:00:30Z', activity: 'testing', is_error: 1, input_tokens: 5_000, output_tokens: 0 }),
+    makeStored({ session_id: 'r2', ts: '2026-06-01T00:00:40Z', activity: 'coding', input_tokens: 5_000, output_tokens: 0 }),
+  ];
+  const cb = decomposeCause('high-rework', events)!;
+  assert.equal(cb.dominant.key, 'broad-failures');
+});
+
+test('decomposeCause stays silent when there is nothing to explain', () => {
+  // No decomposer for this finding key.
+  const some = [makeStored({ session_id: 's', input_tokens: 100_000, output_tokens: 0 })];
+  assert.equal(decomposeCause('premium-misroute', some), undefined);
+  // high-rework with no failure -> no rework tokens -> no cause.
+  const clean = [makeStored({ session_id: 's', activity: 'coding', input_tokens: 100_000, output_tokens: 0 })];
+  assert.equal(decomposeCause('high-rework', clean), undefined);
+});
+
+test('low-cache-hit: late growth served from CACHE is not churn (matches the bloat signal)', () => {
+  // 8-turn session whose late-half context doubles, but the growth is cache
+  // reads, not fresh input — metrics.ts would NOT count this as bloated, so the
+  // cause must not claim context churn either (regression for the missing
+  // BLOAT_FRESH_SHARE gate).
+  const events = Array.from({ length: 8 }, (_, i) =>
+    makeStored({
+      session_id: 'cached',
+      ts: `2026-06-01T00:0${i}:00Z`,
+      input_tokens: 1_000,
+      cache_read_tokens: i < 4 ? 0 : 50_000, // late context grows from reads
+      output_tokens: 0,
+    }),
+  );
+  // Sanity: the metric itself sees no bloat here.
+  assert.equal(computeMetrics(events).bloatedSessions, 0);
+  // ...and every fresh token is steady-state, so no actionable cause is named.
+  assert.equal(decomposeCause('low-cache-hit', events), undefined);
+});
+
+test('low-cache-hit: a baseline majority is surfaced but never named the dominant lever', () => {
+  const events: StoredEvent[] = [];
+  // 10-turn steady session: 800k fresh, all steady-state (no gaps, no bloat).
+  for (let i = 0; i < 10; i++) {
+    events.push(makeStored({ session_id: 'steady', ts: `2026-06-01T00:${String(i).padStart(2, '0')}:00Z`, input_tokens: 80_000, output_tokens: 0 }));
+  }
+  // Cold session: two >5-min-gap turns re-pay 200k fresh.
+  events.push(makeStored({ session_id: 'cold', ts: '2026-06-01T01:00:00Z', input_tokens: 0, output_tokens: 0 }));
+  events.push(makeStored({ session_id: 'cold', ts: '2026-06-01T01:10:00Z', input_tokens: 100_000, output_tokens: 0 }));
+  events.push(makeStored({ session_id: 'cold', ts: '2026-06-01T01:20:00Z', input_tokens: 100_000, output_tokens: 0 }));
+  const cb = decomposeCause('low-cache-hit', events)!;
+  assert.equal(cb.causes[0].key, 'steady-state'); // baseline owns the largest share (~80%)
+  assert.equal(cb.dominant.key, 'cold-restarts'); // ...but the dominant lever is the actionable one
+  assert.ok(cb.causes.some((c) => c.key === 'steady-state')); // baseline still surfaced for context
+});
+
+test('low-cache-hit: an actionable cause below the floor stays silent rather than over-claim', () => {
+  const events: StoredEvent[] = [];
+  for (let i = 0; i < 10; i++) {
+    events.push(makeStored({ session_id: 'steady', ts: `2026-06-01T00:${String(i).padStart(2, '0')}:00Z`, input_tokens: 100_000, output_tokens: 0 }));
+  }
+  events.push(makeStored({ session_id: 'cold', ts: '2026-06-01T01:00:00Z', input_tokens: 0, output_tokens: 0 }));
+  events.push(makeStored({ session_id: 'cold', ts: '2026-06-01T01:10:00Z', input_tokens: 50_000, output_tokens: 0 })); // ~4.7% < 0.15
+  assert.equal(decomposeCause('low-cache-hit', events), undefined);
+});
+
+test('low-cache-hit: DOMINANT_FLOOR boundary — just under stays silent, just over fires', () => {
+  // 5-turn (non-short, non-bloated: <8 turns) single session; cold is the only
+  // non-baseline bucket. turns 1-3 carry no fresh input, so they drop out.
+  const mk = (turn0: number, turn4: number): StoredEvent[] => [
+    makeStored({ session_id: 's', ts: '2026-06-01T00:00:00Z', input_tokens: turn0, output_tokens: 0 }),
+    makeStored({ session_id: 's', ts: '2026-06-01T00:01:00Z', input_tokens: 0, output_tokens: 0 }),
+    makeStored({ session_id: 's', ts: '2026-06-01T00:02:00Z', input_tokens: 0, output_tokens: 0 }),
+    makeStored({ session_id: 's', ts: '2026-06-01T00:03:00Z', input_tokens: 0, output_tokens: 0 }),
+    makeStored({ session_id: 's', ts: '2026-06-01T00:10:00Z', input_tokens: turn4, output_tokens: 0 }), // 7-min gap -> cold
+  ];
+  assert.equal(decomposeCause('low-cache-hit', mk(86_000, 14_000)), undefined); // cold 14% < floor
+  const cb = decomposeCause('low-cache-hit', mk(84_000, 16_000))!; // cold 16% >= floor
+  assert.equal(cb.dominant.key, 'cold-restarts');
+  assert.equal(cb.dominant.tokens, 16_000);
+});
+
+test('low-cache-hit: buckets are a true partition and cold reconciles with metrics', () => {
+  const events: StoredEvent[] = [
+    makeStored({ session_id: 'cold', ts: '2026-06-01T00:00:00Z', input_tokens: 10_000, output_tokens: 0 }),
+    makeStored({ session_id: 'cold', ts: '2026-06-01T00:20:00Z', input_tokens: 50_000, cache_creation_tokens: 20_000, output_tokens: 0 }),
+    makeStored({ session_id: 'short', ts: '2026-06-02T00:00:00Z', input_tokens: 8_000, output_tokens: 0 }),
+    ...Array.from({ length: 8 }, (_, i) => makeStored({ session_id: 'churn', ts: `2026-06-03T00:0${i}:00Z`, input_tokens: i < 4 ? 100 : 5_000, output_tokens: 0 })),
+    ...Array.from({ length: 6 }, (_, i) => makeStored({ session_id: 'steady', ts: `2026-06-04T00:0${i}:00Z`, input_tokens: 1_000, output_tokens: 0 })),
+  ];
+  const cb = decomposeCause('low-cache-hit', events)!;
+  const bucketSum = cb.causes.reduce((s, c) => s + c.tokens, 0);
+  const fresh = events.reduce((s, e) => s + e.input_tokens + e.cache_creation_tokens, 0);
+  assert.equal(bucketSum, fresh); // disjoint + complete: catches any double-count or dropped token
+  const cold = cb.causes.find((c) => c.key === 'cold-restarts')!;
+  assert.equal(cold.tokens, computeMetrics(events).coldRestartTokens); // cross-module reconciliation
+});
+
+test('high-rework: repeated testing->coding loops attribute to stacked corrections', () => {
+  const acts = ['coding', 'testing', 'coding', 'testing', 'coding', 'testing', 'coding'] as const;
+  const events = acts.map((activity, i) =>
+    makeStored({
+      session_id: 'r', ts: `2026-06-01T00:0${i}:00Z`, activity,
+      is_error: i === 0 ? 1 : 0, // single failure -> low error rate, but 3 fix loops
+      input_tokens: 5_000, output_tokens: 0,
+    }),
+  );
+  const cb = decomposeCause('high-rework', events)!;
+  assert.equal(cb.dominant.key, 'stacked-corrections');
+});
+
+test('high-rework: rework with no dominant pattern lands in the baseline and stays silent', () => {
+  const acts = ['coding', 'testing', 'coding', 'coding'] as const; // 1 fix, 25% errors, has tests
+  const events = acts.map((activity, i) =>
+    makeStored({
+      session_id: 'r', ts: `2026-06-01T00:0${i}:00Z`, activity,
+      is_error: i === 0 ? 1 : 0,
+      input_tokens: 5_000, output_tokens: 0,
+    }),
+  );
+  assert.equal(decomposeCause('high-rework', events), undefined);
+});

--- a/test/recommendations.test.ts
+++ b/test/recommendations.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { computeMetrics } from '../src/metrics.js';
-import { blendedRates, enrichFindings, fmtSavings, fmtEvidence, potentialBill, fmtPotential, realizedMonthly, fmtUsdShort } from '../src/recommendations.js';
+import { blendedRates, enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPotential, realizedMonthly, fmtUsdShort } from '../src/recommendations.js';
 import { makeStored } from './helpers.js';
 import type { StoredEvent } from '../src/store.js';
 import type { FollowRow } from '../src/followthrough.js';
@@ -113,6 +113,15 @@ test('personalized target: enough sessions -> own top quartile, message cites it
   // p75 of [0×8, 0.9×4] sits between the cold mass and the strong sessions
   assert.ok(rec.target!.value > 0.5 && rec.target!.value <= 0.9);
   assert.match(rec.message, /top-quartile sessions already run at/);
+});
+
+test('enrichFindings attaches the dominant cause; fmtCause renders it', () => {
+  const events = selfBenchmarkEvents(); // 12 single-turn cache-cold sessions
+  const m = computeMetrics(events);
+  const rec = enrichFindings(events, m, 30).find((r) => r.key === 'low-cache-hit')!;
+  assert.ok(rec.cause);
+  assert.equal(rec.cause!.dominant.key, 'short-sessions');
+  assert.match(fmtCause(rec)!, /^cause: sessions too short to build reusable cache \(\d+%\)$/);
 });
 
 test('personalized target: thin data falls back to the static target', () => {


### PR DESCRIPTION
## #41 — cause decomposition

A finding names a **symptom** ("cache hit low") but not the dominant **cause**. This adds the cause.

New `src/causes.ts` partitions a finding's symptom tokens — already collected per session, nothing new collected — into **disjoint** candidate-cause buckets (every token lands in exactly one), then names the largest *actionable* bucket with its share.

| Finding | Decomposed into |
|---|---|
| `low-cache-hit` | cold-restarts · short-sessions · context-churn · *steady-state (baseline)* |
| `high-rework` | no-test-gate · broad-failures · stacked-corrections · *other (baseline)* |

Guardrails:
- **Baseline buckets** (`steady-state`, `other-rework`) are surfaced in `causes[]` but **never** reported as the dominant lever.
- A cause under **`DOMINANT_FLOOR` (15%)** stays silent — better than over-claiming a 4%-of-the-problem "cause".
- The `context-churn` bucket uses the **same `ratio + lateFreshShare` bloat definition as `metrics.ts`** (constants now exported from there to prevent drift), so a cause can't contradict the tool's own `contextBloatShare` signal.
- The `cold-restarts` bucket reconciles exactly with `metrics.coldRestartTokens` (asserted in tests).

Surfaces as a dim `cause: …(52%)` line under each rec in **report / analyze / HTML**, and rides into signed exports via `recommendationDetails` — **aggregate-only** (`key/label/tokens/share`, no prompt/code content).

### Testing
- `test/causes.test.ts`: 13 cases — each cause branch, the disjoint-partition + cross-module reconciliation invariant, the `DOMINANT_FLOOR` boundary, baseline-never-dominant, and a regression for the cache-served-growth case.
- Verified end-to-end against the real CLI (`report`/`analyze`/`html`/`--json`) on a synthetic db.
- Full suite: **125 passing**.

Reviewed by a multi-agent adversarial pass; the one real correctness finding it surfaced (churn gate missing `lateFreshShare`) is fixed here.

Milestone: v0.8.0. Closes #41.
