### PR TITLE
feat(categorize): HTML dashboard + cross-surface duplicate-work line (v0.10 PR3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,14 @@ Duplicate work (same task across ≥2 projects)
 
 It runs **fully offline and deterministic** — no agent, no network. Each session's prompt is reduced **on-device** to a handful of redacted keyword tokens (structured secrets — keys, URLs, paths, IPs, connection strings — are stripped first); raw prompt text is never stored, printed, or sent. `--threshold` (0–1, default 0.4) and `--min-cluster` (default 2) tune the clustering; bias toward false negatives, since a wrong "duplicate work" call costs more trust than a missed one.
 
+Intent text is read from Claude Code, Cursor, Copilot, Gemini CLI, and Codex sessions (Antigravity is token-only for now). `--html <path>` writes a self-contained task-category dashboard, and once you've run `categorize`, `report` and `html` surface a one-line duplicate-work callout (counts and cost only — never labels).
+
 ## CLI
 
 ```
 token-monitor collect [--source claude-code|gemini-cli|codex|cursor|antigravity|copilot] [--db <path>]
 token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>] [--json] [--db <path>]
-token-monitor categorize [--days 30] [--threshold 0.4] [--min-cluster 2] [--project <name>] [--source <name>] [--json] [--db <path>]
+token-monitor categorize [--days 30] [--threshold 0.4] [--min-cluster 2] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
 token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline] [--verify] [--keys keys.json] [--json] [--html team.html]

--- a/src/categorize.ts
+++ b/src/categorize.ts
@@ -17,7 +17,7 @@
  */
 import type { DatabaseSync } from 'node:sqlite';
 import { loadEvents, recordIntents, loadIntents } from './store.js';
-import type { StoredEvent } from './store.js';
+import type { StoredEvent, IntentRow } from './store.js';
 import { groupBy, parseTools } from './metrics.js';
 import { costOf } from './pricing.js';
 import { ADAPTERS } from './adapters/index.js';
@@ -124,7 +124,6 @@ export function runCategorize(
 ): CategorizeResult {
   const events = loadEvents(db, { days: opts.days, project: opts.project, source: opts.source });
   const days = opts.days ?? 30;
-  const minCluster = Math.max(2, opts.minCluster ?? 2);
 
   const aggs = [...groupBy(events, 'session_id').entries()].map(([id, evs]) => aggregateSession(id, evs));
   if (aggs.length === 0) {
@@ -150,6 +149,28 @@ export function runCategorize(
 
   // Cluster the FROZEN (first-wins) fingerprints, so display is idempotent.
   const frozen = loadIntents(db, aggs.map((a) => a.sessionId));
+  return buildResult(aggs, frozen, days, opts);
+}
+
+const byCostThenSessions = (a: CategoryRow, b: CategoryRow) =>
+  b.sessions - a.sessions ||
+  b.cost - a.cost ||
+  (a.name < b.name ? -1 : a.name > b.name ? 1 : 0) ||
+  (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+
+/**
+ * Cluster the frozen fingerprints into category rows and derive the
+ * duplicate-work / skill-candidate signals. Shared by `runCategorize` (after
+ * recording) and the read-only `categorizeSummary` (no recording), so both see
+ * identical clusters for the same window.
+ */
+function buildResult(
+  aggs: SessionAgg[],
+  frozen: Map<string, IntentRow>,
+  days: number,
+  opts: { threshold?: number; minCluster?: number },
+): CategorizeResult {
+  const minCluster = Math.max(2, opts.minCluster ?? 2);
   // Count from the frozen rows the categories are actually built from (not the
   // fresh re-derivation), so the header matches the per-row labels on re-runs.
   const textSessions = [...frozen.values()].filter((r) => r.has_text === 1).length;
@@ -175,12 +196,6 @@ export function runCategorize(
     return { id: c.id, name: c.name, sessions: members.length, projects, tokens, cost, estimated, hasText, duplicate };
   });
 
-  const byCostThenSessions = (a: CategoryRow, b: CategoryRow) =>
-    b.sessions - a.sessions ||
-    b.cost - a.cost ||
-    (a.name < b.name ? -1 : a.name > b.name ? 1 : 0) ||
-    (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
-
   return {
     days,
     totalSessions: aggs.length,
@@ -189,4 +204,45 @@ export function runCategorize(
     duplicates: categories.filter((c) => c.duplicate).sort((a, b) => b.cost - a.cost || byCostThenSessions(a, b)),
     skillCandidates: categories.filter((c) => c.hasText && c.sessions >= minCluster).sort(byCostThenSessions),
   };
+}
+
+/** Cross-surface duplicate-work signal for `report`/`html` (see categorizeSummary). */
+export interface CategorizeSummary {
+  duplicateTasks: number;
+  duplicateSessions: number;
+  duplicateCost: number;
+  estimated: boolean;
+}
+
+/**
+ * Read-only duplicate-work signal for the shared `report`/`html` surfaces,
+ * derived from ALREADY-FROZEN intents only — no re-collection, no recording, no
+ * privacy surface beyond what `categorize` already persisted. Returns undefined
+ * when `categorize` has not run for this window, or found no cross-project
+ * duplicate work, so the callout only appears when there is something to say.
+ */
+export function categorizeSummary(
+  db: DatabaseSync,
+  opts: { days?: number; project?: string; source?: string; threshold?: number; minCluster?: number } = {},
+): CategorizeSummary | undefined {
+  const events = loadEvents(db, { days: opts.days, project: opts.project, source: opts.source });
+  if (events.length === 0) return undefined;
+  const aggs = [...groupBy(events, 'session_id').entries()].map(([id, evs]) => aggregateSession(id, evs));
+  const frozen = loadIntents(db, aggs.map((a) => a.sessionId));
+  if (frozen.size === 0) return undefined;
+  const { duplicates } = buildResult(aggs, frozen, opts.days ?? 30, opts);
+  if (duplicates.length === 0) return undefined;
+  return {
+    duplicateTasks: duplicates.length,
+    duplicateSessions: duplicates.reduce((s, c) => s + c.sessions, 0),
+    duplicateCost: duplicates.reduce((s, c) => s + c.cost, 0),
+    estimated: duplicates.some((c) => c.estimated),
+  };
+}
+
+/** Shared wording for the one-line duplicate-work callout in report/html. */
+export function fmtCategorizeSummary(s: CategorizeSummary): string {
+  const cost = (s.estimated ? '~' : '') + '$' + s.duplicateCost.toFixed(2);
+  const tasks = s.duplicateTasks === 1 ? '1 recurring task' : `${s.duplicateTasks} recurring tasks`;
+  return `${tasks} spanning ≥2 projects (${cost})`;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { ADAPTERS } from './adapters/index.js';
 import { openDb, insertEvents, loadEvents, DEFAULT_DB } from './store.js';
 import { renderReport, renderTeamReport, renderTrend, renderCategorize } from './report.js';
-import { runCategorize } from './categorize.js';
+import { runCategorize, categorizeSummary } from './categorize.js';
 import { splitWindow } from './trends.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import { buildExport, parseTeamConfig, mergeMetrics, dedupeExports, rollupExports, displayName, identityOf } from './team.js';
@@ -12,7 +12,7 @@ import { syncFindings, recordLlmFindings } from './followthrough.js';
 import { enrichFindings } from './recommendations.js';
 import { reconcile, renderReconcile, PROVIDERS } from './reconcile.js';
 import { computeMetrics } from './metrics.js';
-import { renderHtml, renderTeamHtml } from './html.js';
+import { renderHtml, renderTeamHtml, renderCategorizeHtml } from './html.js';
 import { renderAnalysis, deepAnalysis, buildLlmPrompt, buildLlmTrackPrompt, runLlm, runLlmCapture, parseLlmFindings, renderTrackedLlm, detectAgent } from './analyze.js';
 import { signObject, verifyObject, ensureKeypair, fingerprint, loadKeyring, checkKeyring, keyDirFor, DEFAULT_KEY_DIR } from './sign.js';
 import { fetchTeamConfig, saveConfig, loadConfig, pushExport, installSchedule, removeSchedule } from './deploy.js';
@@ -25,7 +25,7 @@ const HELP = `token-monitor — measure how effectively your team spends AI codi
 Usage:
   token-monitor collect [--source <name>] [--db <path>]
   token-monitor report  [--days <n>] [--trend] [--project <name>] [--source <name>] [--json] [--db <path>]
-  token-monitor categorize [--days <n>] [--threshold <0-1>] [--min-cluster <n>] [--project <name>] [--source <name>] [--json] [--db <path>]
+  token-monitor categorize [--days <n>] [--threshold <0-1>] [--min-cluster <n>] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
   token-monitor analyze [--days <n>] [--llm] [--track] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline]
