### PR TITLE
chore: release 0.9.0 — task categorization

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-monitor",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-monitor",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "token-monitor",
   "displayName": "Token Monitor",
   "description": "Status-bar token/cost for the current project plus the token-monitor dashboard, for VS Code, Cursor, Windsurf, and Antigravity.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publisher": "ryan653133",
   "license": "MIT",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ryandemelo/token-monitor",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "bin": {
         "token-monitor": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex, Cursor, Antigravity, Copilot Chat) — activity breakdowns, usage personas, and recommendations.",
   "license": "MIT",
   "author": "Ryan de Melo",


### PR DESCRIPTION
Version bump to **0.9.0** (root + extension). Ships the v0.9 task-categorization feature merged in #54.

Highlights:
- New offline `categorize` command — cluster sessions by task intent, flag cross-project duplicate work, surface org-skill candidates
- On-device privacy floor (raw prompt text never persisted/printed/sent)
- Zero new runtime dependencies; 159 tests; CI green Node 24/25 × Linux/macOS

After merge: tag `v0.9.0` → GitHub release + marketplace auto-publish (CI), then npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)