### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-monitor",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-monitor",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "token-monitor",
   "displayName": "Token Monitor",
   "description": "Status-bar token/cost for the current project plus the token-monitor dashboard, for VS Code, Cursor, Windsurf, and Antigravity.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "publisher": "ryan653133",
   "license": "MIT",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ryandemelo/token-monitor",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "bin": {
         "token-monitor": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex, Cursor, Antigravity, Copilot Chat) — activity breakdowns, usage personas, and recommendations.",
   "license": "MIT",
   "author": "Ryan de Melo",


### PR DESCRIPTION
Release **v0.8.0** bundling the two milestone features:
- #41 cause decomposition (PR #49)
- #42 LLM recs through follow-through, experimental (PR #50)

Version-only bump (root + extension). No tag is pushed by this PR — tagging `v0.8.0` is the publish trigger and stays manual.