@@ -73,7 +73,7 @@ Options:
   --team      member map: flat (\`alice: frontend\`) or two-level YAML
               (\`platform:\` header, indented members), or JSON
   --by        merge rollup axis: team or discipline (default: discipline)
-  --html      also write the merged team dashboard to this path
+  --html      write an HTML dashboard to this path (merge: team rollup; categorize: task categories)
   --db        SQLite path (default: ${DEFAULT_DB})
 `;
 
@@ -280,7 +280,12 @@ Signing fingerprint (send to your team lead for keys.json):
         !values.project && !values.source && events.length > 0
           ? syncFindings(db, computeMetrics(events))
           : undefined;
-      let out = renderReport(events, { days, follow });
+      // Cross-surface the duplicate-work signal from any prior `categorize` run
+      // (read-only over frozen intents; absent until the user has categorized).
+      const cat = events.length > 0
+        ? categorizeSummary(db, { days, project: values.project, source: values.source })
+        : undefined;
+      let out = renderReport(events, { days, follow, categorize: cat });
       if (values.trend && events.length > 0) out += '\n' + renderTrend(events, previous, days);
       console.log(out);
     }
@@ -307,7 +312,10 @@ Signing fingerprint (send to your team lead for keys.json):
       threshold,
       minCluster,
     });
