### PR TITLE
chore: release v0.10.0

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-monitor",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-monitor",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "token-monitor",
   "displayName": "Token Monitor",
   "description": "Status-bar token/cost for the current project plus the token-monitor dashboard, for VS Code, Cursor, Windsurf, and Antigravity.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publisher": "ryan653133",
   "license": "MIT",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ryandemelo/token-monitor",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "bin": {
         "token-monitor": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex, Cursor, Antigravity, Copilot Chat) — activity breakdowns, usage personas, and recommendations.",
   "license": "MIT",
   "author": "Ryan de Melo",


### PR DESCRIPTION
Version bump 0.9.0 → 0.10.0 (root + extension).

**v0.10.0 — Task categorization, expanded**
- #56 — `categorize` derives intent text from Cursor, Copilot, Gemini CLI and Codex sessions, not just Claude Code (Antigravity deferred to PR5).
- #58 — `categorize --html` task-category dashboard + read-only duplicate-work callout in `report`/`html`.

On-device privacy floor unchanged; zero new runtime deps. 167 tests.

After merge: tag `v0.10.0` (CI auto-publishes the Marketplace .vsix) + npm publish + GitHub release.