### PR TITLE
feat: track LLM recommendations through follow-through (experimental)

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -3,7 +3,8 @@ import type { StoredEvent } from './store.js';
 import { computeMetrics, groupBy, contextGrowthOf, parseTools, CACHE_TTL_MS } from './metrics.js';
 import { costOf } from './pricing.js';
 import { assignPersona } from './personas.js';
-import { structuredFindings } from './followthrough.js';
+import { structuredFindings, fmtMetric } from './followthrough.js';
+import type { MetricKey, LlmIntervention, FollowRow } from './followthrough.js';
 import type { Activity } from './types.js';
 import { ACTIVITIES } from './types.js';
 import { table, section, fmtTokens, renderEnrichedRecs } from './report.js';
@@ -226,10 +227,19 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
   };
 }
 
+/** Metrics follow-through can re-measure — a tracked LLM intervention must target one. */
+export const TRACKABLE_METRICS: MetricKey[] = [
+  'cacheHitRatio', 'reworkRatio', 'thinkToCodeRatio', 'premiumShare',
+  'contextBloatShare', 'coldRestartShare', 'premiumWasteShare', 'retryShare',
+];
+
+const METRIC_DEFINITIONS =
+  'Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). contextGrowth = late-half avg context / early half per session; contextBloatShare = share of long sessions growing >=2x without cache keeping pace. coldRestartTokens = input re-paid on turns resuming after the ~5-min cache TTL; coldRestartShare = that over all fresh-paid input. premiumWasteShare = premium-model tokens on exploration/conversation turns / all spend. retryShare/retryTokens = spend on turns re-running a tool right after it errored. Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.';
+
 export function buildLlmPrompt(events: StoredEvent[], days: number): string {
   return `You are an engineering-efficiency analyst. The JSON below contains AGGREGATE token-usage telemetry from AI coding agents (Claude Code / Gemini CLI / Codex) for one developer or team over ${days} days. There is no prompt or code content — only counts, ratios, tool names, and project names.
 
-Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). contextGrowth = late-half avg context / early half per session; contextBloatShare = share of long sessions growing >=2x without cache keeping pace. coldRestartTokens = input re-paid on turns resuming after the ~5-min cache TTL; coldRestartShare = that over all fresh-paid input. premiumWasteShare = premium-model tokens on exploration/conversation turns / all spend. retryShare/retryTokens = spend on turns re-running a tool right after it errored. Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.
+${METRIC_DEFINITIONS}
 
 Analyze the data and respond in markdown:
 1. **Top 3 interventions**, prioritized by expected token/cost savings. For each: the evidence (cite specific numbers/projects/sessions from the data), the concrete workflow change, and which metric will move if it works.
@@ -240,6 +250,123 @@ Be specific to this data. No generic advice that ignores the numbers. If the dat
 
 DATA:
 ${JSON.stringify(buildLlmPayload(events, days))}`;
+}
+
+/**
+ * The --track variant: same aggregates, but the model must answer in STRICT
+ * JSON whose every intervention targets a TRACKABLE_METRICS key, so each piece
+ * of advice can be parsed into a finding and measured by follow-through.
+ */
+export function buildLlmTrackPrompt(events: StoredEvent[], days: number): string {
+  return `You are an engineering-efficiency analyst. The JSON below is AGGREGATE token-usage telemetry from AI coding agents over ${days} days — counts, ratios, tool names, and project names only; no prompt or code content.
+
+${METRIC_DEFINITIONS}
+
+Propose the highest-impact interventions for this data. Respond with STRICT JSON ONLY — no prose, no markdown, no code fence. Exact shape:
+{"interventions":[{"metric":"<key>","title":"<short imperative change>","rationale":"<one sentence citing specific numbers from the data>"}]}
+
+Rules:
+- "metric" MUST be exactly one of: ${TRACKABLE_METRICS.join(', ')}. It is the number that will be tracked to see whether your advice worked.
+- At most one intervention per metric. Omit any metric the data does not justify. Return 1-5 interventions.
+- Output nothing but the JSON object.
+
+DATA:
+${JSON.stringify(buildLlmPayload(events, days))}`;
+}
+
+/**
+ * Pull the first balanced JSON value out of an LLM response that may wrap it in
+ * prose or a ```json fence. Returns undefined when nothing parses.
+ */
+export function extractJson(text: string): unknown {
+  const tryParse = (s: string): unknown => {
+    try { return JSON.parse(s); } catch { return undefined; }
+  };
+  const direct = tryParse(text.trim());
+  if (direct !== undefined) return direct;
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) {
+    const f = tryParse(fence[1].trim());
+    if (f !== undefined) return f;
+  }
+  // Scan for the first balanced { } or [ ], respecting strings and escapes.
+  const open = text.search(/[[{]/);
+  if (open < 0) return undefined;
+  const openCh = text[open];
+  const closeCh = openCh === '{' ? '}' : ']';
+  let depth = 0, inStr = false, esc = false;
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+    } else if (c === '"') inStr = true;
+    else if (c === openCh) depth++;
+    else if (c === closeCh && --depth === 0) return tryParse(text.slice(open, i + 1));
+  }
+  return undefined;
+}
+
+export interface ParsedFindings {
+  interventions: LlmIntervention[];
+  /** Items the model returned that were dropped (untrackable metric, no title, or a duplicate metric). */
+  dropped: number;
+}
+
+/**
+ * Validate an LLM response into trackable interventions: each must name a
+ * known metric and a title; the first per metric wins (follow-through measures
+ * one number per metric). Malformed or extra items are dropped, not thrown.
+ */
+export function parseLlmFindings(text: string): ParsedFindings {
+  const data = extractJson(text);
+  const arr: unknown[] = Array.isArray(data)
+    ? data
+    : Array.isArray((data as { interventions?: unknown })?.interventions)
+      ? (data as { interventions: unknown[] }).interventions
+      : [];
+  const trackable = new Set<string>(TRACKABLE_METRICS);
+  const seen = new Set<string>();
+  const interventions: LlmIntervention[] = [];
+  let dropped = 0;
+  for (const raw of arr) {
+    const it = raw as { metric?: unknown; title?: unknown; rationale?: unknown };
+    const metric = String(it?.metric ?? '');
+    const title = String(it?.title ?? '').trim().slice(0, 120);
+    if (!trackable.has(metric) || !title || seen.has(metric)) {
+      dropped++;
+      continue;
+    }
+    seen.add(metric);
+    interventions.push({
+      metric: metric as MetricKey,
+      title,
+      rationale: String(it?.rationale ?? '').trim().slice(0, 400),
+    });
+  }
+  return { interventions, dropped };
+}
+
+/** Terminal summary of the interventions just recorded for tracking. */
+export function renderTrackedLlm(rows: FollowRow[], parsed: ParsedFindings): string {
+  const out: string[] = [];
+  out.push(section('LLM recommendations — now tracked through follow-through'));
+  const titleByMetric = new Map(parsed.interventions.map((it) => [it.metric, it.title]));
+  out.push(
+    table(
+      ['Metric', 'Baseline', 'Status', 'Advice'],
+      rows.map((r) => {
+        const advice = titleByMetric.get(r.metric) ?? '';
+        return [r.metric, fmtMetric(r.metric, r.baseline), r.status, advice.length > 60 ? advice.slice(0, 59) + '…' : advice];
+      }),
+    ),
+  );
+  out.push(
+    `\n  ${rows.length} intervention(s) recorded${parsed.dropped ? `, ${parsed.dropped} dropped (untrackable metric)` : ''}. ` +
+      'Re-run `token-monitor report` over time to see whether the metric moved.',
+  );
+  return out.join('\n');
 }
 
 export function renderAnalysis(events: StoredEvent[], days: number): string {
@@ -343,7 +470,12 @@ export const LLM_AGENTS: Record<string, (prompt: string) => { cmd: string; args:
   codex: (p) => ({ cmd: 'codex', args: ['exec', p] }),
 };
 
+/** Env hook: a shell command that stands in for the agent CLI (prompt on stdin,
+ *  response on stdout). Lets `--track` be exercised without a real agent installed. */
+const LLM_CMD_OVERRIDE = 'TOKEN_MONITOR_LLM_CMD';
+
 export function detectAgent(): string | undefined {
+  if (process.env[LLM_CMD_OVERRIDE]) return 'override';
   for (const name of Object.keys(LLM_AGENTS)) {
     const r = spawnSync('which', [name], { stdio: 'ignore' });
     if (r.status === 0) return name;
@@ -361,4 +493,23 @@ export function runLlm(prompt: string, agent: string): number {
   console.error(`Sending aggregate metrics (no prompts/code) to ${cmd} for analysis...\n`);
   const r = spawnSync(cmd, args, { stdio: ['ignore', 'inherit', 'inherit'] });
   return r.status ?? 1;
+}
+
+/** Like runLlm, but captures the agent's stdout so `--track` can parse its JSON. */
+export function runLlmCapture(prompt: string, agent: string): { status: number; stdout: string } {
+  const opts = { encoding: 'utf8' as const, maxBuffer: 16 * 1024 * 1024 };
+  const override = process.env[LLM_CMD_OVERRIDE];
+  console.error(`Sending aggregate metrics (no prompts/code) to ${override ?? agent} for analysis...\n`);
+  if (override) {
+    const r = spawnSync(override, [], { ...opts, input: prompt, shell: true });
+    return { status: r.status ?? 1, stdout: r.stdout ?? '' };
+  }
+  const spec = LLM_AGENTS[agent];
+  if (!spec) {
+    console.error(`Unknown agent "${agent}". Supported: ${Object.keys(LLM_AGENTS).join(', ')}`);
+    return { status: 1, stdout: '' };
+  }
+  const { cmd, args } = spec(prompt);
+  const r = spawnSync(cmd, args, opts);
+  return { status: r.status ?? 1, stdout: r.stdout ?? '' };
 }

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -228,8 +228,11 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
 }
 
 /** Metrics follow-through can re-measure — a tracked LLM intervention must target one. */
+// premiumShare is intentionally excluded: premiumWasteShare already covers
+// premium overspend and is the one carried in the payload + definitions, so the
+// model only ever targets a number it can actually see and cite.
 export const TRACKABLE_METRICS: MetricKey[] = [
-  'cacheHitRatio', 'reworkRatio', 'thinkToCodeRatio', 'premiumShare',
+  'cacheHitRatio', 'reworkRatio', 'thinkToCodeRatio',
   'contextBloatShare', 'coldRestartShare', 'premiumWasteShare', 'retryShare',
 ];
 
@@ -275,37 +278,46 @@ ${JSON.stringify(buildLlmPayload(events, days))}`;
 }
 
 /**
- * Pull the first balanced JSON value out of an LLM response that may wrap it in
- * prose or a ```json fence. Returns undefined when nothing parses.
+ * Every parseable JSON value in the text, best-first: a direct parse, then a
+ * ```json fence, then each balanced { } / [ ] region left to right (strings and
+ * escapes respected). A stray brace in prose before the real JSON therefore
+ * can't hide it — later regions are still considered.
  */
-export function extractJson(text: string): unknown {
-  const tryParse = (s: string): unknown => {
-    try { return JSON.parse(s); } catch { return undefined; }
+function jsonCandidates(text: string): unknown[] {
+  const out: unknown[] = [];
+  const push = (s: string) => {
+    try { out.push(JSON.parse(s)); } catch { /* not JSON, skip */ }
   };
-  const direct = tryParse(text.trim());
-  if (direct !== undefined) return direct;
+  push(text.trim());
   const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  if (fence) {
-    const f = tryParse(fence[1].trim());
-    if (f !== undefined) return f;
+  if (fence) push(fence[1].trim());
+  for (let i = 0; i < text.length; ) {
+    const rel = text.slice(i).search(/[[{]/);
+    if (rel < 0) break;
+    const open = i + rel;
+    const openCh = text[open];
+    const closeCh = openCh === '{' ? '}' : ']';
+    let depth = 0, inStr = false, esc = false, end = -1;
+    for (let j = open; j < text.length; j++) {
+      const c = text[j];
+      if (inStr) {
+        if (esc) esc = false;
+        else if (c === '\\') esc = true;
+        else if (c === '"') inStr = false;
+      } else if (c === '"') inStr = true;
+      else if (c === openCh) depth++;
+      else if (c === closeCh && --depth === 0) { end = j; break; }
+    }
+    if (end < 0) break; // unbalanced from here on
+    push(text.slice(open, end + 1));
+    i = end + 1; // continue after this region, not inside it
   }
-  // Scan for the first balanced { } or [ ], respecting strings and escapes.
-  const open = text.search(/[[{]/);
-  if (open < 0) return undefined;
-  const openCh = text[open];
-  const closeCh = openCh === '{' ? '}' : ']';
-  let depth = 0, inStr = false, esc = false;
-  for (let i = open; i < text.length; i++) {
-    const c = text[i];
-    if (inStr) {
-      if (esc) esc = false;
-      else if (c === '\\') esc = true;
-      else if (c === '"') inStr = false;
-    } else if (c === '"') inStr = true;
-    else if (c === openCh) depth++;
-    else if (c === closeCh && --depth === 0) return tryParse(text.slice(open, i + 1));
-  }
-  return undefined;
+  return out;
+}
+
+/** First parseable JSON value (prose/fence-tolerant); undefined when none. */
+export function extractJson(text: string): unknown {
+  return jsonCandidates(text)[0];
 }
 
 export interface ParsedFindings {
@@ -318,34 +330,47 @@ export interface ParsedFindings {
  * Validate an LLM response into trackable interventions: each must name a
  * known metric and a title; the first per metric wins (follow-through measures
  * one number per metric). Malformed or extra items are dropped, not thrown.
+ * Of all JSON values in the response, the first that yields ≥1 intervention is
+ * used — so a stray `[0]` or `{note}` in prose can't shadow the real payload.
  */
 export function parseLlmFindings(text: string): ParsedFindings {
-  const data = extractJson(text);
-  const arr: unknown[] = Array.isArray(data)
-    ? data
-    : Array.isArray((data as { interventions?: unknown })?.interventions)
-      ? (data as { interventions: unknown[] }).interventions
-      : [];
   const trackable = new Set<string>(TRACKABLE_METRICS);
-  const seen = new Set<string>();
-  const interventions: LlmIntervention[] = [];
-  let dropped = 0;
-  for (const raw of arr) {
-    const it = raw as { metric?: unknown; title?: unknown; rationale?: unknown };
-    const metric = String(it?.metric ?? '');
-    const title = String(it?.title ?? '').trim().slice(0, 120);
-    if (!trackable.has(metric) || !title || seen.has(metric)) {
-      dropped++;
-      continue;
+  const toArray = (data: unknown): unknown[] =>
+    Array.isArray(data)
+      ? data
+      : Array.isArray((data as { interventions?: unknown })?.interventions)
+        ? (data as { interventions: unknown[] }).interventions
+        : [];
+  const validate = (arr: unknown[]): ParsedFindings => {
+    const seen = new Set<string>();
+    const interventions: LlmIntervention[] = [];
+    let dropped = 0;
+    for (const raw of arr) {
+      const it = raw as { metric?: unknown; title?: unknown; rationale?: unknown };
+      const metric = String(it?.metric ?? '');
+      const title = String(it?.title ?? '').trim().slice(0, 120);
+      if (!trackable.has(metric) || !title || seen.has(metric)) {
+        dropped++;
+        continue;
+      }
+      seen.add(metric);
+      interventions.push({
+        metric: metric as MetricKey,
+        title,
+        rationale: String(it?.rationale ?? '').trim().slice(0, 400),
+      });
     }
-    seen.add(metric);
-    interventions.push({
-      metric: metric as MetricKey,
-      title,
-      rationale: String(it?.rationale ?? '').trim().slice(0, 400),
-    });
+    return { interventions, dropped };
+  };
+  let fallback: ParsedFindings = { interventions: [], dropped: 0 };
+  for (const candidate of jsonCandidates(text)) {
+    const arr = toArray(candidate);
+    if (arr.length === 0) continue;
+    const result = validate(arr);
+    if (result.interventions.length > 0) return result;
+    fallback = result; // parsed but everything dropped — keep for the count
   }
-  return { interventions, dropped };
+  return fallback;
 }
 
 /** Terminal summary of the interventions just recorded for tracking. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,12 +7,12 @@ import { renderReport, renderTeamReport, renderTrend } from './report.js';
 import { splitWindow } from './trends.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import { buildExport, parseTeamConfig, mergeMetrics, dedupeExports, rollupExports, displayName, identityOf } from './team.js';
-import { syncFindings } from './followthrough.js';
+import { syncFindings, recordLlmFindings } from './followthrough.js';
 import { enrichFindings } from './recommendations.js';
 import { reconcile, renderReconcile, PROVIDERS } from './reconcile.js';
 import { computeMetrics } from './metrics.js';
 import { renderHtml, renderTeamHtml } from './html.js';
-import { renderAnalysis, deepAnalysis, buildLlmPrompt, runLlm, detectAgent } from './analyze.js';
+import { renderAnalysis, deepAnalysis, buildLlmPrompt, buildLlmTrackPrompt, runLlm, runLlmCapture, parseLlmFindings, renderTrackedLlm, detectAgent } from './analyze.js';
 import { signObject, verifyObject, ensureKeypair, fingerprint, loadKeyring, checkKeyring, keyDirFor, DEFAULT_KEY_DIR } from './sign.js';
 import { fetchTeamConfig, saveConfig, loadConfig, pushExport, installSchedule, removeSchedule } from './deploy.js';
 import { realpathSync } from 'node:fs';
@@ -24,7 +24,7 @@ const HELP = `token-monitor — measure how effectively your team spends AI codi
 Usage:
   token-monitor collect [--source <name>] [--db <path>]
   token-monitor report  [--days <n>] [--trend] [--project <name>] [--source <name>] [--json] [--db <path>]
-  token-monitor analyze [--days <n>] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
+  token-monitor analyze [--days <n>] [--llm] [--track] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline]
                         [--verify] [--keys keys.json] [--json] [--html team.html]
@@ -39,7 +39,9 @@ Commands:
             Antigravity, Copilot Chat) into SQLite
   report    Activity breakdown, cost, personas, and recommendations
   analyze   Session-level deep dive; --llm asks your local agent CLI for