-    if (values.json) {
+    if (values.html) {
+      writeFileSync(values.html, renderCategorizeHtml(result, days));
+      console.log(`Wrote ${values.html} (${result.totalSessions} sessions, last ${days} days). Open it in a browser.`);
+    } else if (values.json) {
       console.log(JSON.stringify(result, null, 2));
     } else {
       console.log(renderCategorize(result, days));
@@ -378,7 +386,8 @@ Signing fingerprint (send to your team lead for keys.json):
     const days = Number(values.days) || 30;
     const { current: events, previous } = splitWindow(loadEvents(db, { days: days * 2 }), days);
     const follow = events.length > 0 ? syncFindings(db, computeMetrics(events)) : undefined;
-    writeFileSync(values.out, renderHtml(events, { days, follow, previousEvents: previous }));
+    const cat = events.length > 0 ? categorizeSummary(db, { days }) : undefined;
+    writeFileSync(values.out, renderHtml(events, { days, follow, previousEvents: previous, categorize: cat }));
     console.log(`Wrote ${values.out} (${events.length} turns, last ${days} days). Open it in a browser.`);
   } else {
     console.error(`Unknown command "${cmd}"\n`);

--- a/src/html.ts
+++ b/src/html.ts
@@ -10,6 +10,8 @@ import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
 import { mergeMetrics, rollupExports, displayName } from './team.js';
 import { enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
+import type { CategorizeResult, CategoryRow, CategorizeSummary } from './categorize.js';
+import { fmtCategorizeSummary } from './categorize.js';
 
 const ACTIVITY_COLORS: Record<string, string> = {
   thinking: '#8b7ff5',
@@ -44,7 +46,7 @@ function stackedBar(m: Metrics): string {
 
 export function renderHtml(
   events: StoredEvent[],
-  opts: { days: number; follow?: FollowRow[]; previousEvents?: StoredEvent[] },
+  opts: { days: number; follow?: FollowRow[]; previousEvents?: StoredEvent[]; categorize?: CategorizeSummary },
 ): string {
   const m = computeMetrics(events);
   const persona = assignPersona(m);
@@ -141,6 +143,7 @@ ${stackedBar(m)}
 <div class="legend">${legend}</div>
 <p class="muted">rework ${pct(m.reworkRatio)} · think:code ${m.thinkToCodeRatio.toFixed(2)} · ${m.errorEvents} turns hit tool errors</p>
 <p class="muted">signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions · cold restarts ${pct(m.coldRestartShare)} of fresh input · premium on exploration/chat ${pct(m.premiumWasteShare)} · retry loops ${pct(m.retryShare)}</p>
+${opts.categorize ? `<p class="dup">🔁 ${esc(fmtCategorizeSummary(opts.categorize))} <span class="muted">— run <code>categorize</code> for detail</span></p>` : ''}
 
 <h2>Projects</h2>
 <table><tr><th>Project</th><th>Activity mix</th><th>Tokens</th><th>Cost</th><th>Cache</th><th>Rework</th><th>Persona</th></tr>${projRows}</table>
@@ -186,6 +189,8 @@ function pageShell(title: string, body: string): string {
   .save { color:#5dc98a; font-weight:600; white-space:nowrap; }
   .ev { font-size:.8rem; margin-top:.15rem; }
   .potential { margin:.5rem 0 .2rem; font-weight:600; color:#9fd45d; }
+  .dup { margin:.3rem 0; color:#e8c468; }
+  .dup code, td code { background:#252b37; border-radius:4px; padding:.05rem .3rem; }
   .st-resolved { color:#5dc98a; } .st-regressing { color:#e88f68; } .st-improving { color:#9fd45d; }
   footer { margin:2.5rem 0 1rem; font-size:.8rem; color:#717a8a; }
 </style></head><body>
@@ -239,5 +244,71 @@ export function renderTeamHtml(
   <div class="muted">${esc(persona.description)}</div>
   <ul class="recs">${recs.map((r) => `<li>${esc(r)}</li>`).join('')}</ul>
 </div>`,
+  );
+}
+
+/** Dashboard face of `categorize` — task clusters, duplicate work, skill candidates. */
+export function renderCategorizeHtml(r: CategorizeResult, days: number): string {
+  const title = `token-monitor — task categories (last ${days} days)`;
+  if (r.totalSessions === 0) {
+    return pageShell(
+      title,
+      `<h1>Task categories</h1>
+<p class="muted">No sessions in range. Run <code>token-monitor collect</code> first, or widen the window.</p>`,
+    );
+  }
+  const catCost = (c: CategoryRow): string => (c.estimated ? '~' : '') + '$' + c.cost.toFixed(2);
+
+  const cards = [
+    ['Sessions', String(r.totalSessions)],
+    ['From prompt text', String(r.textSessions)],
+    ['Categories', String(r.categories.length)],
+    ['Duplicate tasks', String(r.duplicates.length)],
+  ]
+    .map(([k, v]) => `<div class="card"><div class="k">${k}</div><div class="v">${v}</div></div>`)
+    .join('');
+
+  const catRows = r.categories
+    .slice(0, 40)
+    .map(
+      (c) =>
+        `<tr><td>${c.duplicate ? '⚠ ' : ''}${esc(c.name)}${c.hasText ? '' : ' <span class="muted">(no text)</span>'}</td><td class="num">${c.sessions}</td><td class="num">${c.projects.length}</td><td class="num">${fmtTokens(c.tokens)}</td><td class="num">${catCost(c)}</td></tr>`,
+    )
+    .join('');
+
+  const dupSection = r.duplicates.length
+    ? `<h2>Duplicate work <span class="muted">— same task across ≥2 projects</span></h2>
+<table><tr><th>Task</th><th>Sessions</th><th>Projects</th><th>Where</th><th>Cost</th></tr>${r.duplicates
+        .slice(0, 20)
+        .map(
+          (c) =>
+            `<tr><td>⚠ ${esc(c.name)}</td><td class="num">${c.sessions}</td><td class="num">${c.projects.length}</td><td>${esc(c.projects.join(', '))}</td><td class="num">${catCost(c)}</td></tr>`,
+        )
+        .join('')}</table>
+<p class="muted">Recurring across projects → codify it as a shared skill/prompt instead of re-deriving it.</p>`
+    : `<h2>Duplicate work</h2>
+<p class="muted">No task repeated across multiple projects in this window.</p>`;
+
+  const skillSection = r.skillCandidates.length
+    ? `<h2>Org-skill candidates <span class="muted">— recurring tasks worth codifying</span></h2>
+<table><tr><th>Task</th><th>Sessions</th><th>Projects</th><th>Cost</th></tr>${r.skillCandidates
+        .slice(0, 20)
+        .map(
+          (c) =>
+            `<tr><td>${esc(c.name)}</td><td class="num">${c.sessions}</td><td class="num">${c.projects.length}</td><td class="num">${catCost(c)}</td></tr>`,
+        )
+        .join('')}</table>`
+    : '';
+
+  return pageShell(
+    title,
+    `<h1>Task categories <span class="muted">— last ${days} days · generated ${new Date().toISOString().slice(0, 16).replace('T', ' ')}</span></h1>
+<div class="cards">${cards}</div>
+
+<h2>By category</h2>
+<table><tr><th>Category</th><th>Sessions</th><th>Projects</th><th>Tokens</th><th>Cost</th></tr>${catRows}</table>
+${dupSection}
+${skillSection}
+<p class="muted">Labels are derived on-device from redacted prompts; raw prompt text is never stored.</p>`,
   );
 }

--- a/src/report.ts
+++ b/src/report.ts
@@ -11,7 +11,8 @@ import type { EnrichedRec } from './recommendations.js';
 import { enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
 import type { TrendRow, TrendVerdict } from './trends.js';
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
-import type { CategorizeResult } from './categorize.js';
+import type { CategorizeResult, CategorizeSummary } from './categorize.js';
+import { fmtCategorizeSummary } from './categorize.js';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -67,7 +68,7 @@ const STATUS_LABEL: Record<FollowRow['status'], string> = {
 
 export function renderReport(
   events: StoredEvent[],
-  opts: { days: number; follow?: FollowRow[] },
+  opts: { days: number; follow?: FollowRow[]; categorize?: CategorizeSummary },
 ): string {
   if (events.length === 0) {
     return 'No events in range. Run `token-monitor collect` first, or widen --days.';
@@ -106,6 +107,11 @@ export function renderReport(
   out.push(
     `  ${DIM}signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions  ·  cold restarts ${(m.coldRestartShare * 100).toFixed(0)}% of fresh input  ·  premium on exploration/chat ${(m.premiumWasteShare * 100).toFixed(0)}%  ·  retry loops ${(m.retryShare * 100).toFixed(1)}%${RESET}`,
   );
+  if (opts.categorize) {
+    out.push(
+      `  ${YELLOW}🔁 ${fmtCategorizeSummary(opts.categorize)}${RESET} ${DIM}— run \`categorize\` for detail${RESET}`,
+    );
+  }
 
   out.push(section('By project'));
   const projRows = [...groupBy(events, 'project').entries()]

--- a/test/categorize.test.ts
+++ b/test/categorize.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openDb, insertEvents, recordIntents } from '../src/store.js';
+import { categorizeSummary, fmtCategorizeSummary } from '../src/categorize.js';
+import { makeEvent } from './helpers.js';
+
+const DAYS = { days: 36500 };
+
+function freshDb() {
+  return openDb(join(mkdtempSync(join(tmpdir(), 'tm-catsum-')), 'db.sqlite'));
+}
+
+test('categorizeSummary is undefined until intents are recorded, then reports cross-project duplicates', () => {
+  const db = freshDb();
+  insertEvents(db, [
+    makeEvent({ source: 'claude-code', eventKey: 'k1', sessionId: 's1', project: 'proj-a', activity: 'coding' }),
+    makeEvent({ source: 'claude-code', eventKey: 'k2', sessionId: 's2', project: 'proj-b', activity: 'coding' }),
+  ]);
+
+  // No frozen intents yet -> the cross-surface signal stays silent.
+  assert.equal(categorizeSummary(db, DAYS), undefined);
+
+  // Two projects, one shared task -> a duplicate-work cluster.
+  const fp = ['jwt', 'auth', 'login', 'rest', 'api'];
+  recordIntents(db, [
+    { sessionId: 's1', source: 'claude-code', project: 'proj-a', intentId: 'i1', label: 'jwt auth login', fingerprint: fp, hasText: true, firstSeen: '2026-06-01T10:00:00.000Z' },
+    { sessionId: 's2', source: 'claude-code', project: 'proj-b', intentId: 'i2', label: 'jwt auth login', fingerprint: fp, hasText: true, firstSeen: '2026-06-01T10:00:00.000Z' },
+  ]);
+
+  const s = categorizeSummary(db, DAYS);
+  assert.ok(s, 'expected a summary once a cross-project duplicate is recorded');
+  assert.equal(s!.duplicateTasks, 1);
+  assert.equal(s!.duplicateSessions, 2);
+  db.close();
+});
+
+test('categorizeSummary gates out no-text clusters (no false duplicate-work accusation)', () => {
+  const db = freshDb();
+  insertEvents(db, [
+    makeEvent({ source: 'claude-code', eventKey: 'k1', sessionId: 's1', project: 'proj-a', activity: 'coding' }),
+    makeEvent({ source: 'claude-code', eventKey: 'k2', sessionId: 's2', project: 'proj-b', activity: 'coding' }),
+  ]);
+  const fp = ['coding', 'edit'];
+  recordIntents(db, [
+    { sessionId: 's1', source: 'claude-code', project: 'proj-a', intentId: 'i1', label: 'coding edit', fingerprint: fp, hasText: false, firstSeen: '2026-06-01T10:00:00.000Z' },
+    { sessionId: 's2', source: 'claude-code', project: 'proj-b', intentId: 'i2', label: 'coding edit', fingerprint: fp, hasText: false, firstSeen: '2026-06-01T10:00:00.000Z' },
+  ]);
+  // The cluster forms, but with no real text it is never flagged as duplicate work.
+  assert.equal(categorizeSummary(db, DAYS), undefined);
+  db.close();
+});
+
+test('fmtCategorizeSummary: singular/plural wording and the estimated marker', () => {
+  assert.equal(
+    fmtCategorizeSummary({ duplicateTasks: 1, duplicateSessions: 2, duplicateCost: 4, estimated: false }),
+    '1 recurring task spanning ≥2 projects ($4.00)',
+  );
+  assert.equal(
+    fmtCategorizeSummary({ duplicateTasks: 3, duplicateSessions: 7, duplicateCost: 48.5, estimated: true }),
+    '3 recurring tasks spanning ≥2 projects (~$48.50)',
+  );
+});

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -463,6 +463,26 @@ test('e2e: categorize clusters intents offline, flags cross-project dup, never l
   // Idempotent: a second run records nothing new and freezes intent ids first-wins.
   const idsAfter = [...loadIntents(openDb(dbPath), ['sa', 'sb', 'sc']).values()].map((r) => r.intent_id).sort();
   assert.deepEqual(idsAfter, idsBefore, 'intent ids must be stable across runs');
+
+  // PR3: --html writes a self-contained categorize dashboard, still leak-free.
+  const htmlPath = join(home, 'cat.html');
+  assert.equal(run(['categorize', '--html', htmlPath, ...DAYS], { home }).code, 0);
+  const catHtml = readFileSync(htmlPath, 'utf8');
+  assert.ok(catHtml.startsWith('<!doctype html>'));
+  assert.ok(catHtml.includes('Duplicate work'), 'dashboard missing Duplicate work section');
+  assert.ok(catHtml.includes('proj-auth-a') && catHtml.includes('proj-auth-b'), 'dashboard must name both projects');
+  assert.ok(catHtml.includes('raw prompt text is never stored'), 'dashboard missing privacy footnote');
+  for (const leak of [SECRET_KEY, SECRET_EMAIL, 'CANARY', RAW_PHRASE]) {
+    assert.ok(!catHtml.includes(leak), `categorize --html leaked "${leak}"`);
+  }
+
+  // PR3: report cross-surfaces the duplicate-work signal from the frozen intents.
+  const rep = run(['report', ...DAYS], { home });
+  assert.equal(rep.code, 0);
+  assert.match(rep.stdout, /🔁 1 recurring task spanning ≥2 projects/, 'report missing the duplicate-work callout');
+  for (const leak of [SECRET_KEY, SECRET_EMAIL, 'CANARY', RAW_PHRASE]) {
+    assert.ok(!rep.stdout.includes(leak), `report duplicate-work line leaked "${leak}"`);
+  }
 });
 
 test('e2e: unknown command and bare invocation fail with help', () => {

--- a/test/html.test.ts
+++ b/test/html.test.ts
@@ -1,8 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { renderHtml } from '../src/html.js';
+import { renderHtml, renderCategorizeHtml } from '../src/html.js';
 import { makeStored } from './helpers.js';
 import type { FollowRow } from '../src/followthrough.js';
+import type { CategorizeResult, CategoryRow } from '../src/categorize.js';
 
 test('renderHtml produces a self-contained document with key sections', () => {
   const html = renderHtml(
@@ -26,6 +27,57 @@ test('renderHtml escapes project names', () => {
     { days: 30 },
   );
   assert.ok(!html.includes('<img src=x'));
+});
+
+test('renderHtml surfaces the duplicate-work line only when a categorize summary is passed', () => {
+  const ev = [makeStored({ activity: 'coding', input_tokens: 1000, output_tokens: 0 })];
+  const without = renderHtml(ev, { days: 30 });
+  assert.ok(!without.includes('🔁'));
+
+  const withSummary = renderHtml(ev, {
+    days: 30,
+    categorize: { duplicateTasks: 3, duplicateSessions: 7, duplicateCost: 48.5, estimated: false },
+  });
+  assert.ok(withSummary.includes('🔁'));
+  assert.ok(withSummary.includes('3 recurring tasks spanning ≥2 projects'));
+  assert.ok(withSummary.includes('$48.50'));
+});
+
+const catRow = (p: Partial<CategoryRow>): CategoryRow => ({
+  id: 'c', name: 'task', sessions: 1, projects: ['proj'], tokens: 1000, cost: 1, estimated: false, hasText: true, duplicate: false, ...p,
+});
+
+test('renderCategorizeHtml renders categories, duplicate work, and skill candidates', () => {
+  const dup = catRow({ id: 'd1', name: 'jwt auth login', sessions: 3, projects: ['proj-a', 'proj-b'], tokens: 12000, cost: 4.2, duplicate: true });
+  const solo = catRow({ id: 's1', name: 'css <flex>', sessions: 1, projects: ['proj-c'], tokens: 3000, cost: 1.1, estimated: true });
+  const notext = catRow({ id: 'n1', name: 'coding edit', sessions: 2, projects: ['proj-d', 'proj-e'], tokens: 2000, cost: 0.5, hasText: false });
+  const result: CategorizeResult = {
+    days: 30, totalSessions: 6, textSessions: 4,
+    categories: [dup, solo, notext], duplicates: [dup], skillCandidates: [dup],
+  };
+  const html = renderCategorizeHtml(result, 30);
+
+  assert.ok(html.startsWith('<!doctype html>'));
+  assert.ok(html.includes('Task categories'));
+  assert.ok(html.includes('jwt auth login'));
+  assert.ok(html.includes('Duplicate work'));
+  assert.ok(html.includes('proj-a, proj-b'), 'duplicate row names both projects');
+  assert.ok(html.includes('Org-skill candidates'));
+  assert.ok(html.includes('(no text)'), 'no-text category is marked');
+  assert.ok(html.includes('raw prompt text is never stored'), 'privacy footnote present');
+  // labels are HTML-escaped
+  assert.ok(!html.includes('css <flex>'));
+  assert.ok(html.includes('css &#60;flex&#62;'));
+  // self-contained
+  assert.ok(!/<script\s+src|<link\s+rel="stylesheet"/.test(html));
+});
+
+test('renderCategorizeHtml shows an empty state when there are no sessions', () => {
+  const html = renderCategorizeHtml(
+    { days: 30, totalSessions: 0, textSessions: 0, categories: [], duplicates: [], skillCandidates: [] },
+    30,
+  );
+  assert.ok(html.includes('No sessions in range'));
 });
 
 test('renderHtml marks LLM-origin follow-through rows with a robot', () => {


### PR DESCRIPTION
## What

"Findings + HTML parity" for `categorize`.

- **`categorize --html <path>`** writes a self-contained task-category dashboard (categories, duplicate work, org-skill candidates) — HTML parity with `report`/`merge`.
- **`report`/`html` now surface a one-line duplicate-work callout** (🔁 N recurring tasks spanning ≥2 projects) computed **read-only** from already-frozen intents: no re-collection, no recording, **counts and cost only — never labels or raw text**. Silent until `categorize` has run for the window and there's ≥1 cross-project duplicate.

## Refactor

The cluster → `CategoryRow` → signals logic is now a shared `buildResult()` used by both `runCategorize` (after recording) and the new read-only `categorizeSummary()`. An adversarial review proved the extraction is byte-identical to the prior `runCategorize` behaviour.

## Notes

- The `report`/`html` callout uses default `--threshold`/`--min-cluster` (can differ from a tuned `categorize` run — accepted by design).
- HTML review: all interpolations escaped, zero XSS findings.

## Tests

161 → 167. New: `renderCategorizeHtml` (content/escaping/empty-state), `categorizeSummary` gating, and e2e coverage for `categorize --html` + the report callout (both leak-checked).

---
Builds on #56 (already merged). Supersedes the auto-closed #57.