### PR TITLE
feat(categorize): task-intent clustering + cross-project duplicate-work detection (v0.9 PR1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,31 @@ premium-model-overuse  premiumShare   99%       97%   2026-06-12  — tracking
 
 Resolved findings re-open automatically if the metric regresses.
 
+## Task categories
+
+`token-monitor categorize` answers a different question from the cost report: *what* is the team using the agent for, and where is that work being repeated?
+
+It clusters sessions by task intent and surfaces duplicate work across projects plus candidates worth codifying as a shared skill or prompt:
+
+```
+By category
+  Category                  Sessions  Projects  Tokens  Cost
+  ⚠ api authentication jwt  6         3         210k    ~$84.00
+  css layout responsive     4         2          88k    ~$31.00
+
+Duplicate work (same task across ≥2 projects)
+  ⚠ api authentication jwt — 6 sessions across 3 projects (billing, gateway, mobile-api)  ~$84.00
+  Recurring across projects → codify it as a shared skill/prompt instead of re-deriving it.
+```
+
+It runs **fully offline and deterministic** — no agent, no network. Each session's prompt is reduced **on-device** to a handful of redacted keyword tokens (structured secrets — keys, URLs, paths, IPs, connection strings — are stripped first); raw prompt text is never stored, printed, or sent. `--threshold` (0–1, default 0.4) and `--min-cluster` (default 2) tune the clustering; bias toward false negatives, since a wrong "duplicate work" call costs more trust than a missed one.
+
 ## CLI
 
 ```
 token-monitor collect [--source claude-code|gemini-cli|codex|cursor|antigravity|copilot] [--db <path>]
 token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>] [--json] [--db <path>]
+token-monitor categorize [--days 30] [--threshold 0.4] [--min-cluster 2] [--project <name>] [--source <name>] [--json] [--db <path>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
 token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline] [--verify] [--keys keys.json] [--json] [--html team.html]
@@ -231,6 +251,7 @@ The most valuable contribution: an adapter for another agent CLI (Aider, OpenCod
 - [x] VS Code-family extension: status-bar cost + dashboard webview
 - [x] Org-level cross-check via provider usage APIs: `reconcile`
 - [x] npm publish: `npx @ryandemelo/token-monitor`
+- [x] Task categorization: cluster sessions by intent, flag cross-project duplicate work, suggest org skills (`categorize`, on-device)
 
 ## Integrity & threat model
 
@@ -262,9 +283,11 @@ Per model it shows local tokens, org-billed tokens, and a coverage %. The local 
 
 ## Privacy
 
-Everything stays on your machine. token-monitor reads log files locally, stores aggregate numbers in a local SQLite file, and never makes a network request. Prompt and code content is never stored — only token counts, tool names, timestamps, and project/branch names.
+Everything stays on your machine. token-monitor reads log files locally, stores aggregate numbers in a local SQLite file, and never makes a network request. The core report stores only token counts, tool names, timestamps, and project/branch names — never prompt or code content.
 
-The one opt-in exception: `analyze --llm` sends those aggregates to your own agent CLI's provider for analysis. Everything else is fully offline.
+`categorize` is the one command that looks at prompt text, and it does so **entirely on-device**: each session is reduced to at most 8 redacted keyword tokens before anything is written. Structured secrets of known shape (emails, API keys, URLs, file paths, IPs, UUIDs, connection strings, PEM blocks, `key=value` secrets) are stripped first, and key/hash-shaped survivors are dropped — so the database stores keyword *labels*, never sentences. This is defence-in-depth, not a guarantee: a secret that looks exactly like an ordinary word can still survive, which is why only labels (never raw prose) are ever kept.
+
+The one network exception is opt-in: `analyze --llm` sends aggregates to your own agent CLI's provider for analysis. Everything else — `categorize` included — is fully offline.
 
 ## License
 

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -39,16 +39,31 @@ interface ClaudeLine {
       cache_read_input_tokens?: number;
       cache_creation_input_tokens?: number;
     };
-    content?: Array<{
-      type: string;
-      name?: string;
-      id?: string;
-      input?: { command?: string };
-      tool_use_id?: string;
-      is_error?: boolean;
-      content?: unknown;
-    }>;
+    // User messages can be a plain string or a block array; assistant messages
+    // are always a block array.
+    content?: string | ContentBlock[];
   };
+}
+
+interface ContentBlock {
+  type: string;
+  name?: string;
+  id?: string;
+  text?: string;
+  input?: { command?: string };
+  tool_use_id?: string;
+  is_error?: boolean;
+  content?: unknown;
+}
+
+/** Pull the user's typed text out of a `user` line (string or text blocks). */
+function userText(content: string | ContentBlock[] | undefined): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((b) => b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text as string)
+    .join('\n');
 }
 
 /** Parse Claude Code session transcripts: ~/.claude/projects/<dir>/<session>.jsonl */
@@ -77,6 +92,9 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
       }
       // tool_use id -> event, so a failed tool_result can flag its turn
       const byToolUseId = new Map<string, UsageEvent>();
+      // The most recent genuine user prompt, carried forward onto the assistant
+      // turns it triggered (transient — used only by `categorize`).
+      let lastUserText = '';
       for (const line of text.split('\n')) {
         if (!line.trim()) continue;
         let d: ClaudeLine;
@@ -85,18 +103,23 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
         } catch {
           continue;
         }
-        if (d.type === 'user' && Array.isArray(d.message?.content)) {
-          for (const block of d.message.content) {
-            if (
-              block.type === 'tool_result' &&
-              block.is_error &&
-              block.tool_use_id &&
-              !isDeclination(block.content)
-            ) {
-              const ev = byToolUseId.get(block.tool_use_id);
-              if (ev) ev.isError = true;
+        if (d.type === 'user') {
+          const content = d.message?.content;
+          if (Array.isArray(content)) {
+            for (const block of content) {
+              if (
+                block.type === 'tool_result' &&
+                block.is_error &&
+                block.tool_use_id &&
+                !isDeclination(block.content)
+              ) {
+                const ev = byToolUseId.get(block.tool_use_id);
+                if (ev) ev.isError = true;
+              }
             }
           }
+          const t = userText(content).trim();
+          if (t) lastUserText = t;
           continue;
         }
         if (d.type !== 'assistant' || !d.message?.usage || !d.uuid) continue;
@@ -108,7 +131,8 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
         const commands: string[] = [];
         let hasThinking = false;
         const toolUseIds: string[] = [];
-        for (const block of d.message.content ?? []) {
+        const blocks = Array.isArray(d.message.content) ? d.message.content : [];
+        for (const block of blocks) {
           if (block.type === 'tool_use' && block.name) {
             tools.push(block.name);
             if (block.id) toolUseIds.push(block.id);
@@ -135,6 +159,7 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
           hasThinking,
           isError: false,
           gitBranch: d.gitBranch,
+          intentText: lastUserText || undefined,
         };
         ev.activity = classify(ev);
         events.push(ev);

--- a/src/categorize.ts
+++ b/src/categorize.ts
@@ -1,0 +1,174 @@
+/**
+ * `categorize` — what tasks the team uses the agent for, where work repeats,
+ * and which recurring tasks are worth codifying as a shared "org skill".
+ *
+ * Path A (local scrape), fully offline and deterministic by default — no agent,
+ * no network. The pipeline:
+ *   1. spend per session from the DB (StoredEvent), so $ is canonical & auditable;
+ *   2. user-intent TEXT per session re-collected in-memory from the adapter and
+ *      reduced to a redacted fingerprint ON-DEVICE (intent.ts) — raw prompt text
+ *      never lands in the DB, the result, or stdout;
+ *   3. join on session_id, persist the intent first-wins, cluster the frozen
+ *      fingerprints (cluster.ts), then derive the duplicate-work / skill signals
+ *      DETERMINISTICALLY from cluster membership — never asked of an LLM.
+ *
+ * PR1 scope: claude-code only for text. Other already-collected sources still
+ * get a coarse activity-based fallback label so their spend is accounted for.
+ */
+import type { DatabaseSync } from 'node:sqlite';
+import { loadEvents, recordIntents, loadIntents } from './store.js';
+import type { StoredEvent } from './store.js';
+import { groupBy, parseTools } from './metrics.js';
+import { costOf } from './pricing.js';
+import { collectClaudeCode } from './adapters/claude-code.js';
+import { deriveSessionIntent, fnv1a } from './intent.js';
+import { clusterLabels } from './cluster.js';
+import type { ClusterItem } from './cluster.js';
+
+export interface CategoryRow {
+  id: string;
+  name: string;
+  sessions: number;
+  projects: string[];
+  tokens: number;
+  cost: number;
+  estimated: boolean;
+  /** True when at least one member was derived from real user text. */
+  hasText: boolean;
+  /** Recurring task spanning ≥2 projects — a redundant-work signal. */
+  duplicate: boolean;
+}
+
+export interface CategorizeResult {
+  days: number;
+  totalSessions: number;
+  textSessions: number;
+  categories: CategoryRow[];
+  duplicates: CategoryRow[];
+  skillCandidates: CategoryRow[];
+}
+
+interface SessionAgg {
+  sessionId: string;
+  source: string;
+  project: string;
+  tokens: number;
+  cost: number;
+  estimated: boolean;
+  activity: string;
+  tools: string[];
+}
+
+function aggregateSession(sessionId: string, evs: StoredEvent[]): SessionAgg {
+  let tokens = 0, cost = 0, estimated = false;
+  const tools = new Set<string>();
+  const actCount = new Map<string, number>();
+  for (const e of evs) {
+    tokens += e.input_tokens + e.output_tokens;
+    const c = costOf(e.model, e.input_tokens, e.output_tokens, e.cache_read_tokens, e.cache_creation_tokens);
+    cost += c.usd;
+    if (c.estimated) estimated = true;
+    for (const t of parseTools(e.tools)) tools.add(t);
+    actCount.set(e.activity, (actCount.get(e.activity) ?? 0) + 1);
+  }
+  const activity = [...actCount.entries()].sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))[0]?.[0] ?? 'conversation';
+  return {
+    sessionId,
+    source: evs[0]?.source ?? 'claude-code',
+    project: evs[0]?.project ?? 'unknown',
+    tokens,
+    cost,
+    estimated,
+    activity,
+    tools: [...tools],
+  };
+}
+
+/** Per-session user-intent text, re-collected in-memory (claude-code, PR1). */
+function intentTextBySession(): Map<string, string> {
+  const out = new Map<string, string>();
+  const seen = new Map<string, Set<string>>();
+  for (const ev of collectClaudeCode().events) {
+    if (!ev.intentText) continue;
+    let s = seen.get(ev.sessionId);
+    if (!s) seen.set(ev.sessionId, (s = new Set()));
+    if (s.has(ev.intentText)) continue; // consecutive turns share one prompt
+    s.add(ev.intentText);
+    out.set(ev.sessionId, (out.get(ev.sessionId) ? out.get(ev.sessionId) + '\n' : '') + ev.intentText);
+  }
+  return out;
+}
+
+export function runCategorize(
+  db: DatabaseSync,
+  opts: { days?: number; project?: string; source?: string; threshold?: number; minCluster?: number } = {},
+  now: string = new Date().toISOString(),
+): CategorizeResult {
+  const events = loadEvents(db, { days: opts.days, project: opts.project, source: opts.source });
+  const days = opts.days ?? 30;
+  const minCluster = Math.max(2, opts.minCluster ?? 2);
+
+  const aggs = [...groupBy(events, 'session_id').entries()].map(([id, evs]) => aggregateSession(id, evs));
+  if (aggs.length === 0) {
+    return { days, totalSessions: 0, textSessions: 0, categories: [], duplicates: [], skillCandidates: [] };
+  }
+
+  // Derive intent on-device, then persist first-wins.
+  const textMap = intentTextBySession();
+  const toRecord = aggs.map((a) => {
+    const intent = deriveSessionIntent(textMap.get(a.sessionId) ?? '', { activity: a.activity, tools: a.tools });
+    return {
+      sessionId: a.sessionId,
+      source: a.source,
+      project: a.project,
+      intentId: fnv1a([...intent.fingerprint].sort().join('|')),
+      label: intent.label,
+      fingerprint: intent.fingerprint,
+      hasText: intent.hasText,
+      firstSeen: now,
+    };
+  });
+  recordIntents(db, toRecord);
+
+  // Cluster the FROZEN (first-wins) fingerprints, so display is idempotent.
+  const frozen = loadIntents(db, aggs.map((a) => a.sessionId));
+  // Count from the frozen rows the categories are actually built from (not the
+  // fresh re-derivation), so the header matches the per-row labels on re-runs.
+  const textSessions = [...frozen.values()].filter((r) => r.has_text === 1).length;
+  const aggById = new Map(aggs.map((a) => [a.sessionId, a]));
+  const items: ClusterItem[] = aggs.map((a) => {
+    const row = frozen.get(a.sessionId);
+    return { id: a.sessionId, project: a.project, terms: row ? (JSON.parse(row.fingerprint) as string[]) : [] };
+  });
+  const clusters = clusterLabels(items, { threshold: opts.threshold });
+
+  const categories: CategoryRow[] = clusters.map((c) => {
+    const members = c.items.map((it) => aggById.get(it.id)!).filter(Boolean);
+    const projects = [...new Set(members.map((m) => m.project))].sort();
+    const tokens = members.reduce((s, m) => s + m.tokens, 0);
+    const cost = members.reduce((s, m) => s + m.cost, 0);
+    const estimated = members.some((m) => m.estimated);
+    const hasText = c.items.some((it) => frozen.get(it.id)?.has_text === 1);
+    // Only real-text clusters earn the high-trust signals: a no-text fallback
+    // cluster (shared activity+tools, e.g. two "coding+edit" sessions) is NOT
+    // evidence of the same task, so it must never trigger a "duplicate work"
+    // accusation or an org-skill recommendation.
+    const duplicate = hasText && members.length >= minCluster && projects.length >= 2;
+    return { id: c.id, name: c.name, sessions: members.length, projects, tokens, cost, estimated, hasText, duplicate };
+  });
+
+  const byCostThenSessions = (a: CategoryRow, b: CategoryRow) =>
+    b.sessions - a.sessions ||
+    b.cost - a.cost ||
+    (a.name < b.name ? -1 : a.name > b.name ? 1 : 0) ||
+    (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+
+  return {
+    days,
+    totalSessions: aggs.length,
+    textSessions,
+    categories: [...categories].sort(byCostThenSessions),
+    duplicates: categories.filter((c) => c.duplicate).sort((a, b) => b.cost - a.cost || byCostThenSessions(a, b)),
+    skillCandidates: categories.filter((c) => c.hasText && c.sessions >= minCluster).sort(byCostThenSessions),
+  };
+}

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -29,7 +29,7 @@ const TEST_RE =
 
 const SHIP_RE = /\bgit\s+(commit|push)\b|\bgh\s+pr\b|\bgit\s+merge\b/i;
 
-function norm(name: string): string {
+export function norm(name: string): string {
   return name.toLowerCase().replace(/^mcp__\S+__/, '');
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,8 @@ import { parseArgs } from 'node:util';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { ADAPTERS } from './adapters/index.js';
 import { openDb, insertEvents, loadEvents, DEFAULT_DB } from './store.js';
-import { renderReport, renderTeamReport, renderTrend } from './report.js';
+import { renderReport, renderTeamReport, renderTrend, renderCategorize } from './report.js';
+import { runCategorize } from './categorize.js';
 import { splitWindow } from './trends.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import { buildExport, parseTeamConfig, mergeMetrics, dedupeExports, rollupExports, displayName, identityOf } from './team.js';
@@ -24,6 +25,7 @@ const HELP = `token-monitor — measure how effectively your team spends AI codi
 Usage:
   token-monitor collect [--source <name>] [--db <path>]
   token-monitor report  [--days <n>] [--trend] [--project <name>] [--source <name>] [--json] [--db <path>]
+  token-monitor categorize [--days <n>] [--threshold <0-1>] [--min-cluster <n>] [--project <name>] [--source <name>] [--json] [--db <path>]
   token-monitor analyze [--days <n>] [--llm] [--track] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline]
