### PR TITLE
feat(categorize): capture intent text from Cursor, Copilot, Gemini & Codex (v0.10 PR2)

### DIFF
--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -25,6 +25,8 @@ interface CodexLine {
     model?: string;
     name?: string;
     arguments?: string;
+    role?: string;
+    content?: string | Array<{ type?: string; text?: string }>;
     info?: {
       total_token_usage?: TokenUsage;
       last_token_usage?: TokenUsage;
@@ -37,6 +39,19 @@ interface TokenUsage {
   cached_input_tokens?: number;
   output_tokens?: number;
   reasoning_output_tokens?: number;
+}
+
+/** Flatten a message `content` (plain string or block array) into one string. */
+function textOf(content: string | Array<{ text?: string }> | undefined): string {
+  if (typeof content === 'string') return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .map((b) => b?.text)
+      .filter((x): x is string => typeof x === 'string')
+      .join(' ')
+      .trim();
+  }
+  return '';
 }
 
 function* walk(dir: string): Generator<string> {
@@ -68,6 +83,7 @@ export function collectCodex(root: string = ROOT): { events: UsageEvent[]; resul
     let prev: TokenUsage | null = null;
     let pendingTools: string[] = [];
     let pendingCommands: string[] = [];
+    let lastUserText: string | undefined;
     let tick = 0;
 
     for (const line of text.split('\n')) {
@@ -85,6 +101,11 @@ export function collectCodex(root: string = ROOT): { events: UsageEvent[]; resul
         if (p.cwd) project = basename(p.cwd);
       } else if (p.type === 'turn_context' && p.model) {
         model = p.model;
+      } else if (d.type === 'response_item' && p.type === 'message' && p.role === 'user') {
+        // Carry the user prompt forward to the next token_count turn it triggered.
+        // content may be a plain string or a block array (format is unvalidated).
+        const t = textOf(p.content);
+        if (t) lastUserText = t;
       } else if (d.type === 'response_item' && p.type === 'function_call' && p.name) {
         pendingTools.push(p.name);
         if (/shell|exec/.test(p.name) && typeof p.arguments === 'string') {
@@ -123,6 +144,7 @@ export function collectCodex(root: string = ROOT): { events: UsageEvent[]; resul
           commands: pendingCommands,
           hasThinking: (delta.reasoning_output_tokens ?? 0) > 0,
           isError: false,
+          intentText: lastUserText || undefined,
         };
         ev.activity = classify(ev);
         events.push(ev);

--- a/src/adapters/copilot.ts
+++ b/src/adapters/copilot.ts
@@ -121,7 +121,7 @@ export function collectCopilot(userDir: string = codeUserDir()): { events: Usage
       if (!session) continue;
       const sessionId = session.sessionId ?? basename(file).replace(/\.jsonl?$/, '');
       (session.requests ?? []).forEach((req, i) => {
-        const userText = req.message?.text ?? '';
+        const userText = typeof req.message?.text === 'string' ? req.message.text : '';
         const { text: responseText, tools, commands } = walkResponse(req.response ?? []);
         if (!userText && !responseText) return;
         const ts = req.timestamp ?? session.lastMessageDate ?? session.creationDate;
@@ -142,6 +142,7 @@ export function collectCopilot(userDir: string = codeUserDir()): { events: Usage
           commands,
           hasThinking: false,
           isError: !!req.result?.errorDetails && !req.isCanceled,
+          intentText: userText || undefined,
         };
         ev.activity = classify(ev);
         events.push(ev);

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -33,6 +33,8 @@ export function cursorUserDir(home: string = homedir()): string {
 interface Bubble {
   type?: number; // 1 = user, 2 = assistant
   createdAt?: string;
+  /** User-prompt text (type 1 bubbles); carried in-memory only, for `categorize`. */
+  text?: string;
   tokenCount?: { inputTokens?: number; outputTokens?: number };
   toolFormerData?: { name?: string; status?: string; rawArgs?: string };
   modelInfo?: { modelName?: string };
@@ -161,8 +163,14 @@ export function collectCursor(userDir: string = cursorUserDir()): { events: Usag
       let tools: string[] = [];
       let commands: string[] = [];
       let isError = false;
+      // Carry the latest user prompt forward to the turn-final assistant bubble
+      // that it triggered — that's the only bubble we emit an event for.
+      let lastUserText: string | undefined;
 
       for (const [bubbleId, bubble] of ordered) {
+        if (bubble.type === 1 && typeof bubble.text === 'string' && bubble.text.trim()) {
+          lastUserText = bubble.text.trim();
+        }
         const tf = bubble.toolFormerData;
         if (tf?.name) {
           tools.push(tf.name);
@@ -199,6 +207,7 @@ export function collectCursor(userDir: string = cursorUserDir()): { events: Usag
           commands,
           hasThinking: false,
           isError,
+          intentText: lastUserText || undefined,
         };
         ev.activity = classify(ev);
         events.push(ev);

--- a/src/adapters/gemini-cli.ts
+++ b/src/adapters/gemini-cli.ts
@@ -12,6 +12,8 @@ interface GeminiMessage {
   type?: string;
   timestamp?: string;
   model?: string;
+  /** User-turn prompt; a plain string or block array. In-memory only, for `categorize`. */
+  content?: string | Array<{ text?: string }>;
   tokens?: { input?: number; output?: number; cached?: number; thoughts?: number; tool?: number };
   thoughts?: unknown[];
   toolCalls?: Array<{ name?: string; status?: string; args?: { command?: string } }>;
@@ -21,6 +23,19 @@ interface GeminiChat {
   sessionId?: string;
   projectHash?: string;
   messages?: GeminiMessage[];
+}
+
+/** Flatten a message `content` (plain string or parts array) into one string. */
+function textOf(content: string | Array<{ text?: string }> | undefined): string {
+  if (typeof content === 'string') return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .map((c) => c?.text)
+      .filter((x): x is string => typeof x === 'string')
+      .join(' ')
+      .trim();
+  }
+  return '';
 }
 
 /** ~/.gemini/projects.json maps project paths to the hash dirs under tmp/. */
@@ -71,8 +86,16 @@ export function collectGeminiCli(root: string = ROOT): { events: UsageEvent[]; r
         continue;
       }
       const sessionId = chat.sessionId ?? file;
+      // Carry the latest user prompt forward to the assistant turns it triggered.
+      let lastUserText: string | undefined;
       for (const m of chat.messages ?? []) {
-        if (m.type === 'user' || !m.tokens || !m.id) continue;
+        if (m.type === 'user') {
+          // content may be a plain string or a parts array, depending on version.
+          const t = textOf(m.content);
+          if (t) lastUserText = t;
+          continue;
+        }
+        if (!m.tokens || !m.id) continue;
         const tools = (m.toolCalls ?? []).map((t) => t.name ?? 'unknown');
         const commands = (m.toolCalls ?? [])
           .map((t) => t.args?.command)
@@ -96,6 +119,7 @@ export function collectGeminiCli(root: string = ROOT): { events: UsageEvent[]; r
           commands,
           hasThinking: Array.isArray(m.thoughts) && m.thoughts.length > 0,
           isError,
+          intentText: lastUserText || undefined,
         };
         ev.activity = classify(ev);
         events.push(ev);

--- a/src/categorize.ts
+++ b/src/categorize.ts
@@ -20,7 +20,8 @@ import { loadEvents, recordIntents, loadIntents } from './store.js';
 import type { StoredEvent } from './store.js';
 import { groupBy, parseTools } from './metrics.js';
 import { costOf } from './pricing.js';
-import { collectClaudeCode } from './adapters/claude-code.js';
+import { ADAPTERS } from './adapters/index.js';
+import type { Source } from './types.js';
 import { deriveSessionIntent, fnv1a } from './intent.js';
 import { clusterLabels } from './cluster.js';
 import type { ClusterItem } from './cluster.js';
@@ -84,17 +85,34 @@ function aggregateSession(sessionId: string, evs: StoredEvent[]): SessionAgg {
   };
 }
 
-/** Per-session user-intent text, re-collected in-memory (claude-code, PR1). */
-function intentTextBySession(): Map<string, string> {
+/**
+ * Per-session user-intent text, re-collected in-memory across every adapter that
+ * exposes it (claude-code, cursor, copilot, gemini-cli, codex). The text is
+ * carried only long enough to derive an on-device fingerprint — it is never
+ * persisted. A `source` filter narrows the re-collection to one adapter so a
+ * filtered `categorize` run doesn't pay to re-scan the others.
+ */
+function intentTextBySession(source?: string): Map<string, string> {
   const out = new Map<string, string>();
   const seen = new Map<string, Set<string>>();
-  for (const ev of collectClaudeCode().events) {
-    if (!ev.intentText) continue;
-    let s = seen.get(ev.sessionId);
-    if (!s) seen.set(ev.sessionId, (s = new Set()));
-    if (s.has(ev.intentText)) continue; // consecutive turns share one prompt
-    s.add(ev.intentText);
-    out.set(ev.sessionId, (out.get(ev.sessionId) ? out.get(ev.sessionId) + '\n' : '') + ev.intentText);
+  const sources = (source ? [source] : Object.keys(ADAPTERS)) as Source[];
+  for (const src of sources) {
+    const adapter = ADAPTERS[src];
+    if (!adapter) continue;
+    let events;
+    try {
+      events = adapter().events;
+    } catch {
+      continue; // a malformed local log in one source must never abort the others
+    }
+    for (const ev of events) {
+      if (!ev.intentText) continue;
+      let s = seen.get(ev.sessionId);
+      if (!s) seen.set(ev.sessionId, (s = new Set()));
+      if (s.has(ev.intentText)) continue; // consecutive turns share one prompt
+      s.add(ev.intentText);
+      out.set(ev.sessionId, (out.get(ev.sessionId) ? out.get(ev.sessionId) + '\n' : '') + ev.intentText);
+    }
   }
   return out;
 }
@@ -114,7 +132,7 @@ export function runCategorize(
   }
 
   // Derive intent on-device, then persist first-wins.
-  const textMap = intentTextBySession();
+  const textMap = intentTextBySession(opts.source);
   const toRecord = aggs.map((a) => {
     const intent = deriveSessionIntent(textMap.get(a.sessionId) ?? '', { activity: a.activity, tools: a.tools });
     return {

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -9,7 +9,7 @@ import { collectCursor } from '../src/adapters/cursor.js';
 import { collectAntigravity } from '../src/adapters/antigravity.js';
 import { collectCopilot } from '../src/adapters/copilot.js';
 import { makeCursorFixture, makeAntigravityFixture } from './helpers.js';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 // dist/test/ -> repo root -> test/fixtures
@@ -57,6 +57,10 @@ test('gemini-cli adapter parses checkpoints incl. thoughts and tool errors', () 
 
   assert.equal(m2.activity, 'shipping'); // git commit command
   assert.equal(m2.isError, true); // failed tool call
+
+  // User-turn prompt carries forward to the assistant turns it triggered.
+  assert.equal(m1.intentText, 'refactor the database connection pooling logic');
+  assert.equal(m2.intentText, 'refactor the database connection pooling logic');
 });
 
 test('codex adapter diffs cumulative token counts into per-turn events', () => {
@@ -80,6 +84,10 @@ test('codex adapter diffs cumulative token counts into per-turn events', () => {
   assert.equal(t2.outputTokens, 70);
   assert.equal(t2.thinkingTokens, 5);
   assert.equal(t2.activity, 'coding'); // apply_patch
+
+  // User message carries forward to the turns it triggered.
+  assert.equal(t1.intentText, 'run the failing tests and patch the bug');
+  assert.equal(t2.intentText, 'run the failing tests and patch the bug');
 });
 
 test('antigravity adapter decodes gen_metadata blobs and attributes tool steps', () => {
@@ -141,6 +149,10 @@ test('cursor adapter emits turn-final token events, maps workspaces, skips abort
   assert.equal(t2.activity, 'coding'); // edit_file
   assert.equal(t2.isError, true); // errored tool linked to its turn
 
+  // Each turn-final event inherits the user prompt of its type-1 bubble.
+  assert.equal(t1.intentText, 'add retry with backoff to the http client');
+  assert.equal(t2.intentText, 'fix the failing authentication unit test');
+
   // The auth canary in ItemTable must never appear in adapter output.
   assert.ok(!JSON.stringify({ events, result }).includes('AUTH-CANARY'));
   assert.ok(result.note?.includes('completed turns'));
@@ -164,6 +176,7 @@ test('copilot adapter estimates tokens from text, parses json and jsonl sessions
   assert.deepEqual(r1.commands, ['npm test']);
   assert.equal(r1.activity, 'testing');
   assert.equal(r1.isError, false);
+  assert.equal(r1.intentText, 'Fix the failing test in utils.spec.ts'); // request message text
 
   assert.equal(r2.isError, true); // errorDetails without cancellation
   assert.equal(r2.activity, 'conversation');
@@ -173,6 +186,53 @@ test('copilot adapter estimates tokens from text, parses json and jsonl sessions
   assert.equal(s2.sessionId, 'cop-s2');
   assert.equal(s2.project, 'proj-cop2');
   assert.equal(s2.timestamp, new Date(1780000200000).toISOString());
+});
+
+test('adapters tolerate non-array (string/object) user-content shapes without throwing', () => {
+  // Local logs are untyped JSON: a user message `content` can be a plain string
+  // (Responses-style) or, for Copilot, a non-string `text`. None may crash the
+  // collector — adapters must fail soft. Regression guard for the PR2 fan-out.
+  const dir = mkdtempSync(join(tmpdir(), 'tm-shape-'));
+
+  // gemini: user content is a plain string
+  const gchats = join(dir, 'gemini', 'h1', 'chats');
+  mkdirSync(gchats, { recursive: true });
+  writeFileSync(join(gchats, 'session-x.json'), JSON.stringify({
+    sessionId: 'gx',
+    messages: [
+      { id: 'u', type: 'user', content: 'please refactor the connection pooling logic' },
+      { id: 'a', type: 'gemini', timestamp: '2026-06-01T00:00:00.000Z', model: 'gemini', tokens: { input: 10, output: 5 } },
+    ],
+  }));
+  const g = collectGeminiCli(join(dir, 'gemini'));
+  assert.equal(g.events.length, 1);
+  assert.equal(g.events[0].intentText, 'please refactor the connection pooling logic');
+
+  // codex: user content is a plain string
+  const cdir = join(dir, 'codex', '2026', '06', '01');
+  mkdirSync(cdir, { recursive: true });
+  writeFileSync(join(cdir, 'rollout-x.jsonl'), [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'cx', cwd: '/p' } }),
+    JSON.stringify({ type: 'response_item', payload: { type: 'message', role: 'user', content: 'run the failing tests' } }),
+    JSON.stringify({ timestamp: '2026-06-01T00:00:00.000Z', type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 10, output_tokens: 5 } } } }),
+  ].join('\n') + '\n');
+  const c = collectCodex(join(dir, 'codex'));
+  assert.equal(c.events.length, 1);
+  assert.equal(c.events[0].intentText, 'run the failing tests');
+
+  // copilot: message.text is a non-string object -> empty intent, no NaN tokens
+  const wsDir = join(dir, 'code', 'workspaceStorage', 'w1');
+  const sessDir = join(wsDir, 'chatSessions');
+  mkdirSync(sessDir, { recursive: true });
+  writeFileSync(join(wsDir, 'workspace.json'), JSON.stringify({ folder: 'file:///home/u/proj-x' }));
+  writeFileSync(join(sessDir, 's.json'), JSON.stringify({
+    sessionId: 'cs',
+    requests: [{ requestId: 'r', message: { text: { weird: true } }, response: [{ value: 'ok' }] }],
+  }));
+  const cop = collectCopilot(join(dir, 'code'));
+  assert.equal(cop.events.length, 1);
+  assert.equal(cop.events[0].intentText, undefined);
+  assert.ok(!Number.isNaN(cop.events[0].inputTokens), 'object text must not yield NaN tokens');
 });
 
 test('adapters return a note instead of throwing when logs are absent', () => {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -68,6 +68,24 @@ test('e2e: report renders all sections from collected data', () => {
   }
 });
 
+test('e2e: categorize captures intent text from every adapter, not just claude-code', async () => {
+  // The shared HOME has all sources collected. categorize re-collects intent
+  // text in-memory across adapters, so cursor/copilot/gemini/codex sessions now
+  // yield real-text fingerprints (has_text=1) — the PR2 fan-out.
+  const cat = run(['categorize', ...DAYS]);
+  assert.equal(cat.code, 0, cat.stderr);
+
+  const { openDb, loadIntents } = await import('../src/store.js');
+  const dbPath = join(HOME, '.token-monitor', 'token-monitor.sqlite');
+  const sids = ['c1', 'g1', 'sess-c1', 'cop-s1']; // cursor, gemini, codex, copilot
+  const intents = loadIntents(openDb(dbPath), sids);
+  for (const sid of sids) {
+    assert.equal(intents.get(sid)?.has_text, 1, `expected a text-derived intent for ${sid}`);
+    const fp = JSON.parse(intents.get(sid)!.fingerprint) as string[];
+    assert.ok(fp.length >= 1 && fp.length <= 8, `fingerprint out of bounds for ${sid}`);
+  }
+});
+
 test('e2e: report --json emits a signed v1 export; fingerprint command matches it', () => {
   const exportJson = run(['report', '--json', ...DAYS]).stdout;
   const data = JSON.parse(exportJson);

--- a/test/fixtures/codex/2026/06/01/rollout-2026-06-01-abc.jsonl
+++ b/test/fixtures/codex/2026/06/01/rollout-2026-06-01-abc.jsonl
@@ -1,5 +1,6 @@
 {"timestamp":"2026-06-01T08:00:00.000Z","type":"session_meta","payload":{"id":"sess-c1","cwd":"/home/dev/proj-c"}}
 {"timestamp":"2026-06-01T08:00:01.000Z","type":"turn_context","payload":{"type":"turn_context","model":"gpt-5-codex"}}
+{"timestamp":"2026-06-01T08:00:01.500Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"run the failing tests and patch the bug"}]}}
 {"timestamp":"2026-06-01T08:00:02.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":[\"pytest\",\"-q\"]}"}}
 {"timestamp":"2026-06-01T08:00:03.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":50,"reasoning_output_tokens":10}}}}
 {"timestamp":"2026-06-01T08:00:04.000Z","type":"response_item","payload":{"type":"function_call","name":"apply_patch","arguments":"{}"}}

--- a/test/fixtures/gemini/proj-g/chats/session-2026-06-01.json
+++ b/test/fixtures/gemini/proj-g/chats/session-2026-06-01.json
@@ -2,7 +2,7 @@
   "sessionId": "g1",
   "projectHash": "abc",
   "messages": [
-    { "id": "m0", "type": "user", "content": [{ "text": "do it" }], "timestamp": "2026-06-01T09:00:00.000Z" },
+    { "id": "m0", "type": "user", "content": [{ "text": "refactor the database connection pooling logic" }], "timestamp": "2026-06-01T09:00:00.000Z" },
     {
       "id": "m1",
       "type": "gemini",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -53,7 +53,10 @@ export function makeCursorFixture(userDir: string): void {
       { bubbleId: 'b5' }, { bubbleId: 'b6' }, { bubbleId: 'b7' },
     ],
   }));
-  put.run('bubbleId:c1:b1', bubble({ type: 1, createdAt: '2026-06-01T10:00:00.000Z' }));
+  put.run('bubbleId:c1:b1', bubble({
+    type: 1, createdAt: '2026-06-01T10:00:00.000Z',
+    text: 'add retry with backoff to the http client',
+  }));
   put.run('bubbleId:c1:b2', bubble({
     type: 2, toolFormerData: { name: 'read_file', status: 'completed', rawArgs: '{}' },
   }));
@@ -65,7 +68,10 @@ export function makeCursorFixture(userDir: string): void {
     tokenCount: { inputTokens: 1200, outputTokens: 300 },
     modelInfo: { modelName: 'default' },
   }));
-  put.run('bubbleId:c1:b5', bubble({ type: 1, createdAt: '2026-06-01T10:02:00.000Z' }));
+  put.run('bubbleId:c1:b5', bubble({
+    type: 1, createdAt: '2026-06-01T10:02:00.000Z',
+    text: 'fix the failing authentication unit test',
+  }));
   put.run('bubbleId:c1:b6', bubble({
     type: 2, toolFormerData: { name: 'edit_file', status: 'error', rawArgs: '{}' },
   }));


### PR DESCRIPTION
## What

Fan the in-memory intent-text re-collection across **every adapter**, not just claude-code, so `categorize` clusters tasks from Cursor, Copilot, Gemini CLI and Codex sessions too. Antigravity stays out (undecoded protobuf is a deliberate privacy non-descent — deferred to PR5).

- Each adapter attaches the user prompt as the **in-memory-only** `intentText` (carried forward to the assistant turns it triggered).
- `categorize.ts intentTextBySession(source?)` now iterates the full `ADAPTERS` registry (respecting `--source`) instead of hardcoding claude-code.

## Privacy

Nothing new is persisted — `insertEvents` has no `intentText` column. On-device redaction to a bounded ≤8-token fingerprint still runs before anything is stored. Verified empirically by an adversarial review pass that injected per-adapter secrets and grepped the DB + stdout: no leak.

## Robustness

Adapters never throw on malformed local logs: a string/non-array message `content` is handled via a `textOf()` guard (mirrors claude-code's `userText`), and the fan-out skips a source that fails to collect rather than aborting the whole run.

## Tests

159 → 161. New: per-adapter `intentText` assertions, and a regression test for non-array/string/object content shapes.