### PR TITLE
fix(ci): compile the extension before vsce publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,10 @@ jobs:
       - run: npm run build
       - run: npm ci
         working-directory: extension
+      # vsce publish has no prepublish hook here, so compile the entrypoint
+      # (dist/src/extension.js) before packaging — otherwise publish aborts.
+      - run: npm run compile
+        working-directory: extension
       - run: npx @vscode/vsce publish -p "$VSCE_PAT"
         working-directory: extension
         env:


### PR DESCRIPTION
The `marketplace` job published without compiling the extension first (no `vscode:prepublish` hook), so `dist/src/extension.js` was missing on the fresh runner and `vsce publish` aborted with *Extension entrypoint(s) missing*. It only surfaced now because this was the job's first real auto-run — v0.7.0 was hand-published.

v0.8.0 was published manually for this release; this makes the next version tag auto-publish cleanly.

Adds `npm run compile` (working-directory: extension) before the publish step.