@@ -38,6 +40,9 @@ Commands:
   collect   Scan local agent logs (Claude Code, Gemini CLI, Codex, Cursor,
             Antigravity, Copilot Chat) into SQLite
   report    Activity breakdown, cost, personas, and recommendations
+  categorize  Cluster sessions by task intent (on-device, offline), flag work
+            repeated across projects, and surface org-skill candidates. Prompt
+            text is redacted to keyword labels locally — never stored or sent.
   analyze   Session-level deep dive; --llm asks your local agent CLI for
             prioritized recommendations (sends aggregate metrics only); add
             --track to record those recommendations and measure (via
@@ -127,6 +132,8 @@ async function main() {
       by: { type: 'string' },
       html: { type: 'string' },
       provider: { type: 'string' },
+      threshold: { type: 'string' },
+      'min-cluster': { type: 'string' },
       from: { type: 'string' },
       hours: { type: 'string' },
       remove: { type: 'boolean', default: false },
@@ -276,6 +283,34 @@ Signing fingerprint (send to your team lead for keys.json):
       let out = renderReport(events, { days, follow });
       if (values.trend && events.length > 0) out += '\n' + renderTrend(events, previous, days);
       console.log(out);
+    }
+  } else if (cmd === 'categorize') {
+    const days = Number(values.days);
+    if (!Number.isInteger(days) || days < 1) {
+      console.error(`--days must be a positive integer, got "${values.days}"`);
+      process.exit(1);
+    }
+    const threshold = values.threshold !== undefined ? Number(values.threshold) : undefined;
+    if (threshold !== undefined && (Number.isNaN(threshold) || threshold < 0 || threshold > 1)) {
+      console.error(`--threshold must be a number between 0 and 1, got "${values.threshold}"`);
+      process.exit(1);
+    }
+    const minCluster = values['min-cluster'] !== undefined ? Number(values['min-cluster']) : undefined;
+    if (minCluster !== undefined && (!Number.isInteger(minCluster) || minCluster < 2)) {
+      console.error(`--min-cluster must be an integer ≥ 2, got "${values['min-cluster']}"`);
+      process.exit(1);
+    }
+    const result = runCategorize(db, {
+      days,
+      project: values.project,
+      source: values.source,
+      threshold,
+      minCluster,
+    });
+    if (values.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(renderCategorize(result, days));
     }
   } else if (cmd === 'analyze') {
     const days = Number(values.days) || 30;

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,0 +1,192 @@
+/**
+ * Zero-dep lexical clustering of session intents.
+ *
+ * Groups sessions by what they were about, from their ≤8-term fingerprints
+ * only (never raw text). Mechanism: IDF-weighted TF-IDF vectors, an inverted
+ * index to find candidate neighbours cheaply, cosine similarity, and union-find
+ * to merge. Two guards keep single-link chaining from fusing unrelated work:
+ * a similarity threshold and a hard max-cluster-size cap (a wrong "duplicate
+ * work" accusation costs more trust than a missed one). Fully deterministic —
+ * no Math.random, no Date, stable tie-breaks — so output is golden-testable.
+ *
+ * The engine is hidden behind clusterLabels(); swap it (e.g. for Jaccard) in
+ * this one file without touching callers.
+ */
+import { fnv1a } from './intent.js';
+
+export interface ClusterItem {
+  id: string;
+  project: string;
+  /** The session's redacted fingerprint terms. */
+  terms: string[];
+}
+
+export interface Cluster {
+  /** Stable for a given membership set (FNV of sorted member ids). */
+  id: string;
+  name: string;
+  items: ClusterItem[];
+  /** Aggregate top terms across members. */
+  terms: string[];
+}
+
+export interface ClusterOpts {
+  /**
+   * Cosine threshold to link two sessions. Default 0.4: fingerprints are capped
+   * at 8 tokens, so even strong paraphrases (≥4 shared salient terms among a few
+   * noise words) land around 0.45-0.60, while coincidental 1-2 term overlaps sit
+   * near 0.15-0.30 — 0.4 separates them. Zero-overlap pairs score 0 regardless.
+   */
+  threshold?: number;
+  /** Hard cap on a cluster's size — chaining guard (default 50). */
+  maxSize?: number;
+}
+
+function dot(a: Map<string, number>, b: Map<string, number>): number {
+  const [small, large] = a.size < b.size ? [a, b] : [b, a];
+  let s = 0;
+  for (const [t, w] of small) {
+    const w2 = large.get(t);
+    if (w2) s += w * w2;
+  }
+  return s;
+}
+
+/**
+ * Aggregate top terms for a cluster's NAME. Ranked first by how many members
+ * contain the term (so the SHARED topic leads), then by summed TF-IDF, then
+ * alpha. This deliberately demotes rare one-off tokens — a codename or secret
+ * that survived redaction in a single member won't become the public label of a
+ * multi-session cluster (the export surface). Singletons are unavoidably named
+ * from their own terms.
+ */
+function topTerms(items: ClusterItem[], idf: (t: string) => number): string[] {
+  const memberDf = new Map<string, number>();
+  const weight = new Map<string, number>();
+  for (const it of items) {
+    const tf = new Map<string, number>();
+    for (const t of it.terms) tf.set(t, (tf.get(t) ?? 0) + 1);
+    for (const [t, f] of tf) {
+      memberDf.set(t, (memberDf.get(t) ?? 0) + 1);
+      weight.set(t, (weight.get(t) ?? 0) + f * idf(t));
+    }
+  }
+  return [...weight.keys()].sort(
+    (a, b) =>
+      (memberDf.get(b)! - memberDf.get(a)!) ||
+      (weight.get(b)! - weight.get(a)!) ||
+      (a < b ? -1 : a > b ? 1 : 0),
+  );
+}
+
+export function clusterLabels(items: ClusterItem[], opts: ClusterOpts = {}): Cluster[] {
+  const tau = opts.threshold ?? 0.4;
+  const maxSize = opts.maxSize ?? 50;
+  const n = items.length;
+
+  // Document frequency -> IDF (smoothed). Rare terms weigh more.
+  const df = new Map<string, number>();
+  for (const it of items) for (const t of new Set(it.terms)) df.set(t, (df.get(t) ?? 0) + 1);
+  const idf = (t: string) => Math.log((n + 1) / ((df.get(t) ?? 0) + 1)) + 1;
+
+  // L2-normalized TF-IDF vectors, so dot product == cosine.
+  const vecs = items.map((it) => {
+    const tf = new Map<string, number>();
+    for (const t of it.terms) tf.set(t, (tf.get(t) ?? 0) + 1);
+    const v = new Map<string, number>();
+    let norm2 = 0;
+    for (const [t, f] of tf) {
+      const w = f * idf(t);
+      v.set(t, w);
+      norm2 += w * w;
+    }
+    const len = Math.sqrt(norm2) || 1;
+    for (const [t, w] of v) v.set(t, w / len);
+    return v;
+  });
+
+  // Inverted index: term -> item indices, to skip non-overlapping pairs.
+  const inv = new Map<string, number[]>();
+  items.forEach((it, i) => {
+    for (const t of new Set(it.terms)) {
+      let arr = inv.get(t);
+      if (!arr) inv.set(t, (arr = []));
+      arr.push(i);
+    }
+  });
+
+  // Union-find with size-capped merges.
+  const parent = Array.from({ length: n }, (_, i) => i);
+  const sizeOf = new Map<number, number>();
+  const size = (r: number) => sizeOf.get(r) ?? 1;
+  const find = (x: number): number => {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]];
+      x = parent[x];
+    }
+    return x;
+  };
+  const union = (a: number, b: number) => {
+    const ra = find(a), rb = find(b);
+    if (ra === rb) return;
+    if (size(ra) + size(rb) > maxSize) return; // chaining guard
+    const [big, small] = size(ra) >= size(rb) ? [ra, rb] : [rb, ra];
+    parent[small] = big;
+    sizeOf.set(big, size(big) + size(small));
+  };
+
+  // Candidate pairs via shared terms, scored, merged highest-similarity first.
+  const pairs: Array<{ i: number; j: number; s: number }> = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < n; i++) {
+    const cand = new Set<number>();
+    for (const t of new Set(items[i].terms)) {
+      for (const j of inv.get(t) ?? []) if (j > i) cand.add(j);
+    }
+    for (const j of cand) {
+      const key = `${i}:${j}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (!sameIntentGate(items[i], items[j])) continue;
+      const s = dot(vecs[i], vecs[j]);
+      if (s >= tau) pairs.push({ i, j, s });
+    }
+  }
+  pairs.sort((a, b) => b.s - a.s || a.i - b.i || a.j - b.j);
+  for (const p of pairs) union(p.i, p.j);
+
+  // Gather clusters.
+  const groups = new Map<number, number[]>();
+  for (let i = 0; i < n; i++) {
+    const r = find(i);
+    let arr = groups.get(r);
+    if (!arr) groups.set(r, (arr = []));
+    arr.push(i);
+  }
+  const clusters: Cluster[] = [];
+  for (const idxs of groups.values()) {
+    const members = idxs.map((i) => items[i]);
+    const terms = topTerms(members, idf);
+    const id = fnv1a(members.map((m) => m.id).sort().join('|'));
+    clusters.push({ id, name: terms.slice(0, 3).join(' ') || 'misc', items: members, terms });
+  }
+  // Biggest clusters first; name then content-hash id as a TOTAL tie-break, so
+  // the returned order never depends on input/scan order (equal-size, equal-name
+  // clusters are reachable when identical fingerprints split at maxSize).
+  clusters.sort(
+    (a, b) =>
+      b.items.length - a.items.length ||
+      (a.name < b.name ? -1 : a.name > b.name ? 1 : 0) ||
+      (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  );
+  return clusters;
+}
+
+/**
+ * Coarse gate: two sessions may only link if they share at least one term.
+ * Candidate pairs already share a term via the inverted index, so this is a
+ * cheap belt-and-suspenders guard and the hook for a future taxonomy gate.
+ */
+function sameIntentGate(a: ClusterItem, b: ClusterItem): boolean {
+  return a.terms.some((t) => b.terms.includes(t));
+}

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -1,0 +1,159 @@
+/**
+ * On-device intent derivation — the privacy floor of `categorize`.
+ *
+ * Raw user-prompt text is redacted and reduced to a bounded keyword fingerprint
+ * HERE, before anything is persisted, clustered, or printed. Nothing downstream
+ * ever sees the raw prompt: `categorize` stores only the ≤8-token fingerprint
+ * plus a short top-terms label — never a free-text sentence column.
+ *
+ * redact() strips structured secrets of KNOWN SHAPE (emails, any-scheme URIs and
+ * connection strings, file paths, PEM blocks, labelled `key=value` secrets,
+ * prefixed API keys, JWTs, IP addresses, UUIDs, long digit/hex/base64 runs);
+ * tokenize() then drops high-entropy key/hash-shaped survivors. This is
+ * defence-in-depth, not a guarantee: a novel secret that looks exactly like an
+ * ordinary word can still survive — which is why only redacted keyword LABELS
+ * (never prose) are kept, and multi-session cluster names prefer shared terms
+ * over rare one-offs so a survivor is unlikely to surface as a public label.
+ */
+import { norm } from './classify.js';
+
+// Redaction patterns. Order matters: structured/credential-bearing spans are
+// removed whole before the generic base64/hex/digit catch-alls.
+const PEM_RE = /-----BEGIN[\s\S]*?-----END[^-]*-----/g;
+// Any scheme://… URI, including credential-bearing connection strings
+// (postgres://user:pass@host, redis://:pw@localhost, ssh://…). URIs are never
+// task keywords, so dropping the whole run is safe.
+const URI_RE = /\b[a-z][a-z0-9+.-]*:\/\/\S+/gi;
+const WWW_RE = /\bwww\.[^\s]+/gi;
+const EMAIL_RE = /\b[\w.+-]+@[\w-]+\.[\w.-]+\b/g;
+// Labelled secret: `password=…`, `token: …`, `api_key = …` → drop the value.
+const ASSIGN_SECRET_RE =
+  /\b(?:pass(?:word|wd)?|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|credential|auth|bearer)s?\s*[:=]\s*\S+/gi;
+const JWT_RE = /\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g;
+const SECRET_RE =
+  /\b(?:sk|pk|rk|ghp|gho|ghs|github_pat|xox[baprs]|AKIA|ASIA|AIza|ya29|Bearer)[-_A-Za-z0-9]{6,}\b/gi;
+const PATH_RE = /(?:[A-Za-z]:)?(?:[\\/][\w.+-]+){2,}[\\/]?/g; // unix + windows paths
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const IPV4_RE = /\b\d{1,3}(?:\.\d{1,3}){3}\b/g;
+const IPV6_RE = /\b(?:[0-9a-f]{0,4}:){2,}[0-9a-f]{0,4}\b/gi;
+const BASE64_RE = /\b[A-Za-z0-9+/]{20,}={0,2}\b/g; // long base64 / opaque secret runs
+const HEX_RE = /\b[0-9a-f]{16,}\b/gi; // hashes / hex secrets
+const DIGITS_RE = /\b\d{7,}\b/g; // long digit runs (ids, card-ish numbers)
+
+/** Strip structured secrets/identifiers on-device. Runs before tokenize. */
+export function redact(text: string): string {
+  return text
+    .replace(PEM_RE, ' ')
+    .replace(URI_RE, ' ')
+    .replace(WWW_RE, ' ')
+    .replace(EMAIL_RE, ' ')
+    .replace(ASSIGN_SECRET_RE, ' ')
+    .replace(JWT_RE, ' ')
+    .replace(SECRET_RE, ' ')
+    // Before PATH_RE: opaque keys may contain '/' (AWS secret keys), so catch the
+    // whole high-entropy run before path-splitting fragments it.
+    .replace(BASE64_RE, ' ')
+    .replace(PATH_RE, ' ')
+    .replace(UUID_RE, ' ')
+    .replace(IPV4_RE, ' ')
+    .replace(IPV6_RE, ' ')
+    .replace(HEX_RE, ' ')
+    .replace(DIGITS_RE, ' ');
+}
+
+/**
+ * Heuristic: does this surviving token look like a key/hash/id rather than a
+ * word? Long mixed letter+digit runs and hex-ish id fragments are dropped so
+ * unknown-prefix secrets don't reach the fingerprint. Short alnum terms with
+ * real signal (oauth2, sha256, utf8, gpt5) are kept.
+ */
+function looksLikeSecret(t: string): boolean {
+  if (t.length >= 12 && /[a-z]/.test(t) && /[0-9]/.test(t)) return true;
+  if (t.length >= 8 && /^[0-9a-f]+$/.test(t) && /[0-9]/.test(t)) return true;
+  return false;
+}
+
+// Common English + instruction filler that carries no task signal. Task verbs
+// that DO carry signal (test, fix, refactor, debug, deploy) are deliberately kept.
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'if', 'then', 'else', 'for', 'to', 'of', 'in', 'on',
+  'at', 'by', 'with', 'from', 'into', 'as', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'do', 'does', 'did', 'done', 'can', 'could', 'should', 'would', 'will', 'shall', 'may', 'might',
+  'must', 'i', 'we', 'you', 'it', 'this', 'that', 'these', 'those', 'my', 'our', 'your', 'its',
+  'me', 'us', 'please', 'want', 'wants', 'need', 'needs', 'make', 'makes', 'use', 'using', 'used',
+  'add', 'adds', 'added', 'adding',
+  'get', 'gets', 'got', 'set', 'help', 'let', 'lets', 'also', 'so', 'not', 'no', 'yes', 'have',
+  'has', 'had', 'here', 'there', 'what', 'which', 'when', 'where', 'how', 'why', 'all', 'any',
+  'some', 'more', 'most', 'very', 'just', 'like', 'about', 'up', 'down', 'out', 'over', 'than',
+  'too', 'one', 'two', 'now', 'via', 'per', 'etc', 'eg', 'ie', 'currently', 'currentl', 'able',
+]);
+
+/** Redact, lowercase, split, drop stopwords/short/pure-number tokens. */
+export function tokenize(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of redact(text).toLowerCase().split(/[^a-z0-9+#.]+/)) {
+    const t = raw.replace(/^[.+#]+|[.+#]+$/g, '');
+    if (t.length < 3 || t.length > 30) continue;
+    if (STOPWORDS.has(t)) continue;
+    if (/^\d+$/.test(t)) continue;
+    if (looksLikeSecret(t)) continue;
+    out.push(t);
+  }
+  return out;
+}
+
+export const FINGERPRINT_K = 8;
+
+/** Top ≤K terms by frequency (alpha tie-break) — the only thing we persist. */
+export function fingerprint(tokens: string[]): string[] {
+  const counts = new Map<string, number>();
+  for (const t of tokens) counts.set(t, (counts.get(t) ?? 0) + 1);
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))
+    .slice(0, FINGERPRINT_K)
+    .map(([t]) => t);
+}
+
+/** First up-to-3 fingerprint terms — a glanceable category name. */
+export function labelOf(fp: string[]): string {
+  return fp.slice(0, 3).join(' ') || 'misc';
+}
+
+/** FNV-1a (deterministic, zero-dep) — stable ids for intents/clusters. */
+export function fnv1a(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+export interface SessionIntent {
+  /** ≤8 redacted keyword tokens — the persisted, labels-only fingerprint. */
+  fingerprint: string[];
+  /** Short top-terms label. */
+  label: string;
+  /** True when derived from real user text; false for a tool/activity fallback. */
+  hasText: boolean;
+}
+
+/**
+ * Derive one session's intent from its (already on-device) user text. When the
+ * session has no usable text — tool-only turns, or a non-text adapter — fall
+ * back to the coarse activity + normalized tool names. Never calls an LLM.
+ */
+export function deriveSessionIntent(
+  text: string,
+  fallback: { activity?: string; tools?: string[] } = {},
+): SessionIntent {
+  const tokens = text ? tokenize(text) : [];
+  if (tokens.length >= 2) {
+    const fp = fingerprint(tokens);
+    return { fingerprint: fp, label: labelOf(fp), hasText: true };
+  }
+  const toolToks = (fallback.tools ?? []).map(norm).filter((t) => t.length >= 3);
+  const act = fallback.activity || 'work';
+  const fp = fingerprint([act, ...toolToks]);
+  return { fingerprint: fp, label: labelOf(fp), hasText: false };
+}

--- a/src/report.ts
+++ b/src/report.ts
@@ -11,6 +11,7 @@ import type { EnrichedRec } from './recommendations.js';
 import { enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
 import type { TrendRow, TrendVerdict } from './trends.js';
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
+import type { CategorizeResult } from './categorize.js';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -213,6 +214,66 @@ export function renderTrend(
       ),
     );
   }
+  return out.join('\n');
+}
+
+export function renderCategorize(r: CategorizeResult, days: number): string {
+  if (r.totalSessions === 0) {
+    return 'No sessions in range. Run `token-monitor collect` first, or widen --days.';
+  }
+  const out: string[] = [];
+  out.push(section(`Task categories — last ${days} days`));
+  out.push(
+    `  ${DIM}${r.totalSessions} sessions · ${r.textSessions} categorized from prompt text · ${r.categories.length} categories${RESET}`,
+  );
+
+  out.push(section('By category'));
+  out.push(
+    table(
+      ['Category', 'Sessions', 'Projects', 'Tokens', 'Cost'],
+      r.categories.slice(0, 20).map((c) => [
+        (c.duplicate ? '⚠ ' : '') + c.name + (c.hasText ? '' : ` ${DIM}(no text)${RESET}`),
+        String(c.sessions),
+        String(c.projects.length),
+        fmtTokens(c.tokens),
+        (c.estimated ? '~' : '') + '$' + c.cost.toFixed(2),
+      ]),
+    ),
+  );
+
+  out.push(section('Duplicate work (same task across ≥2 projects)'));
+  if (r.duplicates.length) {
+    for (const c of r.duplicates.slice(0, 10)) {
+      out.push(
+        `  ${YELLOW}⚠${RESET} ${BOLD}${c.name}${RESET} — ${c.sessions} sessions across ${c.projects.length} projects ` +
+          `${DIM}(${c.projects.join(', ')})${RESET}  ${GREEN}${c.estimated ? '~' : ''}$${c.cost.toFixed(2)}${RESET}`,
+      );
+    }
+    out.push(
+      `\n  ${DIM}Recurring across projects → codify it as a shared skill/prompt instead of re-deriving it.${RESET}`,
+    );
+  } else {
+    out.push(`  ${DIM}No task repeated across multiple projects in this window.${RESET}`);
+  }
+
+  if (r.skillCandidates.length) {
+    out.push(section('Org-skill candidates (recurring tasks worth codifying)'));
+    out.push(
+      table(
+        ['Task', 'Sessions', 'Projects', 'Cost'],
+        r.skillCandidates.slice(0, 10).map((c) => [
+          c.name,
+          String(c.sessions),
+          String(c.projects.length),
+          (c.estimated ? '~' : '') + '$' + c.cost.toFixed(2),
+        ]),
+      ),
+    );
+  }
+
+  out.push(
+    `\n  ${DIM}Labels are derived on-device from redacted prompts; raw prompt text is never stored.${RESET}\n`,
+  );
   return out.join('\n');
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -82,6 +82,95 @@ export interface StoredEvent {
   activity: string;
 }
 
+/**
+ * One session's derived intent — labels only, NEVER raw prompt text. The
+ * fingerprint is the ≤8 redacted keyword tokens from intent.ts; `label` is a
+ * short top-terms name; `intent_id` is a stable per-session signature hash.
+ * There is deliberately no free-text column, so the worst a leak could expose
+ * is a handful of redacted keywords.
+ */
+export interface IntentRow {
+  session_id: string;
+  source: string;
+  project: string;
+  intent_id: string;
+  label: string;
+  /** JSON-encoded string[] of ≤8 redacted keyword tokens. */
+  fingerprint: string;
+  has_text: number;
+  first_seen: string;
+}
+
+export function ensureIntentsTable(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session_intents (
+      session_id TEXT PRIMARY KEY,
+      source TEXT NOT NULL,
+      project TEXT NOT NULL,
+      intent_id TEXT NOT NULL,
+      label TEXT NOT NULL,
+      fingerprint TEXT NOT NULL,
+      has_text INTEGER NOT NULL,
+      first_seen TEXT NOT NULL
+    );
+  `);
+}
+
+/**
+ * Record per-session intents first-wins (INSERT OR IGNORE on session_id), so a
+ * session's first categorization is frozen and re-runs stay idempotent —
+ * mirrors the follow-through baseline pattern. Returns rows inserted.
+ */
+export function recordIntents(
+  db: DatabaseSync,
+  rows: Array<{
+    sessionId: string;
+    source: string;
+    project: string;
+    intentId: string;
+    label: string;
+    fingerprint: string[];
+    hasText: boolean;
+    firstSeen: string;
+  }>,
+): number {
+  ensureIntentsTable(db);
+  const stmt = db.prepare(`
+    INSERT OR IGNORE INTO session_intents
+      (session_id, source, project, intent_id, label, fingerprint, has_text, first_seen)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  let inserted = 0;
+  db.exec('BEGIN');
+  try {
+    for (const r of rows) {
+      const res = stmt.run(
+        r.sessionId, r.source, r.project, r.intentId, r.label,
+        JSON.stringify(r.fingerprint), r.hasText ? 1 : 0, r.firstSeen,
+      );
+      inserted += Number(res.changes);
+    }
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+  return inserted;
+}
+
+/** Frozen intents for the given session ids (first-wins values). */
+export function loadIntents(db: DatabaseSync, sessionIds: string[]): Map<string, IntentRow> {
+  ensureIntentsTable(db);
+  const out = new Map<string, IntentRow>();
+  if (sessionIds.length === 0) return out;
+  const stmt = db.prepare(`SELECT * FROM session_intents WHERE session_id = ?`);
+  for (const id of sessionIds) {
+    const row = stmt.get(id) as IntentRow | undefined;
+    if (row) out.set(row.session_id, row);
+  }
+  return out;
+}
+
 export function loadEvents(
   db: DatabaseSync,
   opts: { days?: number; project?: string; source?: string } = {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,12 @@ export interface UsageEvent {
   isError: boolean;
   gitBranch?: string;
   activity?: Activity;
+  /**
+   * The user's prompt text for this turn, carried in-memory ONLY for `categorize`
+   * to derive an on-device intent fingerprint. Never persisted: insertEvents has
+   * no column for it. Redaction happens in intent.ts before anything is stored.
+   */
+  intentText?: string;
 }
 
 export interface CollectResult {

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { clusterLabels } from '../src/cluster.js';
+import type { ClusterItem } from '../src/cluster.js';
+
+const item = (id: string, project: string, terms: string[]): ClusterItem => ({ id, project, terms });
+
+test('similar fingerprints cluster; unrelated ones stay separate', () => {
+  const items = [
+    item('s1', 'proj-a', ['auth', 'jwt', 'login', 'api']),
+    item('s2', 'proj-b', ['auth', 'jwt', 'token', 'api']), // paraphrase of s1
+    item('s3', 'proj-c', ['css', 'layout', 'flexbox', 'style']),
+  ];
+  const clusters = clusterLabels(items, { threshold: 0.3 });
+  assert.equal(clusters.length, 2);
+  const merged = clusters.find((c) => c.items.length === 2)!;
+  assert.deepEqual(merged.items.map((i) => i.id).sort(), ['s1', 's2']);
+});
+
+test('deterministic: same input yields identical ids, names, and order', () => {
+  const items = [
+    item('a', 'p', ['build', 'webpack', 'bundle']),
+    item('b', 'q', ['build', 'webpack', 'config']),
+    item('c', 'r', ['test', 'jest', 'mock']),
+  ];
+  const r1 = clusterLabels(items, { threshold: 0.3 });
+  const r2 = clusterLabels(items, { threshold: 0.3 });
+  assert.deepEqual(r1.map((c) => c.id), r2.map((c) => c.id));
+  assert.deepEqual(r1.map((c) => c.name), r2.map((c) => c.name));
+});
+
+test('max-size guard caps single-link chaining', () => {
+  const items = Array.from({ length: 6 }, (_, i) => item('s' + i, 'p' + i, ['deploy', 'k8s', 'helm']));
+  const clusters = clusterLabels(items, { threshold: 0.3, maxSize: 2 });
+  for (const c of clusters) assert.ok(c.items.length <= 2, 'cluster exceeded maxSize guard');
+});
+
+test('threshold gates linkage: weak overlap links loose, splits strict', () => {
+  const items = [
+    item('s1', 'a', ['auth', 'api', 'rate', 'limit']),
+    item('s2', 'b', ['auth', 'docs', 'readme', 'changelog']), // shares only "auth"
+  ];
+  assert.equal(clusterLabels(items, { threshold: 0.9 }).length, 2, 'too dissimilar to link at 0.9');
+  assert.ok(
+    clusterLabels(items, { threshold: 0.1 }).some((c) => c.items.length === 2),
+    'should link at 0.1',
+  );
+});
+
+test('returned cluster order is total: independent of input order', () => {
+  // 6 identical fingerprints at maxSize 2 split into 3 same-name same-size
+  // clusters; the array order must not flip when the input is reversed.
+  const fwd = Array.from({ length: 6 }, (_, i) => item('s' + i, 'p' + i, ['deploy', 'k8s', 'helm']));
+  const rev = [...fwd].reverse();
+  const a = clusterLabels(fwd, { threshold: 0.3, maxSize: 2 }).map((c) => c.id);
+  const b = clusterLabels(rev, { threshold: 0.3, maxSize: 2 }).map((c) => c.id);
+  assert.deepEqual(a, b);
+});
+
+test('multi-member cluster name prefers shared terms over a rare one-off token', () => {
+  // A rare survived token (e.g. a codename) in one member must NOT become the
+  // cluster name — shared terms lead.
+  const items = [
+    item('s1', 'a', ['auth', 'login', 'voldemort']),
+    item('s2', 'b', ['auth', 'login', 'session']),
+  ];
+  const [c] = clusterLabels(items, { threshold: 0.3 });
+  assert.equal(c.items.length, 2);
+  assert.ok(!c.name.split(' ').slice(0, 2).includes('voldemort'), `rare token led the name: "${c.name}"`);
+  assert.ok(c.name.startsWith('auth') || c.name.startsWith('login'));
+});
+
+test('cluster name is the aggregate top term', () => {
+  const items = [
+    item('s1', 'a', ['auth', 'auth', 'jwt']),
+    item('s2', 'b', ['auth', 'login']),
+  ];
+  const [c] = clusterLabels(items, { threshold: 0.1 });
+  assert.equal(c.items.length, 2);
+  assert.ok(c.name.startsWith('auth'), `expected auth-led name, got "${c.name}"`);
+});

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -352,6 +352,101 @@ test('e2e: reconcile verifies local totals against a mock usage API', async () =
   }
 });
 
+test('e2e: categorize clusters intents offline, flags cross-project dup, never leaks raw prompts', async () => {
+  // Fresh HOME with hand-built claude transcripts: two projects do the SAME
+  // auth task (a duplicate-work cluster), one does something unrelated. One
+  // prompt embeds secrets that must be redacted on-device.
+  const home = mkdtempSync(join(tmpdir(), 'tm-e2e-categorize-'));
+  const SECRET_KEY = 'sk-CANARYdeadbeef1234567';
+  const SECRET_EMAIL = 'leak@secret.example';
+  const RAW_PHRASE = 'admin credential is';
+
+  const writeSession = (project: string, sid: string, uuid: string, prompt: string) => {
+    const dir = join(home, '.claude', 'projects', project);
+    mkdirSync(dir, { recursive: true });
+    const cwd = `/Users/dev/${project}`;
+    const lines = [
+      { type: 'user', sessionId: sid, timestamp: '2026-06-01T10:00:00.000Z', message: { content: [{ type: 'text', text: prompt }] } },
+      { type: 'assistant', uuid, sessionId: sid, cwd, gitBranch: 'main', timestamp: '2026-06-01T10:00:05.000Z',
+        message: { model: 'claude-opus-4-7', usage: { input_tokens: 500, output_tokens: 300 }, content: [{ type: 'tool_use', id: uuid + 't', name: 'Edit', input: {} }] } },
+    ];
+    writeFileSync(join(dir, sid + '.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+  };
+
+  writeSession('proj-auth-a', 'sa', 'ua',
+    `Add JWT authentication and login to the REST API service. The ${RAW_PHRASE} ${SECRET_KEY} and contact ${SECRET_EMAIL}`);
+  writeSession('proj-auth-b', 'sb', 'ub',
+    'Implement JWT authentication and a login endpoint for the REST API');
+  writeSession('proj-css', 'sc', 'uc',
+    'Fix the CSS flexbox layout on the dashboard settings page');
+
+  // Two tool-only sessions (no user text) in different projects: they share an
+  // activity+tool fallback fingerprint and cluster, but must NEVER be flagged as
+  // duplicate work or an org-skill candidate (no real-text evidence).
+  const writeToolSession = (project: string, sid: string, uuid: string) => {
+    const dir = join(home, '.claude', 'projects', project);
+    mkdirSync(dir, { recursive: true });
+    const line = {
+      type: 'assistant', uuid, sessionId: sid, cwd: `/Users/dev/${project}`, gitBranch: 'main',
+      timestamp: '2026-06-01T11:00:00.000Z',
+      message: { model: 'claude-opus-4-7', usage: { input_tokens: 300, output_tokens: 100 }, content: [{ type: 'tool_use', id: uuid + 't', name: 'Bash', input: { command: 'ls' } }] },
+    };
+    writeFileSync(join(dir, sid + '.jsonl'), JSON.stringify(line) + '\n');
+  };
+  writeToolSession('proj-tool-x', 'sd', 'ud');
+  writeToolSession('proj-tool-y', 'se', 'ue');
+
+  assert.equal(run(['collect', '--source', 'claude-code'], { home }).code, 0);
+
+  const cat = run(['categorize', ...DAYS], { home });
+  assert.equal(cat.code, 0, cat.stderr);
+  assert.ok(cat.stdout.includes('By category'), 'missing By category section');
+  assert.match(cat.stdout, /auth|jwt|login/, 'auth cluster name missing');
+  assert.ok(cat.stdout.includes('Duplicate work'), 'missing Duplicate work section');
+  assert.ok(cat.stdout.includes('proj-auth-a') && cat.stdout.includes('proj-auth-b'),
+    'duplicate-work cluster must name both projects');
+
+  // Secrets must never reach stdout.
+  for (const leak of [SECRET_KEY, SECRET_EMAIL, 'CANARY', RAW_PHRASE]) {
+    assert.ok(!cat.stdout.includes(leak), `leaked "${leak}" to stdout`);
+  }
+
+  // DB canary: the sqlite file must contain no secret and no verbatim sentence.
+  const dbPath = join(home, '.token-monitor', 'token-monitor.sqlite');
+  const dbBytes = readFileSync(dbPath).toString('latin1');
+  for (const leak of [SECRET_KEY, SECRET_EMAIL, 'CANARY', RAW_PHRASE]) {
+    assert.ok(!dbBytes.includes(leak), `leaked "${leak}" into the database`);
+  }
+
+  // session_intents holds 3 labels-only rows, each a bounded redacted fingerprint.
+  const { openDb, loadIntents } = await import('../src/store.js');
+  const db = openDb(dbPath);
+  const intents = loadIntents(db, ['sa', 'sb', 'sc']);
+  assert.equal(intents.size, 3, 'expected one intent row per session');
+  for (const row of intents.values()) {
+    const fp = JSON.parse(row.fingerprint) as string[];
+    assert.ok(fp.length <= 8, 'fingerprint exceeded 8 tokens');
+    assert.ok(!fp.some((t) => t.toLowerCase().includes('canary')), 'secret token persisted in fingerprint');
+    assert.equal(row.has_text, 1, 'these sessions had real user text');
+  }
+  const idsBefore = [...intents.values()].map((r) => r.intent_id).sort();
+
+  // --json surfaces the deterministic duplicate-work signal across 2 projects.
+  const json = JSON.parse(run(['categorize', '--json', ...DAYS], { home }).stdout);
+  assert.ok(json.duplicates.length >= 1, 'expected a duplicate-work cluster');
+  assert.ok(json.duplicates.some((d: { projects: string[] }) => d.projects.length >= 2));
+
+  // No-text fallback clusters must be gated out of the high-trust signals.
+  type Cat = { hasText: boolean; sessions: number };
+  assert.ok(json.duplicates.every((d: Cat) => d.hasText), 'no-text cluster wrongly flagged as duplicate work');
+  assert.ok(json.categories.some((c: Cat) => !c.hasText && c.sessions >= 2), 'expected the tool-only sessions to cluster');
+  assert.ok(!json.skillCandidates.some((c: Cat) => !c.hasText), 'no-text cluster wrongly offered as an org-skill candidate');
+
+  // Idempotent: a second run records nothing new and freezes intent ids first-wins.
+  const idsAfter = [...loadIntents(openDb(dbPath), ['sa', 'sb', 'sc']).values()].map((r) => r.intent_id).sort();
+  assert.deepEqual(idsAfter, idsBefore, 'intent ids must be stable across runs');
+});
+
 test('e2e: unknown command and bare invocation fail with help', () => {
   assert.equal(run(['definitely-not-a-command']).code, 1);
   const bare = run([]);

--- a/test/intent.test.ts
+++ b/test/intent.test.ts
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  redact,
+  tokenize,
+  fingerprint,
+  FINGERPRINT_K,
+  deriveSessionIntent,
+  fnv1a,
+} from '../src/intent.js';
+
+test('redact strips emails, URLs, paths, API keys, JWTs, long digit/hex runs', () => {
+  const secrets = [
+    'alice@example.com',
+    'https://internal.corp/secret?token=abc123',
+    '/Users/dev/secret/path/file.ts',
+    'sk-CANARYdeadbeef1234',
+    'ghp_ABCDEF0123456789abcdef',
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payloadpart.sigpart',
+    'deadbeefdeadbeef0123',
+    '123456789012',
+  ];
+  for (const s of secrets) {
+    const r = redact(`please look at ${s} thanks`);
+    assert.ok(!r.includes(s), `secret survived redaction: ${s}`);
+  }
+});
+
+test('tokenize drops secrets before they become tokens (privacy canary)', () => {
+  const toks = tokenize('Add auth to the API. key is sk-CANARYdeadbeef1234 and email bob@corp.com');
+  assert.ok(toks.includes('auth'));
+  assert.ok(toks.includes('api'));
+  assert.ok(!toks.some((t) => t.includes('canary')), 'secret leaked into tokens');
+  assert.ok(!toks.some((t) => t.includes('corp')), 'email domain leaked into tokens');
+});
+
+test('tokenize drops stopwords, short tokens, and pure numbers', () => {
+  assert.deepEqual(tokenize('the a I to add 42 refactor'), ['refactor']);
+});
+
+test('redact hardening: connection strings, key=value, IPs, UUIDs, opaque keys, PEM', () => {
+  const leaks: Array<[string, string]> = [
+    ['redis://:hunter2pass@localhost:6379/0', 'hunter2pass'],
+    ['mongodb://root:Pa55word@cluster', 'pa55word'],
+    ['postgres://admin:s3cr3tpw@db.example.com/app', 's3cr3tpw'],
+    ['set password=Tr0ub4dor3 in config', 'tr0ub4dor3'],
+    ['token: xkd9Qm2vLp8Rn4Ts here', 'xkd9qm2vlp8rn4ts'],
+    ['server at 192.168.10.42 done', '192.168.10.42'],
+    ['record 550e8400-e29b-41d4-a716-446655440000 lookup', '550e8400'],
+    ['unknown key Ab12Cd34Ef56Gh78Ij90Kl12 value', 'ab12cd34ef56gh78ij90kl12'],
+    ['aws wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLE done', 'wjalrxutnfemi'],
+    ['-----BEGIN RSA PRIVATE KEY----- MIIBcontent -----END RSA PRIVATE KEY-----', 'miibcontent'],
+  ];
+  for (const [input, secret] of leaks) {
+    const toks = tokenize(input);
+    assert.ok(!toks.some((t) => t.includes(secret)), `"${secret}" leaked from "${input}" -> ${JSON.stringify(toks)}`);
+  }
+});
+
+test('redact hardening keeps legitimate task keywords and short alnum signal', () => {
+  assert.deepEqual(tokenize('fix the css flexbox layout'), ['fix', 'css', 'flexbox', 'layout']);
+  assert.deepEqual(tokenize('use oauth2 sha256 gpt5'), ['oauth2', 'sha256', 'gpt5']);
+});
+
+test('fingerprint caps at K and ranks by frequency then alpha', () => {
+  const tokens = [
+    'auth', 'auth', 'auth', 'api', 'api',
+    'jwt', 'token', 'login', 'cache', 'redis', 'queue', 'worker',
+  ];
+  const fp = fingerprint(tokens);
+  assert.ok(fp.length <= FINGERPRINT_K, 'fingerprint exceeded K');
+  assert.equal(fp[0], 'auth');
+  assert.equal(fp[1], 'api');
+});
+
+test('deriveSessionIntent: real text yields hasText with an auth fingerprint', () => {
+  const i = deriveSessionIntent('Add JWT authentication and login to the REST API');
+  assert.equal(i.hasText, true);
+  assert.ok(
+    i.fingerprint.includes('authentication') || i.fingerprint.includes('jwt'),
+    'auth terms missing from fingerprint',
+  );
+  assert.ok(i.label.length > 0);
+});
+
+test('deriveSessionIntent: no usable text falls back to activity + tools', () => {
+  const i = deriveSessionIntent('', { activity: 'testing', tools: ['Bash', 'mcp__server__run_tests'] });
+  assert.equal(i.hasText, false);
+  assert.ok(i.fingerprint.includes('testing'));
+  assert.ok(i.fingerprint.includes('run_tests'), 'mcp prefix should be normalized off');
+});
+
+test('fnv1a is deterministic and discriminates', () => {
+  assert.equal(fnv1a('auth|api|jwt'), fnv1a('auth|api|jwt'));
+  assert.notEqual(fnv1a('auth'), fnv1a('api'));
+});


### PR DESCRIPTION
First slice of the **v0.9 task-categorization** feature (design chosen via multi-agent workflow: deterministic offline lexical pipeline + on-device privacy floor + deterministic duplicate metric; semantic recall deferred to an opt-in later PR).

## What it does
New `categorize` command: clusters sessions by task intent, flags work repeated across projects, and surfaces org-skill candidates.

```
By category
  Category                  Sessions  Projects  Tokens  Cost
  ⚠ api authentication jwt  6         3         210k    ~$84.00

Duplicate work (same task across ≥2 projects)
  ⚠ api authentication jwt — 6 sessions across 3 projects (billing, gateway, mobile-api)  ~$84.00
```

## How
- **`src/intent.ts`** — on-device redact → tokenize → ≤8-token fingerprint. Raw prompt text never leaves the device.
- **`src/cluster.ts`** — zero-dep IDF-cosine + inverted-index + union-find. Deterministic, chaining-guarded (default threshold 0.4, tuned to observed ≤8-token fingerprint cosines).
- **`src/categorize.ts`** — joins DB spend × in-memory intent on session_id; first-wins persistence in a labels-only `session_intents` table; duplicate/skill signals derived **deterministically from cluster membership, never an LLM**.
- claude-code adapter captures user text into a transient `UsageEvent.intentText` (never persisted); other sources get a coarse activity fallback.

## Privacy (make-or-break)
Fully offline + deterministic. `redact()` strips structured secrets of known shape (emails, any-scheme URIs + connection strings, paths, PEM blocks, `key=value` secrets, prefixed API keys, JWTs, IPs, UUIDs, base64/hex/digit runs); `tokenize()` drops high-entropy key/hash survivors; multi-session cluster names prefer shared terms so a rare survivor can't become a public label. Documented honestly as defence-in-depth, not a guarantee. README Privacy section updated.

## Quality
Designed and reviewed with multi-agent adversarial workflows. All **14 confirmed** review findings fixed and test-covered — 8 redaction leaks, no-text-cluster gating (no false "duplicate work" accusations), non-total cluster sort, `--days` validation, `textSessions`/idempotency.

**159 tests pass** (was 142): `test/intent.test.ts` (redaction + hardening), `test/cluster.test.ts` (golden clustering + total-order determinism), and an offline `categorize` e2e with a secret canary asserting nothing leaks to stdout or the sqlite DB.

Zero new runtime dependencies.

## Follow-ups (later PRs, per design)
PR2 fan text capture to other adapters · PR3 findings + HTML parity · PR4 aggregate-only team export + cross-user dup · PR5 opt-in `--llm`/`--semantic` labels-only naming/recluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)