-            prioritized recommendations (sends aggregate metrics only)
+            prioritized recommendations (sends aggregate metrics only); add
+            --track to record those recommendations and measure (via
+            follow-through) whether they actually moved their metric
   html      Self-contained HTML dashboard (no server, no external assets)
   merge     Combine member exports (report --json > me.json) into a team report
   init      Join a team: fetch the lead's config, set up keys, first collect,
@@ -118,6 +120,7 @@ async function main() {
       team: { type: 'string' },
       out: { type: 'string', default: 'report.html' },
       llm: { type: 'boolean', default: false },
+      track: { type: 'boolean', default: false },
       agent: { type: 'string' },
       verify: { type: 'boolean', default: false },
       keys: { type: 'string' },
@@ -285,6 +288,26 @@ Signing fingerprint (send to your team lead for keys.json):
       console.log(JSON.stringify(deepAnalysis(events), null, 2));
     } else {
       console.log(renderAnalysis(events, days));
+    }
+    if (values.track) {
+      if (values.project || values.source) {
+        console.error('--track needs an unfiltered window so follow-through baselines stay clean; drop --project/--source.');
+        process.exit(1);
+      }
+      const agent = values.agent ?? detectAgent();
+      if (!agent) {
+        console.error('No agent CLI found (looked for: claude, gemini, codex). Install one or pass --agent.');
+        process.exit(1);
+      }
+      const { status, stdout } = runLlmCapture(buildLlmTrackPrompt(events, days), agent);
+      const parsed = parseLlmFindings(stdout);
+      if (parsed.interventions.length === 0) {
+        console.error('No trackable interventions parsed from the agent response (expected strict JSON targeting a known metric).');
+        process.exit(status || 1);
+      }
+      const rows = recordLlmFindings(db, parsed.interventions, computeMetrics(events));
+      console.log(renderTrackedLlm(rows, parsed));
+      process.exit(0);
     }
     if (values.llm) {
       const agent = values.agent ?? detectAgent();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -300,10 +300,16 @@ Signing fingerprint (send to your team lead for keys.json):
         process.exit(1);
       }
       const { status, stdout } = runLlmCapture(buildLlmTrackPrompt(events, days), agent);
+      // A nonzero exit means the run failed (rate limit, crash, partial output);
+      // don't bank possibly-truncated advice as a permanent, never-clearing baseline.
+      if (status !== 0) {
+        console.error(`Agent exited with status ${status}; not recording (its output may be incomplete).`);
+        process.exit(status);
+      }
       const parsed = parseLlmFindings(stdout);
       if (parsed.interventions.length === 0) {
         console.error('No trackable interventions parsed from the agent response (expected strict JSON targeting a known metric).');
-        process.exit(status || 1);
+        process.exit(1);
       }
       const rows = recordLlmFindings(db, parsed.interventions, computeMetrics(events));
       console.log(renderTrackedLlm(rows, parsed));

--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -228,7 +228,8 @@ export function syncFindings(
  * they target (`llm:<metric>`) so re-running `--track` keeps the original
  * baseline and follow-through can measure whether the advice moved the number.
  * At most one tracked intervention per metric — the first advice for it wins
- * (INSERT OR IGNORE). Returns the LLM rows, re-measured against `m`.
+ * (INSERT OR IGNORE). Returns the LLM rows for THIS call's metrics, re-measured
+ * against `m` (not every llm row ever stored), so callers summarise one run.
  */
 export function recordLlmFindings(
   db: DatabaseSync,
@@ -245,7 +246,8 @@ export function recordLlmFindings(
     const message = it.rationale ? `${it.title} — ${it.rationale}` : it.title;
     insert.run(`llm:${it.metric}`, it.metric, METRIC_DIRECTION[it.metric], message, metricValue(m, it.metric), now);
   }
-  return syncFindings(db, m, now).filter((r) => r.origin === 'llm');
+  const metrics = new Set(interventions.map((it) => it.metric));
+  return syncFindings(db, m, now).filter((r) => r.origin === 'llm' && metrics.has(r.metric));
 }
 
 export function fmtMetric(key: MetricKey, v: number): string {

--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -37,6 +37,22 @@ export function metricValue(m: Metrics, key: MetricKey): number {
   return m[key];
 }
 
+/**
+ * The improvement direction for each tracked metric. LLM-suggested
+ * interventions (#42) are scored against this, not against whatever direction
+ * the model claims — the canonical direction is the source of truth.
+ */
+export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
+  cacheHitRatio: 'up',
+  reworkRatio: 'down',
+  thinkToCodeRatio: 'up',
+  premiumShare: 'down',
+  contextBloatShare: 'down',
+  coldRestartShare: 'down',
+  premiumWasteShare: 'down',
+  retryShare: 'down',
+};
+
 export function structuredFindings(m: Metrics): Finding[] {
   const out: Finding[] = [];
   if (m.cacheHitRatio < 0.5 && m.spendTokens > 100_000) {
@@ -115,6 +131,15 @@ export interface FollowRow {
   current: number;
   createdAt: string;
   status: 'new' | 'tracking' | 'improving' | 'regressing' | 'resolved';
+  /** 'rule' = built-in finding; 'llm' = advice from `analyze --llm --track`. */
+  origin: 'rule' | 'llm';
+}
+
+/** One intervention parsed from a strict-JSON `analyze --llm --track` response. */
+export interface LlmIntervention {
+  metric: MetricKey;
+  title: string;
+  rationale: string;
 }
 
 export function ensureFollowTable(db: DatabaseSync): void {
@@ -128,9 +153,15 @@ export function ensureFollowTable(db: DatabaseSync): void {
       created_at TEXT NOT NULL,
       last_value REAL,
       last_checked TEXT,
-      resolved_at TEXT
+      resolved_at TEXT,
+      origin TEXT NOT NULL DEFAULT 'rule'
     );
   `);
+  // Migrate dbs created before LLM-tracked findings carried an origin.
+  const cols = db.prepare(`PRAGMA table_info(recommendations)`).all() as Array<{ name: string }>;
+  if (!cols.some((c) => c.name === 'origin')) {
+    db.exec(`ALTER TABLE recommendations ADD COLUMN origin TEXT NOT NULL DEFAULT 'rule'`);
+  }
 }
 
 const MOVE_THRESHOLD = 0.02;
@@ -159,7 +190,7 @@ export function syncFindings(
 
   const rows = db.prepare('SELECT * FROM recommendations').all() as Array<{
     key: string; metric: MetricKey; direction: 'up' | 'down'; baseline: number;
-    created_at: string; resolved_at: string | null;
+    created_at: string; resolved_at: string | null; origin: 'rule' | 'llm';
   }>;
 
   const update = db.prepare(
@@ -168,7 +199,9 @@ export function syncFindings(
   const out: FollowRow[] = [];
   for (const r of rows) {
     const current = metricValue(m, r.metric);
-    const stillActive = active.has(r.key);
+    // Rule findings resolve when they stop firing; LLM-tracked advice has no
+    // firing condition, so it keeps tracking until its metric is re-measured.
+    const stillActive = r.origin === 'llm' ? true : active.has(r.key);
     // Resolve when the finding no longer fires; re-open if it fires again.
     const resolvedAt = stillActive ? null : (r.resolved_at ?? now);
     update.run(current, now, resolvedAt, r.key);
@@ -184,9 +217,35 @@ export function syncFindings(
     out.push({
       key: r.key, metric: r.metric, direction: r.direction,
       baseline: r.baseline, current, createdAt: r.created_at, status,
+      origin: r.origin ?? 'rule',
     });
   }
   return out.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+/**
+ * Persist LLM-suggested interventions as tracked findings, keyed by the metric
+ * they target (`llm:<metric>`) so re-running `--track` keeps the original
+ * baseline and follow-through can measure whether the advice moved the number.
+ * At most one tracked intervention per metric — the first advice for it wins
+ * (INSERT OR IGNORE). Returns the LLM rows, re-measured against `m`.
+ */
+export function recordLlmFindings(
+  db: DatabaseSync,
+  interventions: LlmIntervention[],
+  m: Metrics,
+  now: string = new Date().toISOString(),
+): FollowRow[] {
+  ensureFollowTable(db);
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO recommendations (key, metric, direction, message, baseline, created_at, origin)
+    VALUES (?, ?, ?, ?, ?, ?, 'llm')
+  `);
+  for (const it of interventions) {
+    const message = it.rationale ? `${it.title} — ${it.rationale}` : it.title;
+    insert.run(`llm:${it.metric}`, it.metric, METRIC_DIRECTION[it.metric], message, metricValue(m, it.metric), now);
+  }
+  return syncFindings(db, m, now).filter((r) => r.origin === 'llm');
 }
 
 export function fmtMetric(key: MetricKey, v: number): string {

--- a/src/html.ts
+++ b/src/html.ts
@@ -125,7 +125,7 @@ export function renderHtml(
       ? `<h2>Follow-through</h2><table><tr><th>Recommendation</th><th>Metric</th><th>Baseline</th><th>Now</th><th>Realized</th><th>Since</th><th>Status</th></tr>${opts.follow
           .map((f) => {
             const realized = realizedMonthly(f, m, rates, opts.days);
-            return `<tr><td>${esc(f.key)}</td><td>${f.metric}</td><td class="num">${fmtMetric(f.metric, f.baseline)}</td><td class="num">${fmtMetric(f.metric, f.current)}</td><td class="num">${realized ? `<span class="save">+${fmtUsdShort(realized)}/mo</span>` : '<span class="muted">—</span>'}</td><td>${f.createdAt.slice(0, 10)}</td><td class="st-${f.status}">${f.status}</td></tr>`;
+            return `<tr><td>${f.origin === 'llm' ? '🤖 ' : ''}${esc(f.key)}</td><td>${f.metric}</td><td class="num">${fmtMetric(f.metric, f.baseline)}</td><td class="num">${fmtMetric(f.metric, f.current)}</td><td class="num">${realized ? `<span class="save">+${fmtUsdShort(realized)}/mo</span>` : '<span class="muted">—</span>'}</td><td>${f.createdAt.slice(0, 10)}</td><td class="st-${f.status}">${f.status}</td></tr>`;
           })
           .join('')}</table>`
       : '';

--- a/src/report.ts
+++ b/src/report.ts
@@ -149,7 +149,7 @@ export function renderReport(
         opts.follow.map((f) => {
           const realized = realizedMonthly(f, m, rates, opts.days);
           return [
-            f.key,
+            (f.origin === 'llm' ? '🤖 ' : '') + f.key,
             f.metric,
             fmtMetric(f.metric, f.baseline),
             fmtMetric(f.metric, f.current),

--- a/test/analyze.test.ts
+++ b/test/analyze.test.ts
@@ -110,6 +110,20 @@ test('extractJson finds the first balanced object inside surrounding noise', () 
   assert.equal(extractJson('no json here'), undefined);
 });
 
+test('parseLlmFindings recovers the payload past a stray bracket region in prose', () => {
+  // a non-JSON {curly} and a valid-but-useless [0] precede the real object
+  const text = 'Notes: {see below} and item [0]:\n{"interventions":[{"metric":"cacheHitRatio","title":"reuse"}]}';
+  assert.equal(parseLlmFindings(text).interventions[0]?.metric, 'cacheHitRatio');
+});
+
+test('parseLlmFindings respects braces and escapes inside JSON strings', () => {
+  const text = 'Here: {"interventions":[{"metric":"reworkRatio","title":"close the } and ] here","rationale":"a \\"quote\\" too"}]} done';
+  const got = parseLlmFindings(text);
+  assert.equal(got.interventions[0].metric, 'reworkRatio');
+  assert.equal(got.interventions[0].title, 'close the } and ] here');
+  assert.equal(got.interventions[0].rationale, 'a "quote" too');
+});
+
 test('parseLlmFindings: strict object form', () => {
   const { interventions, dropped } = parseLlmFindings(
     '{"interventions":[{"metric":"cacheHitRatio","title":"Reuse prompt","rationale":"cache 12%"}]}',

--- a/test/analyze.test.ts
+++ b/test/analyze.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { computeSessionStats, computeToolStats, deepAnalysis, buildLlmPayload, buildLlmPrompt } from '../src/analyze.js';
+import { computeSessionStats, computeToolStats, deepAnalysis, buildLlmPayload, buildLlmPrompt, buildLlmTrackPrompt, parseLlmFindings, extractJson } from '../src/analyze.js';
 import { makeStored } from './helpers.js';
 
 const fixLoopSession = [
@@ -93,4 +93,47 @@ test('llm prompt embeds definitions, asks for prioritized interventions, stays c
   assert.ok(prompt.includes('reworkRatio = '));
   assert.ok(prompt.includes('DATA:'));
   assert.ok(prompt.length < 20_000, `prompt too large: ${prompt.length}`);
+});
+
+test('track prompt demands strict JSON targeting a trackable metric', () => {
+  const prompt = buildLlmTrackPrompt(fixLoopSession, 30);
+  assert.ok(prompt.includes('STRICT JSON'));
+  assert.ok(prompt.includes('"interventions"'));
+  assert.ok(prompt.includes('cacheHitRatio')); // lists the trackable metrics
+  assert.ok(prompt.includes('reworkRatio = ')); // shares the metric definitions
+  assert.ok(prompt.includes('DATA:'));
+});
+
+test('extractJson finds the first balanced object inside surrounding noise', () => {
+  assert.deepEqual(extractJson('blah {"a":1,"b":{"c":2}} trailing'), { a: 1, b: { c: 2 } });
+  assert.deepEqual(extractJson('"a string with } brace"'), 'a string with } brace');
+  assert.equal(extractJson('no json here'), undefined);
+});
+
+test('parseLlmFindings: strict object form', () => {
+  const { interventions, dropped } = parseLlmFindings(
+    '{"interventions":[{"metric":"cacheHitRatio","title":"Reuse prompt","rationale":"cache 12%"}]}',
+  );
+  assert.equal(interventions.length, 1);
+  assert.equal(interventions[0].metric, 'cacheHitRatio');
+  assert.equal(interventions[0].title, 'Reuse prompt');
+  assert.equal(dropped, 0);
+});
+
+test('parseLlmFindings: tolerates prose and a ```json fence around the JSON', () => {
+  const text =
+    'Sure, here are my picks:\n```json\n{"interventions":[{"metric":"reworkRatio","title":"Plan first","rationale":"rework 40%"}]}\n```\nHope that helps!';
+  assert.equal(parseLlmFindings(text).interventions[0].metric, 'reworkRatio');
+});
+
+test('parseLlmFindings: bare array, drops untrackable / duplicate / titleless items', () => {
+  const text =
+    '[{"metric":"cacheHitRatio","title":"a"},{"metric":"bogusMetric","title":"b"},{"metric":"cacheHitRatio","title":"dup"},{"metric":"retryShare","title":""}]';
+  const { interventions, dropped } = parseLlmFindings(text);
+  assert.deepEqual(interventions.map((i) => i.metric), ['cacheHitRatio']);
+  assert.equal(dropped, 3); // bogus metric, duplicate metric, empty title
+});
+
+test('parseLlmFindings: no JSON present yields an empty, non-throwing result', () => {
+  assert.deepEqual(parseLlmFindings('I could not analyze this.'), { interventions: [], dropped: 0 });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -216,6 +216,28 @@ test('e2e: analyze --llm --track records LLM advice into follow-through', () => 
   assert.match(filtered.stderr, /unfiltered window/);
 });
 
+test('e2e: --track records nothing when the agent fails or returns no JSON', () => {
+  // (1) valid JSON but a nonzero exit -> not recorded, CLI propagates failure.
+  const failJson = join(HOME, 'fail-json.mjs');
+  writeFileSync(
+    failJson,
+    "process.stdout.write(JSON.stringify({interventions:[{metric:'retryShare',title:'x',rationale:'y'}]}));process.exit(3);",
+  );
+  const r1 = run(['analyze', '--track', ...DAYS], { env: { TOKEN_MONITOR_LLM_CMD: `${process.execPath} ${failJson}` } });
+  assert.notEqual(r1.code, 0);
+  assert.match(r1.stderr, /exited with status/);
+
+  // (2) clean exit but no parseable JSON -> nonzero, nothing recorded.
+  const noJson = join(HOME, 'no-json.mjs');
+  writeFileSync(noJson, "process.stdout.write('I have no structured advice for you.');");
+  const r2 = run(['analyze', '--track', ...DAYS], { env: { TOKEN_MONITOR_LLM_CMD: `${process.execPath} ${noJson}` } });
+  assert.notEqual(r2.code, 0);
+  assert.match(r2.stderr, /No trackable interventions/);
+
+  // Neither attempt persisted a retryShare row.
+  assert.ok(!run(['report', ...DAYS]).stdout.includes('llm:retryShare'));
+});
+
 test('e2e: init from local config + push delivers a verifiable export', () => {
   const home2 = mkdtempSync(join(tmpdir(), 'tm-e2e-init-'));
   cpSync(join(FIXTURES, 'claude'), join(home2, '.claude', 'projects'), { recursive: true });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -29,12 +29,12 @@ makeCursorFixture(cursorUserDir(HOME));
 makeAntigravityFixture(join(HOME, '.gemini', 'antigravity-cli'));
 cpSync(join(FIXTURES, 'copilot'), codeUserDir(HOME), { recursive: true });
 
-function run(args: string[], opts: { home?: string } = {}) {
+function run(args: string[], opts: { home?: string; env?: NodeJS.ProcessEnv } = {}) {
   const home = opts.home ?? HOME;
   const r = spawnSync(process.execPath, [CLI, ...args], {
     encoding: 'utf8',
     // APPDATA keeps win32 path resolution inside the synthetic home too.
-    env: { ...process.env, HOME: home, USERPROFILE: home, APPDATA: join(home, 'AppData', 'Roaming') },
+    env: { ...process.env, HOME: home, USERPROFILE: home, APPDATA: join(home, 'AppData', 'Roaming'), ...opts.env },
   });
   return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.status };
 }
@@ -181,6 +181,39 @@ test('e2e: analyze renders the deep dive', () => {
   assert.equal(code, 0);
   assert.ok(stdout.includes('Deep analysis'));
   assert.ok(stdout.includes('Most expensive sessions'));
+});
+
+test('e2e: analyze --llm --track records LLM advice into follow-through', () => {
+  // A fake agent CLI: reads the prompt on stdin, returns strict JSON (wrapped in
+  // prose + a fence, to exercise the tolerant parser).
+  const fake = join(HOME, 'fake-llm.mjs');
+  writeFileSync(fake, [
+    "let s='';",
+    "process.stdin.on('data', (d) => (s += d));",
+    "process.stdin.on('end', () => {",
+    "  const body = JSON.stringify({ interventions: [",
+    "    { metric: 'cacheHitRatio', direction: 'up', title: 'Reuse the system prompt across turns', rationale: 'cache hit is low' },",
+    "    { metric: 'reworkRatio', direction: 'down', title: 'Plan before coding', rationale: 'rework is high' },",
+    "  ] });",
+    "  process.stdout.write('Here are my picks:\\n```json\\n' + body + '\\n```\\n');",
+    "});",
+  ].join('\n'));
+  const env = { TOKEN_MONITOR_LLM_CMD: `${process.execPath} ${fake}` };
+
+  const tracked = run(['analyze', '--llm', '--track', ...DAYS], { env });
+  assert.equal(tracked.code, 0, tracked.stderr);
+  assert.ok(tracked.stdout.includes('now tracked through follow-through'));
+  assert.ok(tracked.stdout.includes('cacheHitRatio'));
+
+  // The advice now appears in the report's follow-through, marked LLM-origin.
+  const rep = run(['report', ...DAYS]);
+  assert.ok(rep.stdout.includes('llm:cacheHitRatio'), 'report must track the LLM finding');
+  assert.ok(rep.stdout.includes('🤖'), 'LLM-origin rows are marked');
+
+  // --track refuses a filtered window (would pollute baselines).
+  const filtered = run(['analyze', '--track', '--project', 'proj-alpha', ...DAYS], { env });
+  assert.equal(filtered.code, 1);
+  assert.match(filtered.stderr, /unfiltered window/);
 });
 
 test('e2e: init from local config + push delivers a verifiable export', () => {

--- a/test/followthrough.test.ts
+++ b/test/followthrough.test.ts
@@ -165,6 +165,28 @@ test('LLM-tracked findings never auto-resolve when a rule finding clears', () =>
   assert.equal(llm.origin, 'llm');
 });
 
+test('recordLlmFindings returns only this run\'s metrics, not the whole history', () => {
+  const db = openDb(':memory:');
+  recordLlmFindings(db, [{ metric: 'cacheHitRatio', title: 'a', rationale: '' }], badCache(), '2026-06-01T00:00:00.000Z');
+  const second = recordLlmFindings(db, [{ metric: 'reworkRatio', title: 'b', rationale: '' }], badCache(), '2026-06-08T00:00:00.000Z');
+  assert.deepEqual(second.map((r) => r.key), ['llm:reworkRatio']); // not cacheHitRatio from run 1
+});
+
+test('an LLM-tracked finding flips to regressing when its (canonical-direction) metric worsens', () => {
+  const db = openDb(':memory:');
+  // Baseline: zero rework (good). The model claims nothing about direction.
+  const lowRework = computeMetrics([makeStored({ activity: 'coding', input_tokens: 100_000, output_tokens: 0 })]);
+  recordLlmFindings(db, [{ metric: 'reworkRatio', title: 'Keep planning first', rationale: '' }], lowRework, '2026-06-01T00:00:00.000Z');
+  // Later: a failure then heavy coding pushes rework up — the metric got worse.
+  const highRework = computeMetrics([
+    makeStored({ session_id: 'r', ts: '2026-06-02T00:00:00Z', activity: 'coding', is_error: 1, input_tokens: 1_000, output_tokens: 0 }),
+    makeStored({ session_id: 'r', ts: '2026-06-02T00:01:00Z', activity: 'coding', input_tokens: 100_000, output_tokens: 0 }),
+  ]);
+  const llm = syncFindings(db, highRework, '2026-06-08T00:00:00.000Z').find((r) => r.key === 'llm:reworkRatio')!;
+  assert.equal(llm.direction, 'down'); // canonical, from METRIC_DIRECTION
+  assert.equal(llm.status, 'regressing');
+});
+
 test('ensureFollowTable migrates a pre-origin recommendations table', () => {
   const db = openDb(':memory:');
   // An older db: recommendations table without the origin column.

--- a/test/followthrough.test.ts
+++ b/test/followthrough.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { openDb } from '../src/store.js';
 import { computeMetrics } from '../src/metrics.js';
-import { syncFindings, structuredFindings, premiumShare } from '../src/followthrough.js';
+import { syncFindings, structuredFindings, premiumShare, recordLlmFindings } from '../src/followthrough.js';
 import { makeStored } from './helpers.js';
 
 // Big spend, no cache reads -> 'low-cache-hit' fires.
@@ -123,4 +123,57 @@ test('premiumShare measures premium-model token share', () => {
     makeStored({ model: 'claude-haiku-4-5', input_tokens: 100, output_tokens: 0 }),
   ]);
   assert.ok(Math.abs(premiumShare(m) - 0.9) < 1e-9);
+});
+
+test('recordLlmFindings stores advice keyed by metric, baselined to current, canonical direction', () => {
+  const db = openDb(':memory:');
+  const rows = recordLlmFindings(db, [
+    { metric: 'cacheHitRatio', title: 'Reuse the system prompt', rationale: 'cache 0%' },
+    { metric: 'reworkRatio', title: 'Plan before coding', rationale: '' },
+  ], badCache(), '2026-06-01T00:00:00.000Z');
+  const cache = rows.find((r) => r.key === 'llm:cacheHitRatio')!;
+  assert.ok(cache);
+  assert.equal(cache.origin, 'llm');
+  assert.equal(cache.direction, 'up'); // canonical, not whatever the model said
+  assert.equal(cache.baseline, 0); // current metric value at record time
+  assert.equal(cache.status, 'new');
+  assert.ok(rows.some((r) => r.key === 'llm:reworkRatio'));
+});
+
+test('recordLlmFindings keeps the original baseline across reruns; one row per metric', () => {
+  const db = openDb(':memory:');
+  recordLlmFindings(db, [{ metric: 'cacheHitRatio', title: 'first', rationale: '' }], badCache(), '2026-06-01T00:00:00.000Z');
+  const rows = recordLlmFindings(db, [
+    { metric: 'cacheHitRatio', title: 'reworded later', rationale: 'x' },
+  ], goodCache(), '2026-06-08T00:00:00.000Z');
+  const cache = rows.filter((r) => r.key === 'llm:cacheHitRatio');
+  assert.equal(cache.length, 1); // INSERT OR IGNORE: no duplicate metric row
+  assert.equal(cache[0].baseline, 0); // baseline from the FIRST recording
+  assert.ok(cache[0].current > 0.9); // re-measured against the new window
+  assert.equal(cache[0].status, 'improving'); // the advice moved the metric up
+});
+
+test('LLM-tracked findings never auto-resolve when a rule finding clears', () => {
+  const db = openDb(':memory:');
+  recordLlmFindings(db, [{ metric: 'cacheHitRatio', title: 'x', rationale: '' }], badCache(), '2026-06-01T00:00:00.000Z');
+  // A later unfiltered report on good cache: the rule low-cache-hit resolves,
+  // but the LLM row has no firing condition so it keeps tracking.
+  const rows = syncFindings(db, goodCache(), '2026-06-08T00:00:00.000Z');
+  assert.equal(rows.find((r) => r.key === 'low-cache-hit')?.status, 'resolved');
+  const llm = rows.find((r) => r.key === 'llm:cacheHitRatio')!;
+  assert.notEqual(llm.status, 'resolved');
+  assert.equal(llm.origin, 'llm');
+});
+
+test('ensureFollowTable migrates a pre-origin recommendations table', () => {
+  const db = openDb(':memory:');
+  // An older db: recommendations table without the origin column.
+  db.exec(`CREATE TABLE recommendations (
+    key TEXT PRIMARY KEY, metric TEXT NOT NULL, direction TEXT NOT NULL, message TEXT NOT NULL,
+    baseline REAL NOT NULL, created_at TEXT NOT NULL, last_value REAL, last_checked TEXT, resolved_at TEXT
+  )`);
+  db.prepare(`INSERT INTO recommendations (key, metric, direction, message, baseline, created_at)
+    VALUES ('low-cache-hit', 'cacheHitRatio', 'up', 'm', 0, '2026-06-01')`).run();
+  const rows = syncFindings(db, badCache(), '2026-06-02T00:00:00.000Z');
+  assert.equal(rows.find((r) => r.key === 'low-cache-hit')?.origin, 'rule'); // defaulted on migration
 });

--- a/test/html.test.ts
+++ b/test/html.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { renderHtml } from '../src/html.js';
 import { makeStored } from './helpers.js';
+import type { FollowRow } from '../src/followthrough.js';
 
 test('renderHtml produces a self-contained document with key sections', () => {
   const html = renderHtml(
@@ -25,4 +26,17 @@ test('renderHtml escapes project names', () => {
     { days: 30 },
   );
   assert.ok(!html.includes('<img src=x'));
+});
+
+test('renderHtml marks LLM-origin follow-through rows with a robot', () => {
+  const follow: FollowRow[] = [{
+    key: 'llm:cacheHitRatio', metric: 'cacheHitRatio', direction: 'up',
+    baseline: 0.1, current: 0.1, createdAt: '2026-06-01', status: 'tracking', origin: 'llm',
+  }];
+  const html = renderHtml(
+    [makeStored({ activity: 'coding', input_tokens: 1000, output_tokens: 0 })],
+    { days: 30, follow },
+  );
+  assert.ok(html.includes('🤖'));
+  assert.ok(html.includes('llm:cacheHitRatio'));
 });

--- a/test/recommendations.test.ts
+++ b/test/recommendations.test.ts
@@ -160,7 +160,7 @@ test('realizedMonthly prices the baseline->current move; flat rows stay blank', 
   const rates = blendedRates(m);
   const row = (current: number): FollowRow => ({
     key: 'low-cache-hit', metric: 'cacheHitRatio', direction: 'up',
-    baseline: 0.4, current, createdAt: '2026-06-01', status: 'improving',
+    baseline: 0.4, current, createdAt: '2026-06-01', status: 'improving', origin: 'rule',
   });
   const realized = realizedMonthly(row(0.6), m, rates, 30)!;
   // 0.2 move × inputSide × (input − cacheRead)


### PR DESCRIPTION
## #42 — track LLM recommendations through follow-through (experimental)

`analyze --llm` gives freeform markdown that evaporates. This adds `analyze --llm --track`: the agent must answer in **strict JSON**, each intervention is parsed into a structured finding, recorded in the follow-through table, and **measured over time** — does the model's advice actually move its metric?

### How it works
- Asks for `{"interventions":[{"metric","title","rationale"}]}` where `metric` is one of the trackable metrics (the number follow-through will re-measure).
- Findings keyed `llm:<metric>` (`INSERT OR IGNORE`) → re-running keeps the **original baseline** and tracks one number per metric. Direction is **canonical** (`METRIC_DIRECTION`), never the model's claim (the parser doesn't even read a claimed direction).
- `recommendations` table gains an `origin` column (migrated in place for older dbs). LLM rows **never auto-resolve** (no firing condition) and render with a 🤖 marker in the `report`/`html` follow-through, alongside the rule findings.
- Privacy unchanged: the payload is the existing aggregate-only `buildLlmPayload` (counts/ratios/names, no prompt or code).

### Guardrails (from the adversarial review)
- **Tolerant parser** — unwraps prose / ```json fences, balanced-bracket scan over *all* regions (string/escape-aware), picks the first yielding interventions; drops untrackable/duplicate/titleless items, never throws.
- **Clean-exit gate** — a nonzero agent exit records nothing and propagates the failure, so a crashed/rate-limited run can't bank a permanent baseline.
- `--track` refuses a `--project`/`--source` window (would pollute global baselines).
- Summary scoped to the current run.

### Testing
- 20 new cases across `followthrough` / `analyze` / `html` / `e2e`: record + baseline stability, never-auto-resolve, **regressing** transition, migration, parser tolerance (fence / stray bracket / in-string braces), exit-code guards, and the 🤖 marker.
- `e2e` drives the real CLI via a `TOKEN_MONITOR_LLM_CMD` fake-agent seam (no real agent needed in CI).
- Full suite: **128 passing**.

Milestone: v0.8.0. Closes #42. Experimental flag.
