### PR TITLE
feat: project families, aggregate category exports, cross-user duplicate detection (v0.11 PR4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,15 +226,44 @@ It runs **fully offline and deterministic** — no agent, no network. Each sessi
 
 Intent text is read from Claude Code, Cursor, Copilot, Gemini CLI, and Codex sessions (Antigravity is token-only for now). `--html <path>` writes a self-contained task-category dashboard, and once you've run `categorize`, `report` and `html` surface a one-line duplicate-work callout (counts and cost only — never labels).
 
+### Project families
+
+A session that `cd`-s into monorepo subdirs used to fragment one repo into several "projects" (`backend`, `frontend`, `db`…) — inflating the project table and letting duplicate-work detection accuse the *same* repo of cross-project repetition. `collect` now assigns each session **one project: the directory where most of its events ran**, with subdirectories folding into the shallowest parent the session visited (a directory only adopts a label from an ancestor the session actually entered, so sibling projects can never merge, and near-root launch dirs like a home directory never donate their name). This is pure path grouping — no disk access, identical results for deleted directories — and deliberately conservative: resolving to the git repo root was tried and rejected because on umbrella repos it silently merged distinct products into one row, and a wrong merge corrupts the duplicate-work signal where a missed merge only under-reports.
+
+The first 0.11 collect relabels historical rows in one pass — you'll see `(N relabeled into project families; originals in project_raw)` once, and per-project rows may visibly merge. The pre-relabel name of every changed row is kept in the `project_raw` column (`UPDATE events SET project = project_raw WHERE project_raw IS NOT NULL` reverts). Git-worktree checkouts opened as their own directory (`myapp-wt1`) still count as separate projects — fold those explicitly in `~/.token-monitor/project-aliases.json`:
+
+```json
+{ "myapp-wt1": "myapp", "quaestor-cl-iter-02": "quaestor-cl" }
+```
+
+### Cross-user duplicate work and org skills (lead)
+
+Member exports (`report --json` / `push`) carry each person's task categories — **labels only**: at most 8 redacted keyword terms plus counts and cost per category, capped at the 40 largest, only for sessions with real prompt text. `merge` re-clusters those categories **across people** and reports the same task done independently by two or more members, plus org-skill candidates ranked by `sessions × users`:
+
+```
+Cross-user duplicate work (same task, ≥2 people)
+  $84.00 spent on tasks done independently by ≥2 people (1 task)
+
+  ⚠ payment retry backoff — 5 session(s) by alice, bob across 2 project(s)  $84.00
+
+  Same task, different people → codify one org skill/prompt instead of re-deriving it per person.
+
+Org-skill candidates (team-wide)
+  Task                   Users  Sessions  Cost    Score
+  payment retry backoff  2      5         $84.00  10
+```
+
+`merge` honors the same `--threshold` / `--min-cluster` knobs as `categorize`. Members can opt out entirely with `report --json --no-categories` / `push --no-categories`. Unsigned exports are identified as `user@host` and flagged `(unsigned)` — one person on two machines can read as two people, so sign exports before acting on a cross-user finding.
+
 ## CLI
 
 ```
 token-monitor collect [--source claude-code|gemini-cli|codex|cursor|antigravity|copilot] [--db <path>]
-token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>] [--json] [--db <path>]
+token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>] [--json] [--no-categories] [--db <path>]
 token-monitor categorize [--days 30] [--threshold 0.4] [--min-cluster 2] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
-token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline] [--verify] [--keys keys.json] [--json] [--html team.html]
+token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline] [--verify] [--keys keys.json] [--threshold 0.4] [--min-cluster 2] [--json] [--html team.html]
 token-monitor reconcile [--provider anthropic|openai] [--days 30] [--db <path>]
 ```
 
@@ -254,6 +283,8 @@ The most valuable contribution: an adapter for another agent CLI (Aider, OpenCod
 - [x] Org-level cross-check via provider usage APIs: `reconcile`
 - [x] npm publish: `npx @ryandemelo/token-monitor`
 - [x] Task categorization: cluster sessions by intent, flag cross-project duplicate work, suggest org skills (`categorize`, on-device)
+- [x] Project families: monorepo subdirs fold into one project per session (anchor-based path grouping, `project_raw` audit trail; worktrees fold via `project-aliases.json`)
+- [x] Cross-user duplicate work: aggregate-only category exports, `merge` clusters tasks across people and ranks org-skill candidates
 
 ## Integrity & threat model
 
@@ -288,6 +319,8 @@ Per model it shows local tokens, org-billed tokens, and a coverage %. The local 
 Everything stays on your machine. token-monitor reads log files locally, stores aggregate numbers in a local SQLite file, and never makes a network request. The core report stores only token counts, tool names, timestamps, and project/branch names — never prompt or code content.
 
 `categorize` is the one command that looks at prompt text, and it does so **entirely on-device**: each session is reduced to at most 8 redacted keyword tokens before anything is written. Structured secrets of known shape (emails, API keys, URLs, file paths, IPs, UUIDs, connection strings, PEM blocks, `key=value` secrets) are stripped first, and key/hash-shaped survivors are dropped — so the database stores keyword *labels*, never sentences. This is defence-in-depth, not a guarantee: a secret that looks exactly like an ordinary word can still survive, which is why only labels (never raw prose) are ever kept.
+
+**What's in a team export** (`report --json` / `push`), field by field: token/cost aggregates, activity shares, per-project metrics keyed by project basename, persona + recommendation strings, and — new in 0.11 — task categories: `{id, name, terms (≤8 redacted keywords), sessions, projects, tokens, cost, estimated, duplicate}`. No prompts, no code, no paths, no session text, and `--no-categories` drops the category block entirely. The terms are deliberately *not* hashed: a dictionary of common dev words would reverse such hashes trivially, so hashing would only obscure the surface from the member shipping it — readable terms keep it auditable.
 
 The one network exception is opt-in: `analyze --llm` sends aggregates to your own agent CLI's provider for analysis. Everything else — `categorize` included — is fully offline.
 

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,8 +1,9 @@
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { UsageEvent, CollectResult } from '../types.js';
 import { classify } from '../classify.js';
+import { sessionProjectOf } from '../project-family.js';
 
 const ROOT = join(homedir(), '.claude', 'projects');
 
@@ -95,6 +96,10 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
       // The most recent genuine user prompt, carried forward onto the assistant
       // turns it triggered (transient — used only by `categorize`).
       let lastUserText = '';
+      // Events buffered with their raw cwd: the project is assigned ONCE per
+      // session at end-of-file, so a session that cd-s into monorepo subdirs
+      // ("backend", "frontend") can't fragment into per-subdir pseudo-projects.
+      const fileEvents: Array<{ ev: UsageEvent; cwd?: string }> = [];
       for (const line of text.split('\n')) {
         if (!line.trim()) continue;
         let d: ClaudeLine;
@@ -146,7 +151,7 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
           source: 'claude-code',
           eventKey: d.uuid,
           sessionId: d.sessionId ?? file.replace('.jsonl', ''),
-          project: d.cwd ? basename(d.cwd) : dir,
+          project: '', // assigned per-session at end-of-file, see below
           timestamp: d.timestamp ?? new Date(0).toISOString(),
           model: d.message.model ?? 'unknown',
           inputTokens: u.input_tokens ?? 0,
@@ -162,8 +167,28 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
           intentText: lastUserText || undefined,
         };
         ev.activity = classify(ev);
-        events.push(ev);
+        fileEvents.push({ ev, cwd: d.cwd });
         for (const id of toolUseIds) byToolUseId.set(id, ev);
+      }
+
+      // One project per session: the dominant per-event cwd label after
+      // descendant adoption (see project-family.ts) — the log dir name when
+      // no event carried a cwd. A single-cwd session stays byte-identical to
+      // the old basename(cwd) behavior.
+      const cwdsBySession = new Map<string, string[]>();
+      for (const { ev, cwd } of fileEvents) {
+        if (!cwd) continue;
+        let list = cwdsBySession.get(ev.sessionId);
+        if (!list) cwdsBySession.set(ev.sessionId, (list = []));
+        list.push(cwd); // one entry PER EVENT — dominance needs the counts
+      }
+      const projectBySession = new Map<string, string>();
+      for (const [sessionId, cwds] of cwdsBySession) {
+        projectBySession.set(sessionId, sessionProjectOf(cwds) ?? dir);
+      }
+      for (const { ev } of fileEvents) {
+        ev.project = projectBySession.get(ev.sessionId) ?? dir;
+        events.push(ev);
       }
     }
   }

--- a/src/categorize.ts
+++ b/src/categorize.ts
@@ -25,10 +25,13 @@ import type { Source } from './types.js';
 import { deriveSessionIntent, fnv1a } from './intent.js';
 import { clusterLabels } from './cluster.js';
 import type { ClusterItem } from './cluster.js';
+import type { ExportCategory } from './team.js';
 
 export interface CategoryRow {
   id: string;
   name: string;
+  /** Cluster top terms (≤8, redacted) — feeds the team-export match key. */
+  terms: string[];
   sessions: number;
   projects: string[];
   tokens: number;
@@ -193,7 +196,10 @@ function buildResult(
     // evidence of the same task, so it must never trigger a "duplicate work"
     // accusation or an org-skill recommendation.
     const duplicate = hasText && members.length >= minCluster && projects.length >= 2;
-    return { id: c.id, name: c.name, sessions: members.length, projects, tokens, cost, estimated, hasText, duplicate };
+    return {
+      id: c.id, name: c.name, terms: c.terms.slice(0, 8),
+      sessions: members.length, projects, tokens, cost, estimated, hasText, duplicate,
+    };
   });
 
   return {
@@ -204,6 +210,27 @@ function buildResult(
     duplicates: categories.filter((c) => c.duplicate).sort((a, b) => b.cost - a.cost || byCostThenSessions(a, b)),
     skillCandidates: categories.filter((c) => c.hasText && c.sessions >= minCluster).sort(byCostThenSessions),
   };
+}
+
+/**
+ * Project a categorize run onto the aggregate-only wire shape for team
+ * exports. Two gates keep the surface tight: hasText-only (a no-text
+ * activity-fallback cluster is not an intent and must never leave the machine
+ * dressed as one — same reasoning as the `duplicate` gate above), and a
+ * top-40-by-cost cap, SORTED BEFORE SLICING so two builds over the same DB
+ * emit byte-identical arrays (exports are Ed25519-signed — a wobbling cap
+ * would produce different signatures for the same data).
+ */
+export function exportCategories(r: CategorizeResult): ExportCategory[] {
+  return [...r.categories]
+    .filter((c) => c.hasText)
+    .sort((a, b) => b.cost - a.cost || byCostThenSessions(a, b))
+    .slice(0, 40)
+    .map((c) => ({
+      id: c.id, name: c.name, terms: c.terms, sessions: c.sessions,
+      projects: c.projects, tokens: c.tokens, cost: c.cost,
+      estimated: c.estimated, duplicate: c.duplicate,
+    }));
 }
 
 /** Cross-surface duplicate-work signal for `report`/`html` (see categorizeSummary). */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,14 @@
 import { parseArgs } from 'node:util';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { ADAPTERS } from './adapters/index.js';
-import { openDb, insertEvents, loadEvents, DEFAULT_DB } from './store.js';
+import {
+  openDb, insertEvents, loadEvents, DEFAULT_DB,
+  relabelEvents, loadProjectAliases, applyProjectAliases, syncIntentProjects,
+} from './store.js';
 import { renderReport, renderTeamReport, renderTrend, renderCategorize } from './report.js';
-import { runCategorize, categorizeSummary } from './categorize.js';
+import { runCategorize, categorizeSummary, exportCategories } from './categorize.js';
+import type { ExportCategory } from './team.js';
+import { mergeCategories } from './team-categories.js';
 import { splitWindow } from './trends.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import { buildExport, parseTeamConfig, mergeMetrics, dedupeExports, rollupExports, displayName, identityOf } from './team.js';
@@ -24,14 +29,15 @@ const HELP = `token-monitor — measure how effectively your team spends AI codi
 
 Usage:
   token-monitor collect [--source <name>] [--db <path>]
-  token-monitor report  [--days <n>] [--trend] [--project <name>] [--source <name>] [--json] [--db <path>]
+  token-monitor report  [--days <n>] [--trend] [--project <name>] [--source <name>] [--json] [--no-categories] [--db <path>]
   token-monitor categorize [--days <n>] [--threshold <0-1>] [--min-cluster <n>] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
   token-monitor analyze [--days <n>] [--llm] [--track] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline]
-                        [--verify] [--keys keys.json] [--json] [--html team.html]
+                        [--verify] [--keys keys.json] [--threshold <0-1>]
+                        [--min-cluster <n>] [--json] [--html team.html]
   token-monitor init    --from <url-or-path>
-  token-monitor push    [--db <path>]
+  token-monitor push    [--no-categories] [--db <path>]
   token-monitor schedule [--hours <n>] [--remove]
   token-monitor reconcile [--provider anthropic|openai] [--days <n>] [--db <path>]
   token-monitor fingerprint [--db <path>]
@@ -48,10 +54,16 @@ Commands:
             --track to record those recommendations and measure (via
             follow-through) whether they actually moved their metric
   html      Self-contained HTML dashboard (no server, no external assets)
-  merge     Combine member exports (report --json > me.json) into a team report
+  merge     Combine member exports (report --json > me.json) into a team
+            report; clusters member task categories to flag the same task done
+            independently by ≥2 people and rank org-skill candidates (labels
+            only — no prompts ever cross the wire)
   init      Join a team: fetch the lead's config, set up keys, first collect,
             and (if configured) install the collection schedule
-  push      Sign and deliver an export to the team destination from config
+  push      Sign and deliver an export to the team destination from config.
+            Exports carry aggregate task categories (redacted keyword labels,
+            counts, $ — building them records session intents first-wins);
+            omit with --no-categories
   schedule  Install/remove a recurring collect+push job (launchd/cron)
   reconcile Cross-check local totals against the provider's usage API (org
             lead only — needs ANTHROPIC_ADMIN_KEY or OPENAI_ADMIN_KEY in the
@@ -74,7 +86,17 @@ Options:
               (\`platform:\` header, indented members), or JSON
   --by        merge rollup axis: team or discipline (default: discipline)
   --html      write an HTML dashboard to this path (merge: team rollup; categorize: task categories)
+  --no-categories  omit task categories from report --json / push exports
   --db        SQLite path (default: ${DEFAULT_DB})
+
+Project families:
+  collect assigns each session ONE project — the directory where most of its
+  work happened, with monorepo subdirs folding into the shallowest parent the
+  session visited — so cd-ing around no longer fragments a repo into
+  "backend"/"frontend" rows. Historical rows are relabeled on collect;
+  originals stay in the project_raw column. Worktree dirs that should fold
+  into their repo are mapped manually via
+  ~/.token-monitor/project-aliases.json ({"myapp-wt1": "myapp"}).
 `;
 
 function buildSignedExportJson(
@@ -82,13 +104,32 @@ function buildSignedExportJson(
   days: number,
   dbPath?: string,
   filters: { project?: string; source?: string } = {},
+  opts: { noCategories?: boolean } = {},
 ): string {
   const events = loadEvents(db, { days, ...filters });
   const ex = buildExport(events, days);
   const persona = assignPersona(ex.overall);
+  // Task categories ride along (labels only — see exportCategories) so a
+  // lead's merge can cluster tasks across people without members remembering
+  // to run categorize. runCategorize's first-wins intent recording is a
+  // deliberate, idempotent side effect: scheduled pushes self-refresh
+  // coverage. Any adapter-scan failure just omits the fields — an export or
+  // push must never break on one malformed local log.
+  let categoryFields: { categories?: ExportCategory[]; categorizeDays?: number } = {};
+  if (!opts.noCategories) {
+    try {
+      categoryFields = {
+        categories: exportCategories(runCategorize(db, { days, ...filters })),
+        categorizeDays: days,
+      };
+    } catch {
+      /* additive fields — omit on failure */
+    }
+  }
   const signed = signObject(
     {
       ...ex,
+      ...categoryFields,
       persona,
       recommendations: [...persona.recommendations, ...generalRecommendations(ex.overall)],
       // Evidence is aggregate-only by construction: session ids, dates, token
@@ -100,17 +141,57 @@ function buildSignedExportJson(
   return JSON.stringify(signed, null, 2);
 }
 
+/** Shared --threshold / --min-cluster validation (categorize and merge cluster with the same knobs). */
+function parseClusterOpts(values: { threshold?: string; 'min-cluster'?: string }): {
+  threshold?: number;
+  minCluster?: number;
+} {
+  const threshold = values.threshold !== undefined ? Number(values.threshold) : undefined;
+  if (threshold !== undefined && (Number.isNaN(threshold) || threshold < 0 || threshold > 1)) {
+    console.error(`--threshold must be a number between 0 and 1, got "${values.threshold}"`);
+    process.exit(1);
+  }
+  const minCluster = values['min-cluster'] !== undefined ? Number(values['min-cluster']) : undefined;
+  if (minCluster !== undefined && (!Number.isInteger(minCluster) || minCluster < 2)) {
+    console.error(`--min-cluster must be an integer ≥ 2, got "${values['min-cluster']}"`);
+    process.exit(1);
+  }
+  return { threshold, minCluster };
+}
+
 function runCollect(db: ReturnType<typeof openDb>, sources: Source[]): void {
+  let totalRelabeled = 0;
+  // Aliases compose into the relabel TARGET, not just a separate pass: if an
+  // aliased project's logs still exist, relabeling to the adapter's name and
+  // then aliasing it away would flip the same rows back and forth on every
+  // collect — steady state must stay at 0 changes.
+  const aliases = loadProjectAliases();
   for (const source of sources) {
     const { events, result } = ADAPTERS[source]();
     result.eventsInserted = insertEvents(db, events);
-    const note = result.note ? `  (${result.note})` : '';
+    // Collect IS the backfill: converge historical rows of every session this
+    // scan still sees onto the family-normalized (and aliased) project.
+    const sessions = new Map<string, string>();
+    for (const e of events) sessions.set(`${e.source}\x1f${e.sessionId}`, aliases[e.project] ?? e.project);
+    result.eventsRelabeled = relabelEvents(db, sessions);
+    totalRelabeled += result.eventsRelabeled;
+    const notes = [
+      result.note,
+      result.eventsRelabeled > 0
+        ? `${result.eventsRelabeled} relabeled into project families; originals in project_raw`
+        : undefined,
+    ].filter(Boolean).join('; ');
     console.log(
       `${source.padEnd(12)} ${String(result.filesScanned).padStart(5)} files  ` +
         `${String(result.eventsFound).padStart(7)} turns  ` +
-        `${String(result.eventsInserted).padStart(7)} new${note}`,
+        `${String(result.eventsInserted).padStart(7)} new${notes ? `  (${notes})` : ''}`,
     );
   }
+  // The direct pass catches rows whose logs rotated away (sessions the scan
+  // above never saw); reversible via project_raw like any relabel.
+  const aliased = applyProjectAliases(db, aliases);
+  if (aliased > 0) console.log(`aliases      ${String(aliased).padStart(31)} rows relabeled via project-aliases.json`);
+  if (totalRelabeled + aliased > 0) syncIntentProjects(db);
 }
 
 async function main() {
@@ -121,6 +202,7 @@ async function main() {
       days: { type: 'string', default: '30' },
       project: { type: 'string' },
       json: { type: 'boolean', default: false },
+      'no-categories': { type: 'boolean', default: false },
       trend: { type: 'boolean', default: false },
       team: { type: 'string' },
       out: { type: 'string', default: 'report.html' },
@@ -186,6 +268,11 @@ async function main() {
       console.error(`⊘ skipped stale export from ${displayName(d, keyring)} (${identityOf(d)}, generated ${d.generatedAt}) — newer one present`);
     }
     const team = values.team ? parseTeamConfig(values.team) : {};
+    // Cluster member task categories across people (labels only — see
+    // team-categories.ts). Runs after dedupe so a stale double-push can't
+    // read as two people.
+    const { threshold, minCluster } = parseClusterOpts(values);
+    const categories = mergeCategories(exports, { threshold, minCluster, keyring });
     if (values.json) {
       const overall = mergeMetrics(exports.map((e) => e.overall));
       console.log(JSON.stringify({
@@ -194,12 +281,16 @@ async function main() {
         rollups: rollupExports(exports, team, by, keyring),
         overall,
         persona: assignPersona(overall),
+        categories: categories.categories,
+        crossUserDuplicates: categories.crossUserDuplicates,
+        orgSkillCandidates: categories.orgSkillCandidates,
+        categoryCoverage: { withCategories: categories.withCategories, total: exports.length },
       }, null, 2));
     } else {
-      console.log(renderTeamReport(exports, team, { by, keyring }));
+      console.log(renderTeamReport(exports, team, { by, keyring, categories }));
     }
     if (values.html) {
-      writeFileSync(values.html, renderTeamHtml(exports, team, { by, keyring }));
+      writeFileSync(values.html, renderTeamHtml(exports, team, { by, keyring, categories }));
       console.error(`Wrote ${values.html} (${exports.length} export(s)).`);
     }
     return;
@@ -247,7 +338,10 @@ Signing fingerprint (send to your team lead for keys.json):
   } else if (cmd === 'push') {
     const config = loadConfig(keyDirFor(values.db) ?? DEFAULT_KEY_DIR);
     const days = Number(values.days) || config.windowDays || 30;
-    const where = await pushExport(buildSignedExportJson(db, days, values.db), config);
+    const where = await pushExport(
+      buildSignedExportJson(db, days, values.db, {}, { noCategories: values['no-categories'] }),
+      config,
+    );
     console.log(`Export (last ${days} days, signed) — ${where}`);
   } else if (cmd === 'schedule') {
     if (values.remove) {
@@ -267,7 +361,7 @@ Signing fingerprint (send to your team lead for keys.json):
     const days = Number(values.days) || 30;
     const filters = { project: values.project, source: values.source };
     if (values.json) {
-      console.log(buildSignedExportJson(db, days, values.db, filters));
+      console.log(buildSignedExportJson(db, days, values.db, filters, { noCategories: values['no-categories'] }));
     } else {
       // With --trend, load both windows in one query and partition, so the
       // current slice and the comparison share the same boundary.
@@ -295,16 +389,7 @@ Signing fingerprint (send to your team lead for keys.json):
       console.error(`--days must be a positive integer, got "${values.days}"`);
       process.exit(1);
     }
-    const threshold = values.threshold !== undefined ? Number(values.threshold) : undefined;
-    if (threshold !== undefined && (Number.isNaN(threshold) || threshold < 0 || threshold > 1)) {
-      console.error(`--threshold must be a number between 0 and 1, got "${values.threshold}"`);
-      process.exit(1);
-    }
-    const minCluster = values['min-cluster'] !== undefined ? Number(values['min-cluster']) : undefined;
-    if (minCluster !== undefined && (!Number.isInteger(minCluster) || minCluster < 2)) {
-      console.error(`--min-cluster must be an integer ≥ 2, got "${values['min-cluster']}"`);
-      process.exit(1);
-    }
+    const { threshold, minCluster } = parseClusterOpts(values);
     const result = runCategorize(db, {
       days,
       project: values.project,

--- a/src/html.ts
+++ b/src/html.ts
@@ -12,6 +12,7 @@ import { enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPo
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
 import type { CategorizeResult, CategoryRow, CategorizeSummary } from './categorize.js';
 import { fmtCategorizeSummary } from './categorize.js';
+import type { MergedCategories, OrgCategory } from './team-categories.js';
 
 const ACTIVITY_COLORS: Record<string, string> = {
   thinking: '#8b7ff5',
@@ -199,11 +200,58 @@ ${body}
 </body></html>`;
 }
 
+/** Org-category cost with the shared ~ estimation marker. */
+const orgCost = (c: OrgCategory): string => (c.estimated ? '~' : '') + '$' + c.cost.toFixed(2);
+
+/**
+ * Cross-user duplicate work + org-skill sections for the team dashboard —
+ * HTML parity with renderTeamReport's terminal sections. Everything member-
+ * supplied flows through esc(): terms/names originate from redacted prompt
+ * keywords, but a hand-built export is still attacker-controlled input.
+ */
+function teamCategorySections(mc: MergedCategories | undefined, memberCount: number): string {
+  if (!mc || mc.withCategories === 0) {
+    return `\n<h2>Cross-user duplicate work</h2>
+<p class="muted">No task categories in these exports — members on ≥0.11 include them via <code>report --json</code> / <code>push</code>.</p>`;
+  }
+  const dupRows = mc.crossUserDuplicates
+    .slice(0, 10)
+    .map((c) => `<tr><td title="${esc(c.terms.join(' '))}">${esc(c.name)}</td><td>${esc(c.users.join(', '))}</td><td class="num">${c.sessions}</td><td class="num">${c.projects.length}</td><td class="num">${orgCost(c)}</td></tr>`)
+    .join('');
+  const skillRows = mc.orgSkillCandidates
+    .slice(0, 10)
+    .map((c) => `<tr><td title="${esc(c.terms.join(' '))}">${esc(c.name)}</td><td class="num">${c.userCount}</td><td class="num">${c.sessions}</td><td class="num">${orgCost(c)}</td><td class="num">${c.score}</td></tr>`)
+    .join('');
+  return `
+<h2>Cross-user duplicate work</h2>
+${
+  mc.crossUserDuplicates.length > 0
+    ? `<p class="dup">⚠ Same task done independently by ≥2 people — codify one org skill/prompt instead.</p>
+<table><tr><th>Task</th><th>Users</th><th>Sessions</th><th>Projects</th><th>Cost</th></tr>${dupRows}</table>${
+        mc.anyUnsigned
+          ? `\n<p class="muted">Unsigned exports are identified as user@host — one person on two machines can read as two people.</p>`
+          : ''
+      }`
+    : `<p class="muted">No cross-user duplicate work detected in member categories.</p>`
+}
+<h2>Org-skill candidates</h2>
+${
+  mc.orgSkillCandidates.length > 0
+    ? `<table><tr><th>Task</th><th>Users</th><th>Sessions</th><th>Cost</th><th>Score</th></tr>${skillRows}</table>`
+    : `<p class="muted">No recurring tasks worth codifying yet.</p>`
+}
+${
+  mc.withinMemberDupCost > 0
+    ? `<p class="muted">Within-member duplicate work: $${mc.withinMemberDupCost.toFixed(2)} across ${mc.withinMemberDupMembers} member(s) — each should run <code>categorize</code> locally.</p>\n`
+    : ''
+}<p class="muted">Task categories from ${mc.withCategories} of ${memberCount} export(s). Labels are redacted keyword terms derived on-device; raw prompt text never leaves a member's machine.</p>`;
+}
+
 /** Org dashboard for merged member exports — the HTML face of `merge`. */
 export function renderTeamHtml(
   exports: SignedExport[],
   config: TeamConfig,
-  opts: { by?: RollupAxis; keyring?: Record<string, string> } = {},
+  opts: { by?: RollupAxis; keyring?: Record<string, string>; categories?: MergedCategories } = {},
 ): string {
   const by = opts.by ?? 'discipline';
   const overall = mergeMetrics(exports.map((e) => e.overall));
@@ -212,6 +260,7 @@ export function renderTeamHtml(
   const recs = [...persona.recommendations, ...generalRecommendations(overall)];
   const members = new Set(exports.map((e) => displayName(e, opts.keyring)));
 
+  const crossDup = opts.categories?.crossUserDuplicates ?? [];
   const cards = [
     ['Members', String(members.size)],
     ['Sessions', String(overall.sessions)],
@@ -219,6 +268,9 @@ export function renderTeamHtml(
     ['Cache hit', pct(overall.cacheHitRatio)],
     ['Rework', pct(overall.reworkRatio)],
     ['Est. cost', cost(overall)],
+    ...(crossDup.length > 0
+      ? [['Cross-user dup', (crossDup.some((c) => c.estimated) ? '~' : '') + '$' + crossDup.reduce((s, c) => s + c.cost, 0).toFixed(2)]]
+      : []),
   ]
     .map(([k, v]) => `<div class="card"><div class="k">${k}</div><div class="v">${v}</div></div>`)
     .join('');
@@ -238,7 +290,7 @@ export function renderTeamHtml(
 
 <h2>By ${by}</h2>
 <table><tr><th>${axisLabel}</th><th>Members</th><th>Activity mix</th><th>Tokens</th><th>Cost</th><th>Cache</th><th>Rework</th><th>Think:code</th><th>Persona</th></tr>${rollupRows}</table>
-
+${teamCategorySections(opts.categories, exports.length)}
 <div class="persona">
   <h3>${persona.emoji} ${esc(persona.name)}</h3>
   <div class="muted">${esc(persona.description)}</div>

--- a/src/project-family.ts
+++ b/src/project-family.ts
@@ -1,0 +1,115 @@
+/**
+ * Project-family resolution — folds a session's monorepo-subdirectory cwds
+ * into ONE canonical project name, so `report` doesn't fragment a repo into
+ * per-subdir rows ("backend"/"frontend" out of one session that cd-ed
+ * around) and `categorize` doesn't read those fragments as "duplicate work
+ * across ≥2 projects".
+ *
+ * Mechanism: descendant adoption over the session's OWN observed cwds. A cwd
+ * that is a path-descendant of another observed cwd adopts the shallowest
+ * observed ancestor's basename. Zero disk access, identical answers for live
+ * and deleted paths, and structurally unable to over-merge sibling projects
+ * because a label is only ever adopted from a directory the session actually
+ * visited.
+ *
+ * Git-root resolution (walking up to `.git`, following worktree pointers)
+ * was built, dogfooded, and REJECTED: on a real umbrella repo it folded five
+ * distinct products into the umbrella's single row, while sessions on
+ * deleted worktree paths — which can't walk the disk — kept the subdir name,
+ * splitting one family into two labels. A wrong merge silently corrupts the duplicate-work
+ * signal the product sells; a missed merge only under-reports. The anchor
+ * directory a session was opened in matches the agent's own workspace notion
+ * and never surprises. Name heuristics (stripping "-iter-NN") are absent for
+ * the same reason; worktree checkouts that SHOULD fold into their repo are
+ * the user's call via ~/.token-monitor/project-aliases.json.
+ */
+
+/** Basename that tolerates either separator — cwds may come from another OS's logs. */
+function lastSegment(p: string): string {
+  const parts = p.replace(/\\/g, '/').replace(/\/+$/, '').split('/');
+  return parts[parts.length - 1] || p;
+}
+
+/**
+ * A directory this shallow (`/`, `/Users`, `/Users/alice`) is a launch
+ * location, not a project: a session started in the home dir must not
+ * relabel every repo it cd-s into as "alice". Three path segments
+ * (`/Users/alice/Documents`…) is the shallowest thing that can plausibly BE
+ * a project, so only those may donate their name to descendants — after
+ * discounting OS root prefixes (`C:` drives, `/mnt/c` WSL, `/cygdrive/c`)
+ * so `C:\\Users\\alice` counts the same 2 segments as `/Users/alice`. The one
+ * shallow exception: `/workspaces/<repo>` is the devcontainer mount
+ * convention, where 2 segments IS the repo root.
+ */
+function canDonate(normPath: string): boolean {
+  const parts = normPath.split('/').filter(Boolean);
+  if (parts.length > 0 && /^[A-Za-z]:$/.test(parts[0])) parts.shift();
+  if (parts.length >= 2 && /^(mnt|cygdrive)$/i.test(parts[0]) && /^[A-Za-z]$/.test(parts[1])) {
+    parts.splice(0, 2);
+  }
+  if (parts.length === 2 && parts[0] === 'workspaces') return true;
+  return parts.length >= 3;
+}
+
+/**
+ * Label each observed cwd of ONE session. A cwd that is a path-descendant of
+ * another observed cwd adopts the SHALLOWEST observed ancestor's basename
+ * (a session that visited `…/mono/api` and `…/mono/api/backend` is
+ * one project: `process`). Unrelated cwds keep their own basename — sibling
+ * projects under a common parent can never merge, because the parent itself
+ * was never visited — and near-root launch dirs never donate (canDonate).
+ */
+export function collapseSessionCwds(cwds: string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  const uniq = [...new Set(cwds)];
+  const norm = new Map(uniq.map((c) => [c, c.replace(/\\/g, '/').replace(/\/+$/, '')]));
+  // Shallowest-first (shortest normalized path), so the first matching
+  // ancestor is the shallowest one the session visited.
+  const sorted = [...uniq].sort((a, b) => {
+    const na = norm.get(a)!, nb = norm.get(b)!;
+    return na.length - nb.length || (na < nb ? -1 : na > nb ? 1 : 0);
+  });
+  for (const c of uniq) {
+    const nc = norm.get(c)!;
+    let label = lastSegment(nc);
+    for (const anc of sorted) {
+      if (anc === c) continue;
+      const na = norm.get(anc)!;
+      if (canDonate(na) && nc.startsWith(na + '/')) {
+        label = lastSegment(na);
+        break;
+      }
+    }
+    out.set(c, label);
+  }
+  return out;
+}
+
+/**
+ * One project per session: the DOMINANT label over all events' cwds (after
+ * descendant adoption), first-seen order breaking ties. Dominant beats
+ * first-seen because sessions are often launched in a parent/launcher dir
+ * and immediately cd into the real workspace — where the work happens is
+ * the project. Near-root cwds (home dir, /tmp) can't win the vote while any
+ * plausible project dir was visited — otherwise a chatty home-dir session
+ * would out-vote the repo it briefly worked in, the exact relabeling the
+ * canDonate guard exists to prevent. A single-cwd session is byte-identical
+ * to plain basename(cwd). Pass one cwd PER EVENT (with repeats), not a
+ * unique set.
+ */
+export function sessionProjectOf(eventCwds: string[]): string | undefined {
+  if (eventCwds.length === 0) return undefined;
+  const labels = collapseSessionCwds(eventCwds);
+  const plausible = eventCwds.filter((c) => canDonate(c.replace(/\\/g, '/').replace(/\/+$/, '')));
+  const voters = plausible.length > 0 ? plausible : eventCwds;
+  const counts = new Map<string, number>();
+  const firstSeen = new Map<string, number>();
+  voters.forEach((c, i) => {
+    const l = labels.get(c)!;
+    counts.set(l, (counts.get(l) ?? 0) + 1);
+    if (!firstSeen.has(l)) firstSeen.set(l, i);
+  });
+  return [...counts.entries()].sort(
+    (a, b) => b[1] - a[1] || firstSeen.get(a[0])! - firstSeen.get(b[0])!,
+  )[0][0];
+}

--- a/src/report.ts
+++ b/src/report.ts
@@ -13,6 +13,7 @@ import type { TrendRow, TrendVerdict } from './trends.js';
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
 import type { CategorizeResult, CategorizeSummary } from './categorize.js';
 import { fmtCategorizeSummary } from './categorize.js';
+import type { MergedCategories, OrgCategory } from './team-categories.js';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -297,10 +298,71 @@ export function renderEnrichedRecs(recs: EnrichedRec[]): string[] {
   return out;
 }
 
+const catCost = (c: OrgCategory): string => (c.estimated ? '~' : '') + '$' + c.cost.toFixed(2);
+
+/**
+ * Cross-user duplicate work + org-skill candidates for the team report.
+ * Three duplicate tiers stay visually distinct — member-local cross-project
+ * (carried flag), cross-user (the headline), and skill candidates — because
+ * they are different accusations with different remedies.
+ */
+function renderTeamCategoryLines(mc: MergedCategories, memberCount: number): string[] {
+  const out: string[] = [];
+  if (mc.withCategories === 0) {
+    out.push(
+      `  ${DIM}No task categories in these exports — members on ≥0.11 include them via report --json / push.${RESET}`,
+    );
+    return out;
+  }
+
+  out.push(section('Cross-user duplicate work (same task, ≥2 people)'));
+  if (mc.crossUserDuplicates.length > 0) {
+    const dupCost = mc.crossUserDuplicates.reduce((s, c) => s + c.cost, 0);
+    const est = mc.crossUserDuplicates.some((c) => c.estimated) ? '~' : '';
+    const tasks = mc.crossUserDuplicates.length === 1 ? '1 task' : `${mc.crossUserDuplicates.length} tasks`;
+    out.push(`  ${BOLD}${est}$${dupCost.toFixed(2)} spent on tasks done independently by ≥2 people (${tasks})${RESET}\n`);
+    for (const c of mc.crossUserDuplicates.slice(0, 10)) {
+      out.push(
+        `  ${YELLOW}⚠${RESET} ${BOLD}${c.name}${RESET} — ${c.sessions} session(s) by ${c.users.join(', ')}` +
+          ` across ${c.projects.length} project(s)  ${GREEN}${catCost(c)}${RESET}`,
+      );
+    }
+    out.push(`\n  ${DIM}Same task, different people → codify one org skill/prompt instead of re-deriving it per person.${RESET}`);
+    if (mc.anyUnsigned) {
+      out.push(`  ${DIM}Unsigned exports are identified as user@host — one person on two machines can read as two people.${RESET}`);
+    }
+  } else {
+    out.push(`  ${DIM}No cross-user duplicate work detected in member categories.${RESET}`);
+  }
+
+  if (mc.orgSkillCandidates.length > 0) {
+    out.push(section('Org-skill candidates (team-wide)'));
+    out.push(
+      table(
+        ['Task', 'Users', 'Sessions', 'Cost', 'Score'],
+        mc.orgSkillCandidates.slice(0, 10).map((c) => [
+          c.name, String(c.userCount), String(c.sessions), catCost(c), String(c.score),
+        ]),
+      ),
+    );
+  }
+
+  if (mc.withinMemberDupCost > 0) {
+    out.push(
+      `  ${DIM}within-member duplicate work: $${mc.withinMemberDupCost.toFixed(2)} across ${mc.withinMemberDupMembers} member(s) — each should run categorize locally.${RESET}`,
+    );
+  }
+  out.push(`  ${DIM}task categories from ${mc.withCategories} of ${memberCount} export(s)${RESET}`);
+  out.push(
+    `  ${DIM}Category labels are redacted keyword terms derived on-device; raw prompt text never leaves a member's machine.${RESET}`,
+  );
+  return out;
+}
+
 export function renderTeamReport(
   exports: SignedExport[],
   config: TeamConfig,
-  opts: { by?: RollupAxis; keyring?: Record<string, string> } = {},
+  opts: { by?: RollupAxis; keyring?: Record<string, string>; categories?: MergedCategories } = {},
 ): string {
   const by = opts.by ?? 'discipline';
   const axisLabel = by === 'team' ? 'Team' : 'Discipline';
@@ -352,6 +414,8 @@ export function renderTeamReport(
       out.push(`    ${a.padEnd(13)} ${bar(m.byActivity[a].share)} ${(m.byActivity[a].share * 100).toFixed(1)}%`);
     }
   }
+
+  if (opts.categories) out.push(...renderTeamCategoryLines(opts.categories, exports.length));
 
   const persona = assignPersona(overall);
   out.push(section(`Team persona: ${persona.emoji} ${persona.name}`));

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { UsageEvent, Source } from './types.js';
@@ -33,6 +33,19 @@ export function openDb(path: string = DEFAULT_DB): DatabaseSync {
     CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
     CREATE INDEX IF NOT EXISTS idx_events_project ON events(project);
   `);
+  // Migrate dbs created before project-family relabeling: project_raw keeps
+  // the pre-relabel label so every relabel is auditable and reversible in one
+  // statement (UPDATE events SET project = project_raw WHERE project_raw IS
+  // NOT NULL). Mirrors the followthrough `origin` PRAGMA-guard precedent.
+  const cols = db.prepare(`PRAGMA table_info(events)`).all() as Array<{ name: string }>;
+  if (!cols.some((c) => c.name === 'project_raw')) {
+    try {
+      db.exec(`ALTER TABLE events ADD COLUMN project_raw TEXT`);
+    } catch {
+      // Read-only pre-0.11 DB: skip the migration so read paths still work;
+      // the column appears on the first writable open.
+    }
+  }
   return db;
 }
 
@@ -169,6 +182,109 @@ export function loadIntents(db: DatabaseSync, sessionIds: string[]): Map<string,
     if (row) out.set(row.session_id, row);
   }
   return out;
+}
+
+/**
+ * Re-attribute HISTORICAL rows to the projects the adapters resolve today.
+ * `collect` is the backfill: adapters now emit one family-normalized project
+ * per session, and this pass converges every stored row of every session
+ * whose log still exists onto that label — versionless and idempotent (the
+ * `project <> ?` guard makes steady-state collects free). `project_raw`
+ * preserves the first pre-relabel label for audit/revert.
+ *
+ * Keys are `source\x1fsessionId` (\x1f: neither appears in either part).
+ */
+export function relabelEvents(db: DatabaseSync, sessions: Map<string, string>): number {
+  const stmt = db.prepare(`
+    UPDATE events SET project_raw = COALESCE(project_raw, project), project = ?
+    WHERE source = ? AND session_id = ? AND project <> ?
+  `);
+  let changed = 0;
+  db.exec('BEGIN');
+  try {
+    for (const [key, project] of sessions) {
+      const i = key.indexOf('\x1f');
+      const res = stmt.run(project, key.slice(0, i), key.slice(i + 1), project);
+      changed += Number(res.changes);
+    }
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+  return changed;
+}
+
+export const DEFAULT_ALIASES = join(homedir(), '.token-monitor', 'project-aliases.json');
+
+/**
+ * Optional user-maintained relabel map ({"quaestor-cl-iter-02": "quaestor"})
+ * for rows whose source logs rotated away before family resolution existed —
+ * the resolver can't fix what it can never re-see. Deliberately manual: an
+ * auto-learned alias table was rejected in design review as a
+ * silent-corruption vector. Missing/corrupt file reads as empty.
+ */
+export function loadProjectAliases(path: string = DEFAULT_ALIASES): Record<string, string> {
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf8'));
+    if (typeof data !== 'object' || data === null || Array.isArray(data)) return {};
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(data)) {
+      if (typeof v === 'string' && v && k) out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Apply alias relabels at collect time (same audit trail as relabelEvents). */
+export function applyProjectAliases(db: DatabaseSync, aliases: Record<string, string>): number {
+  const stmt = db.prepare(`
+    UPDATE events SET project_raw = COALESCE(project_raw, project), project = ?
+    WHERE project = ?
+  `);
+  let changed = 0;
+  db.exec('BEGIN');
+  try {
+    for (const [from, to] of Object.entries(aliases)) {
+      if (from === to) continue;
+      changed += Number(stmt.run(to, from).changes);
+    }
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+  return changed;
+}
+
+/**
+ * Keep session_intents.project in step with relabeled events. The freeze
+ * contract is deliberately re-scoped, not broken: intent_id / label /
+ * fingerprint / has_text / first_seen stay first-wins frozen (they are the
+ * privacy and idempotency surface); `project` is signal-inert location
+ * metadata that categorize re-reads from events anyway — leaving it stale
+ * would just be a lie in the DB. Call only when a relabel actually changed
+ * rows; steady-state collects skip the scan entirely.
+ */
+export function syncIntentProjects(db: DatabaseSync): number {
+  ensureIntentsTable(db);
+  // Both subqueries are source-scoped: session ids are only unique WITHIN a
+  // source, and a cross-source id collision must not let one source's project
+  // overwrite (and endlessly re-trigger) another's intent row.
+  const res = db.prepare(`
+    UPDATE session_intents SET project =
+      (SELECT project FROM events e
+       WHERE e.session_id = session_intents.session_id
+         AND e.source = session_intents.source
+       ORDER BY ts LIMIT 1)
+    WHERE EXISTS (SELECT 1 FROM events e
+      WHERE e.session_id = session_intents.session_id
+        AND e.source = session_intents.source
+        AND e.project <> session_intents.project)
+  `).run();
+  return Number(res.changes);
 }
 
 export function loadEvents(

--- a/src/team-categories.ts
+++ b/src/team-categories.ts
@@ -1,0 +1,175 @@
+/**
+ * Cross-user task clustering for `merge` — the org-level face of categorize.
+ *
+ * Each member export carries its categorize clusters as aggregate-only
+ * ExportCategory rows (≤8 redacted keyword terms, counts, $). Here those rows
+ * are re-clustered ACROSS members with the same zero-dep engine sessions use
+ * (cluster.ts): a cluster containing categories from ≥2 distinct identities
+ * is the same task being done independently by different people — the
+ * redundant-work signal `categorize` can only hint at on one machine.
+ *
+ * Identity is identityOf() (signing-key fingerprint; `user@host` unsigned) so
+ * one person's stale double-push can't read as two people — dedupeExports
+ * runs before this. Unsigned exports are flagged instead of trusted: two
+ * unsigned hosts MAY be one human, and a lead must see that caveat before
+ * acting on a "duplicate work" accusation.
+ */
+import { clusterLabels } from './cluster.js';
+import type { ClusterItem } from './cluster.js';
+import { displayName, identityOf } from './team.js';
+import type { ExportCategory, SignedExport } from './team.js';
+
+export interface OrgCategory {
+  id: string;
+  name: string;
+  terms: string[];
+  /** Sorted member display names; unsigned contributors marked `(unsigned)`. */
+  users: string[];
+  /** Distinct identityOf() values — the cross-user threshold. */
+  userCount: number;
+  sessions: number;
+  projects: string[];
+  tokens: number;
+  cost: number;
+  estimated: boolean;
+  /** Same task appears for ≥2 distinct identities. */
+  crossUser: boolean;
+  /**
+   * Org-skill rank: sessions × userCount. Pairwise similarity is deliberately
+   * NOT in the score — clusterLabels doesn't expose cosines, and the
+   * threshold already gates match quality; threading them out would change a
+   * shared API for jittery rank value.
+   */
+  score: number;
+}
+
+export interface MergedCategories {
+  categories: OrgCategory[];
+  crossUserDuplicates: OrgCategory[];
+  orgSkillCandidates: OrgCategory[];
+  /** Exports that actually carried categories — the coverage line. */
+  withCategories: number;
+  /** Aggregate of members' own carried duplicate flags (within-member tier). */
+  withinMemberDupCost: number;
+  withinMemberDupMembers: number;
+  anyUnsigned: boolean;
+}
+
+interface MemberCategory {
+  identity: string;
+  name: string;
+  unsigned: boolean;
+  cat: ExportCategory;
+}
+
+/**
+ * Defense-in-depth: hand-built exports must never crash a merge — nor poison
+ * its sums. The full numeric/array contract is enforced, not just the match
+ * key: NaN sessions or a string cost would flow silently into every
+ * aggregate this file computes.
+ */
+function usable(cat: ExportCategory | undefined): cat is ExportCategory {
+  return (
+    !!cat &&
+    typeof cat.id === 'string' &&
+    Array.isArray(cat.terms) &&
+    cat.terms.length > 0 &&
+    cat.terms.every((t) => typeof t === 'string' && t.length > 0) &&
+    Number.isFinite(cat.sessions) &&
+    Number.isFinite(cat.tokens) &&
+    Number.isFinite(cat.cost) &&
+    (cat.projects === undefined ||
+      (Array.isArray(cat.projects) && cat.projects.every((p) => typeof p === 'string')))
+  );
+}
+
+export function mergeCategories(
+  exports: SignedExport[],
+  opts: { threshold?: number; minCluster?: number; keyring?: Record<string, string> } = {},
+): MergedCategories {
+  const minCluster = Math.max(2, opts.minCluster ?? 2);
+
+  const members: MemberCategory[] = [];
+  let withCategories = 0;
+  let withinMemberDupCost = 0;
+  let withinMemberDupMembers = 0;
+  let anyUnsigned = false;
+  for (const ex of exports) {
+    const cats = (ex.categories ?? []).filter(usable);
+    if (cats.length === 0) continue; // pre-0.11 exports: metrics only
+    withCategories++;
+    const unsigned = !ex.sig?.publicKey;
+    if (unsigned) anyUnsigned = true;
+    const dupCost = cats.filter((c) => c.duplicate).reduce((s, c) => s + c.cost, 0);
+    if (dupCost > 0) {
+      withinMemberDupCost += dupCost;
+      withinMemberDupMembers++;
+    }
+    for (const cat of cats) {
+      members.push({ identity: identityOf(ex), name: displayName(ex, opts.keyring), unsigned, cat });
+    }
+  }
+
+  // Identity rides the inert `project` slot so clusterLabels needs zero
+  // changes; items sorted so output never depends on file argument order.
+  members.sort((a, b) =>
+    a.identity < b.identity ? -1 : a.identity > b.identity ? 1 : a.cat.id < b.cat.id ? -1 : 1,
+  );
+  const byItemId = new Map<string, MemberCategory>();
+  const items: ClusterItem[] = members.map((m) => {
+    // Occurrence suffix on collision: duplicate category ids (hand-built
+    // export, or same-signer files a caller merged without dedupe) must not
+    // silently drop one row's cost into another's.
+    let id = `${m.identity}:${m.cat.id}`;
+    for (let n = 2; byItemId.has(id); n++) id = `${m.identity}:${m.cat.id}#${n}`;
+    byItemId.set(id, m);
+    return { id, project: m.identity, terms: m.cat.terms };
+  });
+  // Same default threshold and rationale as sessions — export terms live in
+  // the same ≤8-token regime the 0.4 default was tuned for.
+  const clusters = clusterLabels(items, { threshold: opts.threshold ?? 0.4 });
+
+  const categories: OrgCategory[] = clusters.map((c) => {
+    const mem = c.items.map((it) => byItemId.get(it.id)!).filter(Boolean);
+    const identities = new Set(mem.map((m) => m.identity));
+    const users = [...new Set(mem.map((m) => (m.unsigned ? `${m.name} (unsigned)` : m.name)))].sort();
+    const sessions = mem.reduce((s, m) => s + m.cat.sessions, 0);
+    const userCount = identities.size;
+    return {
+      id: c.id,
+      name: c.name,
+      terms: c.terms.slice(0, 8),
+      users,
+      userCount,
+      sessions,
+      projects: [...new Set(mem.flatMap((m) => m.cat.projects ?? []))].sort(),
+      tokens: mem.reduce((s, m) => s + m.cat.tokens, 0),
+      cost: mem.reduce((s, m) => s + m.cat.cost, 0),
+      estimated: mem.some((m) => m.cat.estimated),
+      crossUser: userCount >= 2,
+      score: sessions * userCount,
+    };
+  });
+  // Total order (score, cost, name, id) so equal-score clusters can't swap
+  // between runs — merge output is golden-testable.
+  categories.sort(
+    (a, b) =>
+      b.score - a.score ||
+      b.cost - a.cost ||
+      (a.name < b.name ? -1 : a.name > b.name ? 1 : 0) ||
+      (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  );
+
+  return {
+    categories,
+    // Both tiers honor --min-cluster (README: "same knobs as categorize").
+    // At the default of 2 this changes nothing: a crossUser cluster always
+    // has ≥2 sessions.
+    crossUserDuplicates: categories.filter((c) => c.crossUser && c.sessions >= minCluster),
+    orgSkillCandidates: categories.filter((c) => c.sessions >= minCluster),
+    withCategories,
+    withinMemberDupCost,
+    withinMemberDupMembers,
+    anyUnsigned,
+  };
+}

--- a/src/team.ts
+++ b/src/team.ts
@@ -9,9 +9,40 @@ import { fingerprint } from './sign.js';
 import type { Signature } from './sign.js';
 
 /**
+ * One task category as it crosses the wire — the aggregate-only projection of
+ * a categorize cluster. `terms` are the ≤8 redacted keyword tokens from
+ * intent.ts (the ONLY text-derived artifact categorize ever persists); they
+ * are the cross-user match key at merge time. Deliberately not hashed:
+ * a dictionary-reversible hash would be false comfort, whereas readable terms
+ * keep the privacy surface auditable by the member shipping them.
+ */
+export interface ExportCategory {
+  /** fnv1a of sorted member session ids — stable, one-way. */
+  id: string;
+  /** ≤3-term redacted label (cluster name). */
+  name: string;
+  /** Cluster top terms, ≤8 — the cross-user match key. */
+  terms: string[];
+  sessions: number;
+  /** Canonical project basenames — same data class ExportV1.byProject ships. */
+  projects: string[];
+  tokens: number;
+  cost: number;
+  estimated: boolean;
+  /** Member-local same-user cross-≥2-projects flag, carried for display. */
+  duplicate: boolean;
+}
+
+/**
  * Mergeable per-developer export. Contains aggregate numbers only — no
  * prompts, no code, no file paths beyond project basenames — so it is safe
  * to share for a team rollup.
+ *
+ * `categories`/`categorizeDays` are ADDITIVE optional fields on version 1
+ * (the persona/recommendations precedent): a version bump would make every
+ * pre-0.11 lead reject every 0.11 member's scheduled push overnight, while
+ * unknown fields are ignored-but-signed by old binaries — full two-way
+ * compatibility with zero negotiation code.
  */
 export interface ExportV1 {
   version: 1;
@@ -21,6 +52,8 @@ export interface ExportV1 {
   days: number;
   overall: Metrics;
   byProject: Record<string, Metrics>;
+  categories?: ExportCategory[];
+  categorizeDays?: number;
 }
 
 export function buildExport(events: StoredEvent[], days: number): ExportV1 {

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,5 +56,7 @@ export interface CollectResult {
   filesScanned: number;
   eventsFound: number;
   eventsInserted: number;
+  /** Historical rows re-attributed to project families by this collect. */
+  eventsRelabeled?: number;
   note?: string;
 }

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -251,3 +251,55 @@ test('isDeclination matches harness rejection phrasings, not real errors', async
   assert.equal(isDeclination('<tool_use_error>InputValidationError: too_big</tool_use_error>'), false);
   assert.equal(isDeclination('Error: ENOENT no such file'), false);
 });
+
+// ---- project-family wiring (PR4) --------------------------------------------
+
+/** One assistant line with usage, minimal enough for the adapter to accept. */
+function claudeLine(uuid: string, sessionId: string, cwd: string): string {
+  return JSON.stringify({
+    type: 'assistant', uuid, sessionId, cwd, timestamp: '2026-06-01T10:00:00.000Z',
+    message: { model: 'claude-opus-4-7', usage: { input_tokens: 10, output_tokens: 10 }, content: [] },
+  });
+}
+
+test('claude-code: session cd-ing into monorepo subdirs keeps ONE project', () => {
+  const base = mkdtempSync(join(tmpdir(), 'cc-family-'));
+  const dir = join(base, 'enc');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 's1.jsonl'), [
+    claudeLine('u1', 's1', '/w/mono/api'),
+    claudeLine('u2', 's1', '/w/mono/api/backend'),
+    claudeLine('u3', 's1', '/w/mono/api/frontend'),
+    claudeLine('u4', 's1', '/w/mono/api/backend/db'),
+  ].join('\n'));
+
+  const { events } = collectClaudeCode(base);
+  assert.equal(events.length, 4);
+  for (const e of events) assert.equal(e.project, 'api'); // the exact monorepo-subdir regression
+});
+
+test('claude-code: single-cwd session keeps old basename behavior', () => {
+  const base = mkdtempSync(join(tmpdir(), 'cc-single-'));
+  const dir = join(base, 'enc');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 's3.jsonl'), claudeLine('s31', 's3', '/gone/dev/proj-alpha'));
+  const { events } = collectClaudeCode(base);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].project, 'proj-alpha');
+});
+
+test('claude-code: two sessions in one dir label independently', () => {
+  const base = mkdtempSync(join(tmpdir(), 'cc-two-'));
+  const dir = join(base, 'enc');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'sA.jsonl'), [
+    claudeLine('a1', 'sA', '/w/dev/repo-a'),
+    claudeLine('a2', 'sA', '/w/dev/repo-a/sub'),
+  ].join('\n'));
+  writeFileSync(join(dir, 'sB.jsonl'), claudeLine('b1', 'sB', '/w/dev/repo-b'));
+  const { events } = collectClaudeCode(base);
+  const byKey = new Map(events.map((e) => [e.eventKey, e.project]));
+  assert.equal(byKey.get('a1'), 'repo-a');
+  assert.equal(byKey.get('a2'), 'repo-a');
+  assert.equal(byKey.get('b1'), 'repo-b');
+});

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -491,3 +491,162 @@ test('e2e: unknown command and bare invocation fail with help', () => {
   assert.equal(bare.code, 1);
   assert.ok(bare.stdout.includes('Usage:'));
 });
+
+// ---- PR4 e2e: project families, category exports, cross-user merge ----------
+
+test('e2e: two-member category exports merge into cross-user duplicate work, leak-free and deterministic', () => {
+  const SECRET_KEY = 'sk-CANARYfeedface7654321';
+  const SECRET_EMAIL = 'leak2@secret.example';
+  const RAW_PHRASE = 'staging admin password is';
+
+  const memberHome = (name: string, project: string, prompt: string): string => {
+    const home = mkdtempSync(join(tmpdir(), `tm-e2e-${name}-`));
+    const dir = join(home, '.claude', 'projects', project);
+    mkdirSync(dir, { recursive: true });
+    const lines = [
+      { type: 'user', sessionId: 's1', timestamp: '2026-06-01T10:00:00.000Z', message: { content: [{ type: 'text', text: prompt }] } },
+      { type: 'assistant', uuid: `${name}-u1`, sessionId: 's1', cwd: `/Users/${name}/${project}`, timestamp: '2026-06-01T10:00:05.000Z',
+        message: { model: 'claude-opus-4-7', usage: { input_tokens: 500, output_tokens: 300 }, content: [{ type: 'tool_use', id: `${name}-t1`, name: 'Edit', input: {} }] } },
+    ];
+    writeFileSync(join(dir, 's1.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+    assert.equal(run(['collect', '--source', 'claude-code'], { home }).code, 0);
+    return home;
+  };
+
+  const homeA = memberHome('alice', 'proj-pay-a',
+    `Add payment retry with exponential backoff to the billing worker. The ${RAW_PHRASE} ${SECRET_KEY}, contact ${SECRET_EMAIL}`);
+  const homeB = memberHome('bob', 'proj-pay-b',
+    'Implement payment retry and exponential backoff in the billing worker queue');
+
+  // Exports carry categories (signed, labels only); canaries must not cross the wire.
+  const exA = run(['report', '--json', ...DAYS], { home: homeA }).stdout;
+  const exB = run(['report', '--json', ...DAYS], { home: homeB }).stdout;
+  for (const leak of [SECRET_KEY, SECRET_EMAIL, 'CANARY', RAW_PHRASE]) {
+    assert.ok(!exA.includes(leak), `export leaked "${leak}"`);
+  }
+  const parsedA = JSON.parse(exA);
+  assert.equal(parsedA.version, 1, 'wire version must stay 1 (additive fields)');
+  assert.ok(Array.isArray(parsedA.categories) && parsedA.categories.length >= 1, 'export missing categories');
+  assert.ok(!('categories' in JSON.parse(run(['report', '--json', '--no-categories', ...DAYS], { home: homeA }).stdout)),
+    '--no-categories must omit the key entirely');
+  // No raw text classes in the category rows: allowlisted keys only.
+  for (const c of parsedA.categories) {
+    assert.deepEqual(Object.keys(c).sort(), ['cost', 'duplicate', 'estimated', 'id', 'name', 'projects', 'sessions', 'terms', 'tokens']);
+  }
+
+  const mergeHome = mkdtempSync(join(tmpdir(), 'tm-e2e-merge-'));
+  const fA = join(mergeHome, 'a.json'), fB = join(mergeHome, 'b.json');
+  writeFileSync(fA, exA);
+  writeFileSync(fB, exB);
+
+  const merged = run(['merge', fA, fB], { home: mergeHome });
+  assert.equal(merged.code, 0, merged.stderr);
+  assert.ok(merged.stdout.includes('Cross-user duplicate work'), 'missing cross-user section');
+  assert.match(merged.stdout, /done independently by ≥2 people/, 'missing cross-user headline');
+  assert.ok(merged.stdout.includes('Org-skill candidates (team-wide)'), 'missing org-skill section');
+  assert.ok(merged.stdout.includes('task categories from 2 of 2 export(s)'), 'missing coverage footer');
+  for (const leak of [SECRET_KEY, SECRET_EMAIL, 'CANARY', RAW_PHRASE]) {
+    assert.ok(!merged.stdout.includes(leak), `merge stdout leaked "${leak}"`);
+  }
+
+  // Deterministic: same inputs, byte-identical stdout.
+  assert.equal(run(['merge', fA, fB], { home: mergeHome }).stdout, merged.stdout);
+
+  // --json exposes the machine-readable tiers.
+  const mj = JSON.parse(run(['merge', fA, fB, '--json'], { home: mergeHome }).stdout);
+  assert.ok(mj.crossUserDuplicates.length >= 1, 'expected a cross-user duplicate');
+  assert.ok(mj.crossUserDuplicates[0].userCount >= 2);
+  assert.deepEqual(mj.categoryCoverage, { withCategories: 2, total: 2 });
+
+  // --html renders the sections, escaped and leak-free.
+  const htmlPath = join(mergeHome, 'team.html');
+  assert.equal(run(['merge', fA, fB, '--html', htmlPath], { home: mergeHome }).code, 0);
+  const html = readFileSync(htmlPath, 'utf8');
+  assert.ok(html.includes('Cross-user duplicate work'));
+  assert.ok(html.includes('Org-skill candidates'));
+  for (const leak of [SECRET_KEY, SECRET_EMAIL, 'CANARY', RAW_PHRASE]) {
+    assert.ok(!html.includes(leak), `merge --html leaked "${leak}"`);
+  }
+
+  // Raw sqlite bytes (incl. project_raw) never hold the canaries either.
+  const dbBytes = readFileSync(join(homeA, '.token-monitor', 'token-monitor.sqlite')).toString('latin1');
+  for (const leak of [SECRET_KEY, SECRET_EMAIL, 'CANARY', RAW_PHRASE]) {
+    assert.ok(!dbBytes.includes(leak), `db leaked "${leak}"`);
+  }
+
+  // Pre-0.11 mix: stripping categories from one export downgrades gracefully.
+  const legacy = JSON.parse(exB);
+  delete legacy.categories;
+  delete legacy.categorizeDays;
+  delete legacy.sig; // edited payload can't stay signed
+  writeFileSync(fB, JSON.stringify(legacy));
+  const mixed = run(['merge', fA, fB, '--json'], { home: mergeHome });
+  assert.equal(mixed.code, 0, mixed.stderr);
+  const mixedJson = JSON.parse(mixed.stdout);
+  assert.deepEqual(mixedJson.categoryCoverage, { withCategories: 1, total: 2 });
+  assert.equal(mixedJson.crossUserDuplicates.length, 0);
+});
+
+test('e2e: collect relabels fragmented historical rows into project families once', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'tm-e2e-relabel-'));
+  const dbPath = join(home, '.token-monitor', 'token-monitor.sqlite');
+
+  // Seed the DB with pre-0.11 fragmented rows for a session whose transcript
+  // still exists: same session split across "process" and "backend".
+  const { openDb: open, insertEvents: insert } = await import('../src/store.js');
+  const { makeEvent } = await import('./helpers.js');
+  const db = open(dbPath);
+  insert(db, [
+    makeEvent({ eventKey: 'frag-u1', sessionId: 'sfrag', project: 'api', timestamp: '2026-06-01T10:00:05.000Z' }),
+    makeEvent({ eventKey: 'frag-u2', sessionId: 'sfrag', project: 'backend', timestamp: '2026-06-01T10:00:06.000Z' }),
+  ]);
+  db.close();
+
+  // The transcript the adapter re-reads: both events, cwds root + subdir (dead
+  // paths → descendant adoption → both resolve to "process").
+  const dir = join(home, '.claude', 'projects', 'enc');
+  mkdirSync(dir, { recursive: true });
+  const mkLine = (uuid: string, cwd: string) => JSON.stringify({
+    type: 'assistant', uuid, sessionId: 'sfrag', cwd, timestamp: '2026-06-01T10:00:05.000Z',
+    message: { model: 'claude-opus-4-7', usage: { input_tokens: 10, output_tokens: 10 }, content: [] },
+  });
+  writeFileSync(join(dir, 'sfrag.jsonl'),
+    mkLine('frag-u1', '/gone/mono/api') + '\n' + mkLine('frag-u2', '/gone/mono/api/backend') + '\n');
+
+  const first = run(['collect', '--source', 'claude-code'], { home });
+  assert.equal(first.code, 0);
+  assert.match(first.stdout, /1 relabeled into project families/, 'expected the relabel note');
+
+  const db2 = open(dbPath);
+  const rows = db2.prepare(`SELECT event_key, project, project_raw FROM events ORDER BY event_key`).all() as
+    Array<{ event_key: string; project: string; project_raw: string | null }>;
+  assert.deepEqual(rows.map((r) => r.project), ['api', 'api']);
+  assert.deepEqual(rows.map((r) => r.project_raw), [null, 'backend']); // only the changed row is audited
+  db2.close();
+
+  // Steady state: the note disappears, nothing relabels again.
+  const second = run(['collect', '--source', 'claude-code'], { home });
+  assert.equal(second.code, 0);
+  assert.ok(!second.stdout.includes('relabeled into project families'), 'relabel must be idempotent');
+});
+
+test('e2e: an alias for a live project reaches steady state (no relabel flip-flop)', () => {
+  const home = mkdtempSync(join(tmpdir(), 'tm-e2e-alias-'));
+  const dir = join(home, '.claude', 'projects', 'enc');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'wt.jsonl'), JSON.stringify({
+    type: 'assistant', uuid: 'wt-u1', sessionId: 'swt', cwd: '/w/dev/myapp-wt1', timestamp: '2026-06-01T10:00:00.000Z',
+    message: { model: 'claude-opus-4-7', usage: { input_tokens: 10, output_tokens: 10 }, content: [] },
+  }) + '\n');
+  mkdirSync(join(home, '.token-monitor'), { recursive: true });
+  writeFileSync(join(home, '.token-monitor', 'project-aliases.json'), JSON.stringify({ 'myapp-wt1': 'myapp' }));
+
+  const first = run(['collect', '--source', 'claude-code'], { home });
+  assert.equal(first.code, 0);
+  const second = run(['collect', '--source', 'claude-code'], { home });
+  assert.equal(second.code, 0);
+  assert.ok(!second.stdout.includes('relabeled'), `second collect must be silent, got: ${second.stdout}`);
+  const third = run(['report', '--json', '--no-categories', ...DAYS], { home });
+  assert.ok(third.stdout.includes('"myapp"'), 'aliased project must appear in the export');
+  assert.ok(!JSON.parse(third.stdout).byProject['myapp-wt1'], 'raw worktree label must be gone');
+});

--- a/test/html.test.ts
+++ b/test/html.test.ts
@@ -44,7 +44,7 @@ test('renderHtml surfaces the duplicate-work line only when a categorize summary
 });
 
 const catRow = (p: Partial<CategoryRow>): CategoryRow => ({
-  id: 'c', name: 'task', sessions: 1, projects: ['proj'], tokens: 1000, cost: 1, estimated: false, hasText: true, duplicate: false, ...p,
+  id: 'c', name: 'task', terms: ['task'], sessions: 1, projects: ['proj'], tokens: 1000, cost: 1, estimated: false, hasText: true, duplicate: false, ...p,
 });
 
 test('renderCategorizeHtml renders categories, duplicate work, and skill candidates', () => {
@@ -91,4 +91,43 @@ test('renderHtml marks LLM-origin follow-through rows with a robot', () => {
   );
   assert.ok(html.includes('🤖'));
   assert.ok(html.includes('llm:cacheHitRatio'));
+});
+
+// ---- team dashboard cross-user sections (PR4) --------------------------------
+
+import { renderTeamHtml } from '../src/html.js';
+import { mergeCategories } from '../src/team-categories.js';
+import type { ExportV1, ExportCategory, SignedExport } from '../src/team.js';
+import { computeMetrics } from '../src/metrics.js';
+
+const teamExport = (user: string, categories?: ExportCategory[]): SignedExport => ({
+  version: 1, user, host: 'h', generatedAt: '2026-06-01T00:00:00.000Z', days: 30,
+  overall: computeMetrics([makeStored({ session_id: `${user}-s` })]),
+  byProject: {},
+  ...(categories ? { categories, categorizeDays: 30 } : {}),
+} as ExportV1);
+
+test('renderTeamHtml renders cross-user sections, card, and escapes hostile terms', () => {
+  const hostile: ExportCategory = {
+    id: 'x1', name: '<script>alert(1)</script>', terms: ['<script>alert(1)</script>', 'retry'],
+    sessions: 2, projects: ['<img src=x onerror=alert(2)>'], tokens: 100, cost: 9,
+    estimated: false, duplicate: false,
+  };
+  const twin: ExportCategory = { ...hostile, id: 'x2' };
+  const exports = [teamExport('alice', [hostile]), teamExport('bob', [twin])];
+  const html = renderTeamHtml(exports, {}, { categories: mergeCategories(exports) });
+
+  assert.ok(html.includes('Cross-user duplicate work'));
+  assert.ok(html.includes('Org-skill candidates'));
+  assert.ok(html.includes('Cross-user dup')); // headline card
+  assert.ok(!html.includes('<script>alert(1)</script>')); // esc()'d
+  assert.ok(html.includes('&#60;script&#62;'));
+  assert.ok(html.includes('(unsigned)'));
+});
+
+test('renderTeamHtml shows the upgrade hint when no export carries categories', () => {
+  const exports = [teamExport('old1'), teamExport('old2')];
+  const html = renderTeamHtml(exports, {}, { categories: mergeCategories(exports) });
+  assert.ok(html.includes('No task categories in these exports'));
+  assert.ok(!html.includes('Org-skill candidates</h2>')); // sections replaced by the hint
 });

--- a/test/project-family.test.ts
+++ b/test/project-family.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { collapseSessionCwds, sessionProjectOf } from '../src/project-family.js';
+
+test('collapseSessionCwds adopts the shallowest observed ancestor, zero disk', () => {
+  const m = collapseSessionCwds([
+    '/w/mono/api',
+    '/w/mono/api/backend',
+    '/w/mono/api/frontend',
+    '/w/mono/api/backend/db',
+    '/tmp/scratch',
+  ]);
+  assert.equal(m.get('/w/mono/api'), 'api');
+  assert.equal(m.get('/w/mono/api/backend'), 'api');
+  assert.equal(m.get('/w/mono/api/frontend'), 'api');
+  assert.equal(m.get('/w/mono/api/backend/db'), 'api');
+  assert.equal(m.get('/tmp/scratch'), 'scratch');
+});
+
+test('collapseSessionCwds never merges sibling projects under an unvisited parent', () => {
+  const m = collapseSessionCwds(['/home/dev/repo-a', '/home/dev/repo-b']);
+  assert.equal(m.get('/home/dev/repo-a'), 'repo-a');
+  assert.equal(m.get('/home/dev/repo-b'), 'repo-b');
+});
+
+test('collapseSessionCwds normalizes mixed separators', () => {
+  const m = collapseSessionCwds(['C:\\Users\\bob\\proj', 'C:\\Users\\bob\\proj\\sub', 'C:/Users/bob/proj/sub/deep']);
+  assert.equal(m.get('C:\\Users\\bob\\proj\\sub'), 'proj');
+  assert.equal(m.get('C:/Users/bob/proj/sub/deep'), 'proj');
+});
+
+test('adoption works even when the ancestor is observed AFTER the descendant', () => {
+  // Sessions can start in a subdir and cd up later; the label must not
+  // depend on observation order.
+  const m = collapseSessionCwds(['/w/dev/repo/backend', '/w/dev/repo']);
+  assert.equal(m.get('/w/dev/repo/backend'), 'repo');
+});
+
+test('near-root launch dirs never donate their name to descendants', () => {
+  // Session launched in the home dir, then worked in a repo: the repo keeps
+  // its own name instead of everything becoming "ryan".
+  const m = collapseSessionCwds(['/Users/alice', '/Users/alice/Documents/GitHub/sidegig']);
+  assert.equal(m.get('/Users/alice/Documents/GitHub/sidegig'), 'sidegig');
+  assert.equal(m.get('/Users/alice'), 'alice');
+  // …but a real project dir (≥3 segments) still donates
+  const m2 = collapseSessionCwds(['/Users/alice/dev/repo', '/Users/alice/dev/repo/sub']);
+  assert.equal(m2.get('/Users/alice/dev/repo/sub'), 'repo');
+});
+
+test('sessionProjectOf picks the dominant per-event label, ties to first-seen', () => {
+  assert.equal(sessionProjectOf(['/w/mono/api', '/w/mono/api/backend']), 'api');
+  assert.equal(sessionProjectOf(['/w/mono/api/backend', '/w/mono/api']), 'api');
+  assert.equal(sessionProjectOf(['/gone/dev/proj-alpha']), 'proj-alpha'); // single-cwd unchanged
+  assert.equal(sessionProjectOf([]), undefined);
+  // launched at home, worked in the repo → the repo wins on event count
+  assert.equal(
+    sessionProjectOf(['/Users/alice', '/Users/alice/dev/app', '/Users/alice/dev/app']),
+    'app',
+  );
+  // a brief scratch detour does not rename the session
+  assert.equal(sessionProjectOf(['/w/deep/repo', '/w/deep/repo', '/tmp/scratch']), 'repo');
+  // dead-even tie goes to the first-seen label
+  assert.equal(sessionProjectOf(['/w/deep/repo-a', '/w/deep/repo-b']), 'repo-a');
+});
+
+test('Windows and WSL home directories never donate (root prefixes discounted)', () => {
+  assert.equal(
+    sessionProjectOf(['C:\\Users\\bob', 'C:\\Users\\bob\\myrepo', 'C:\\Users\\bob\\myrepo']),
+    'myrepo',
+  );
+  assert.equal(
+    sessionProjectOf(['/mnt/c/Users/bob', '/mnt/c/Users/bob/myrepo', '/mnt/c/Users/bob/myrepo']),
+    'myrepo',
+  );
+  // …but a Windows repo path still donates to its subdirs
+  const m = collapseSessionCwds(['C:\\Users\\bob\\myrepo', 'C:\\Users\\bob\\myrepo\\sub']);
+  assert.equal(m.get('C:\\Users\\bob\\myrepo\\sub'), 'myrepo');
+});
+
+test('devcontainer /workspaces/<repo> mounts donate despite being shallow', () => {
+  const m = collapseSessionCwds(['/workspaces/myapp', '/workspaces/myapp/packages/core']);
+  assert.equal(m.get('/workspaces/myapp/packages/core'), 'myapp');
+});
+
+test('a majority of home-dir events cannot out-vote a real project dir', () => {
+  // Launcher chatter at ~ dominates by count, but near-root labels are
+  // ineligible while any plausible project dir was visited.
+  assert.equal(
+    sessionProjectOf(['/Users/alice', '/Users/alice', '/Users/alice', '/Users/alice/dev/app']),
+    'app',
+  );
+  // a session that never left near-root dirs still gets an honest label
+  assert.equal(sessionProjectOf(['/Users/alice', '/Users/alice']), 'alice');
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -27,3 +27,114 @@ test('loadEvents filters by project, source and window', () => {
   assert.equal(loadEvents(db, { source: 'claude-code' }).length, 3);
   assert.equal(loadEvents(db, { source: 'codex' }).length, 0);
 });
+
+// ---- project-family relabeling (PR4) ----------------------------------------
+
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import {
+  relabelEvents, loadProjectAliases, applyProjectAliases, syncIntentProjects,
+  recordIntents, loadIntents,
+} from '../src/store.js';
+
+test('openDb migrates a pre-0.11 db (no project_raw) via PRAGMA-guarded ALTER', () => {
+  const path = join(mkdtempSync(join(tmpdir(), 'tm-mig-')), 'old.sqlite');
+  const legacy = new DatabaseSync(path);
+  legacy.exec(`CREATE TABLE events (
+    id INTEGER PRIMARY KEY, source TEXT NOT NULL, event_key TEXT NOT NULL,
+    session_id TEXT NOT NULL, project TEXT NOT NULL, ts TEXT NOT NULL,
+    model TEXT NOT NULL, input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL,
+    cache_read_tokens INTEGER NOT NULL, cache_creation_tokens INTEGER NOT NULL,
+    thinking_tokens INTEGER NOT NULL, tools TEXT NOT NULL, has_thinking INTEGER NOT NULL,
+    is_error INTEGER NOT NULL, git_branch TEXT, activity TEXT NOT NULL,
+    UNIQUE(source, event_key))`);
+  legacy.close();
+  const db = openDb(path); // must not throw, must add the column
+  const cols = db.prepare(`PRAGMA table_info(events)`).all() as Array<{ name: string }>;
+  assert.ok(cols.some((c) => c.name === 'project_raw'));
+  openDb(path); // second open: ALTER not re-run
+});
+
+test('relabelEvents updates fragmented sessions, preserves originals, idempotent', () => {
+  const db = openDb(':memory:');
+  insertEvents(db, [
+    makeEvent({ eventKey: 'e1', sessionId: 's1', project: 'backend' }),
+    makeEvent({ eventKey: 'e2', sessionId: 's1', project: 'frontend' }),
+    makeEvent({ eventKey: 'e3', sessionId: 's1', project: 'process' }),
+    makeEvent({ eventKey: 'e4', sessionId: 'other', project: 'untouched' }),
+  ]);
+  const n = relabelEvents(db, new Map([['claude-code\x1fs1', 'process']]));
+  assert.equal(n, 2); // e3 already matched, e4 not in map
+  const rows = db.prepare(`SELECT event_key, project, project_raw FROM events ORDER BY event_key`).all() as
+    Array<{ event_key: string; project: string; project_raw: string | null }>;
+  assert.deepEqual(rows.map((r) => r.project), ['process', 'process', 'process', 'untouched']);
+  assert.deepEqual(rows.map((r) => r.project_raw), ['backend', 'frontend', null, null]);
+  assert.equal(relabelEvents(db, new Map([['claude-code\x1fs1', 'process']])), 0); // steady state
+  // revert story: one statement restores originals
+  db.exec(`UPDATE events SET project = project_raw WHERE project_raw IS NOT NULL`);
+  const back = db.prepare(`SELECT project FROM events WHERE event_key IN ('e1','e2') ORDER BY event_key`).all() as
+    Array<{ project: string }>;
+  assert.deepEqual(back.map((r) => r.project), ['backend', 'frontend']);
+});
+
+test('relabel preserves frozen intent fields but syncs the project column', () => {
+  const db = openDb(':memory:');
+  insertEvents(db, [
+    makeEvent({ eventKey: 'e1', sessionId: 's1', project: 'backend', timestamp: '2026-06-01T00:00:00.000Z' }),
+  ]);
+  recordIntents(db, [{
+    sessionId: 's1', source: 'claude-code', project: 'backend', intentId: 'i1',
+    label: 'fix retry', fingerprint: ['fix', 'retry'], hasText: true, firstSeen: '2026-06-01T00:00:00.000Z',
+  }]);
+  relabelEvents(db, new Map([['claude-code\x1fs1', 'process']]));
+  assert.equal(syncIntentProjects(db), 1);
+  const row = loadIntents(db, ['s1']).get('s1')!;
+  assert.equal(row.project, 'process'); // location metadata follows the events
+  assert.equal(row.intent_id, 'i1'); // frozen fields untouched
+  assert.equal(row.label, 'fix retry');
+  assert.deepEqual(JSON.parse(row.fingerprint), ['fix', 'retry']);
+  assert.equal(row.first_seen, '2026-06-01T00:00:00.000Z');
+  assert.equal(syncIntentProjects(db), 0); // nothing left to sync
+});
+
+test('project aliases relabel at collect time; missing/corrupt file reads empty', () => {
+  const db = openDb(':memory:');
+  insertEvents(db, [
+    makeEvent({ eventKey: 'a1', sessionId: 'w1', project: 'quaestor-cl-iter-02', timestamp: new Date().toISOString() }),
+    makeEvent({ eventKey: 'a2', sessionId: 'w2', project: 'keep-me', timestamp: new Date().toISOString() }),
+  ]);
+  const dir = mkdtempSync(join(tmpdir(), 'tm-alias-'));
+  const aliasPath = join(dir, 'project-aliases.json');
+  writeFileSync(aliasPath, JSON.stringify({ 'quaestor-cl-iter-02': 'quaestor', 'self': 'self', 'bad': 7 }));
+  const aliases = loadProjectAliases(aliasPath);
+  assert.deepEqual(aliases, { 'quaestor-cl-iter-02': 'quaestor', self: 'self' });
+  assert.equal(applyProjectAliases(db, aliases), 1); // self->self skipped, keep-me untouched
+  const row = db.prepare(`SELECT project, project_raw FROM events WHERE event_key = 'a1'`).get() as
+    { project: string; project_raw: string };
+  assert.equal(row.project, 'quaestor');
+  assert.equal(row.project_raw, 'quaestor-cl-iter-02');
+  // SQL filters see the new label (the display/filter consistency fix)
+  assert.equal(loadEvents(db, { project: 'quaestor' }).length, 1);
+  assert.equal(loadEvents(db, { project: 'quaestor-cl-iter-02' }).length, 0);
+  assert.deepEqual(loadProjectAliases(join(dir, 'nope.json')), {});
+  writeFileSync(aliasPath, '{corrupt');
+  assert.deepEqual(loadProjectAliases(aliasPath), {});
+});
+
+test('syncIntentProjects is source-scoped: a cross-source session_id collision cannot cross-write', () => {
+  const db = openDb(':memory:');
+  insertEvents(db, [
+    makeEvent({ eventKey: 'cc1', sessionId: 'shared', source: 'claude-code', project: 'proc', timestamp: '2026-06-01T00:00:00.000Z' }),
+    makeEvent({ eventKey: 'gx1', sessionId: 'shared', source: 'gemini-cli', project: 'other', timestamp: '2026-05-01T00:00:00.000Z' }),
+  ]);
+  recordIntents(db, [{
+    sessionId: 'shared', source: 'claude-code', project: 'proc', intentId: 'i1',
+    label: 'l', fingerprint: ['l'], hasText: true, firstSeen: '2026-06-01T00:00:00.000Z',
+  }]);
+  // Nothing to sync: the claude-code events already agree; the gemini event
+  // (earlier ts, different project) must be invisible to this intent row.
+  assert.equal(syncIntentProjects(db), 0);
+  assert.equal(loadIntents(db, ['shared']).get('shared')!.project, 'proc');
+});

--- a/test/team-categories.test.ts
+++ b/test/team-categories.test.ts
@@ -1,0 +1,143 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mergeCategories } from '../src/team-categories.js';
+import type { ExportV1, ExportCategory, SignedExport } from '../src/team.js';
+import { signObject } from '../src/sign.js';
+import { computeMetrics } from '../src/metrics.js';
+import { makeStored } from './helpers.js';
+
+const cat = (p: Partial<ExportCategory>): ExportCategory => ({
+  id: 'c1', name: 'payment retry', terms: ['payment', 'retry', 'backoff'], sessions: 2,
+  projects: ['shop'], tokens: 1000, cost: 5, estimated: false, duplicate: false, ...p,
+});
+
+function makeExport(user: string, host: string, categories: ExportCategory[] | undefined): SignedExport {
+  const ex: ExportV1 = {
+    version: 1, user, host, generatedAt: '2026-06-01T00:00:00.000Z', days: 30,
+    overall: computeMetrics([makeStored({ session_id: `${user}-s` })]),
+    byProject: {},
+    ...(categories ? { categories, categorizeDays: 30 } : {}),
+  };
+  return ex;
+}
+
+test('same task by two people clusters into one cross-user duplicate', () => {
+  const alice = makeExport('alice', 'h1', [cat({ id: 'a1', terms: ['payment', 'retry', 'backoff'], cost: 5, sessions: 2 })]);
+  const bob = makeExport('bob', 'h2', [cat({ id: 'b1', terms: ['retry', 'backoff', 'payment', 'client'], cost: 3, sessions: 1, estimated: true, projects: ['store'] })]);
+  const mc = mergeCategories([bob, alice]); // order must not matter
+
+  assert.equal(mc.withCategories, 2);
+  assert.equal(mc.crossUserDuplicates.length, 1);
+  const d = mc.crossUserDuplicates[0];
+  assert.equal(d.crossUser, true);
+  assert.equal(d.userCount, 2);
+  assert.deepEqual(d.users, ['alice (unsigned)', 'bob (unsigned)']); // sorted, flagged
+  assert.equal(d.sessions, 3);
+  assert.equal(d.cost, 8);
+  assert.equal(d.estimated, true); // ORed
+  assert.equal(d.score, 6); // sessions x userCount
+  assert.deepEqual(d.projects, ['shop', 'store']);
+  assert.equal(mc.anyUnsigned, true);
+});
+
+test('one person recurring is a skill candidate, never a cross-user accusation', () => {
+  const solo = makeExport('alice', 'h1', [cat({ id: 'a1', sessions: 4 })]);
+  const mc = mergeCategories([solo]);
+  assert.equal(mc.crossUserDuplicates.length, 0);
+  assert.equal(mc.orgSkillCandidates.length, 1);
+  assert.equal(mc.orgSkillCandidates[0].crossUser, false);
+});
+
+test('same unsigned user on two hosts counts as two identities — pinned, flagged', () => {
+  // Documented behavior: without signatures we CANNOT know it is one human,
+  // so it counts as 2 but every users entry carries the (unsigned) caveat.
+  const m1 = makeExport('alice', 'laptop', [cat({ id: 'r1' })]);
+  const m2 = makeExport('alice', 'desktop', [cat({ id: 'r2' })]);
+  const mc = mergeCategories([m1, m2]);
+  assert.equal(mc.crossUserDuplicates.length, 1);
+  assert.equal(mc.crossUserDuplicates[0].userCount, 2);
+  assert.deepEqual(mc.crossUserDuplicates[0].users, ['alice (unsigned)']);
+  assert.equal(mc.anyUnsigned, true);
+});
+
+test('signed exports use the keyring name and drop the unsigned flag', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tm-tc-keys-'));
+  const signed = signObject(
+    makeExport('alice', 'h1', [cat({ id: 'a1' })]) as unknown as Record<string, unknown>,
+    dir,
+  ) as unknown as SignedExport;
+  const mc = mergeCategories([signed, makeExport('bob', 'h2', [cat({ id: 'b1' })])]);
+  assert.equal(mc.crossUserDuplicates[0].userCount, 2);
+  assert.ok(mc.crossUserDuplicates[0].users.includes('alice'));
+  assert.ok(mc.crossUserDuplicates[0].users.includes('bob (unsigned)'));
+});
+
+test('malformed hand-built categories are skipped, never crash the merge', () => {
+  const hostile = makeExport('mallory', 'h9', [
+    cat({ id: 'ok1' }),
+    { id: 'bad1', terms: [] } as unknown as ExportCategory,
+    { id: 'bad2', terms: [7, null] } as unknown as ExportCategory,
+    { name: 'no-id' } as unknown as ExportCategory,
+    null as unknown as ExportCategory,
+  ]);
+  const mc = mergeCategories([hostile]);
+  assert.equal(mc.withCategories, 1);
+  assert.equal(mc.categories.length, 1); // only the usable row survives
+});
+
+test('threshold gates weak matches; shuffled input yields identical output', () => {
+  const a = makeExport('alice', 'h1', [cat({ id: 'a1', terms: ['payment', 'retry', 'backoff', 'stripe'] })]);
+  const b = makeExport('bob', 'h2', [cat({ id: 'b1', terms: ['retry', 'docs', 'readme', 'typo'] })]);
+  const loose = mergeCategories([a, b], { threshold: 0.1 });
+  const strict = mergeCategories([a, b], { threshold: 0.9 });
+  assert.equal(loose.crossUserDuplicates.length, 1); // single shared term links at 0.1
+  assert.equal(strict.crossUserDuplicates.length, 0);
+
+  const c = makeExport('carol', 'h3', [cat({ id: 'c1', terms: ['payment', 'retry', 'backoff'] })]);
+  const one = mergeCategories([a, b, c]);
+  const two = mergeCategories([c, a, b]);
+  assert.deepEqual(one, two);
+});
+
+test('pre-0.11 exports merge as metrics-only; coverage counts category-bearing ones', () => {
+  const legacy = makeExport('old-timer', 'h0', undefined);
+  const modern = makeExport('alice', 'h1', [cat({ id: 'a1', duplicate: true, cost: 12 })]);
+  const mc = mergeCategories([legacy, modern]);
+  assert.equal(mc.withCategories, 1);
+  assert.equal(mc.crossUserDuplicates.length, 0);
+  // within-member tier: carried duplicate flags aggregate, never conflated with cross-user
+  assert.equal(mc.withinMemberDupCost, 12);
+  assert.equal(mc.withinMemberDupMembers, 1);
+});
+
+test('non-numeric category fields are rejected, not summed as NaN', () => {
+  const hostile = makeExport('mallory', 'h9', [
+    cat({ id: 'ok1' }),
+    { id: 'bad', name: 'x', terms: ['x'], sessions: 'NaNbait', tokens: 1, cost: 1 } as unknown as ExportCategory,
+    { id: 'bad2', name: 'y', terms: ['y'], sessions: 1, tokens: 1, cost: Infinity } as unknown as ExportCategory,
+  ]);
+  const mc = mergeCategories([hostile]);
+  assert.equal(mc.categories.length, 1);
+  assert.ok(Number.isFinite(mc.categories[0].cost));
+});
+
+test('duplicate category ids within an export keep both rows (occurrence suffix)', () => {
+  const twinA = cat({ id: 'same', cost: 5, sessions: 1 });
+  const twinB = cat({ id: 'same', cost: 7, sessions: 1 });
+  const mc = mergeCategories([makeExport('alice', 'h1', [twinA, twinB])]);
+  const total = mc.categories.reduce((s, c) => s + c.cost, 0);
+  assert.equal(total, 12); // nothing silently dropped
+});
+
+test('--min-cluster gates both cross-user duplicates and skill candidates', () => {
+  const a = makeExport('alice', 'h1', [cat({ id: 'a1', sessions: 1 })]);
+  const b = makeExport('bob', 'h2', [cat({ id: 'b1', sessions: 1 })]);
+  const loose = mergeCategories([a, b]); // default minCluster 2, cluster has 2 sessions
+  assert.equal(loose.crossUserDuplicates.length, 1);
+  const strict = mergeCategories([a, b], { minCluster: 5 });
+  assert.equal(strict.crossUserDuplicates.length, 0);
+  assert.equal(strict.orgSkillCandidates.length, 0);
+});

--- a/test/team.test.ts
+++ b/test/team.test.ts
@@ -149,3 +149,60 @@ test('dedupeExports keeps only the newest export per identity', () => {
   assert.deepEqual(r.kept, [u2]);
   assert.deepEqual(r.dropped, [u1]);
 });
+
+// ---- category export (PR4) ---------------------------------------------------
+
+import { exportCategories } from '../src/categorize.js';
+import type { CategorizeResult, CategoryRow } from '../src/categorize.js';
+import { verifyObject } from '../src/sign.js';
+
+const cat = (p: Partial<CategoryRow>): CategoryRow => ({
+  id: 'c0', name: 'task label', terms: ['task', 'label'], sessions: 1, projects: ['proj'],
+  tokens: 1000, cost: 1, estimated: false, hasText: true, duplicate: false, ...p,
+});
+const resultOf = (categories: CategoryRow[]): CategorizeResult => ({
+  days: 30, totalSessions: categories.length, textSessions: categories.length,
+  categories, duplicates: [], skillCandidates: [],
+});
+
+test('exportCategories ships hasText clusters only, capped and cost-sorted', () => {
+  const rows = [
+    cat({ id: 'lo', cost: 1 }),
+    cat({ id: 'notext', cost: 99, hasText: false }), // never leaves the machine
+    cat({ id: 'hi', cost: 50 }),
+  ];
+  const out = exportCategories(resultOf(rows));
+  assert.deepEqual(out.map((c) => c.id), ['hi', 'lo']);
+
+  const many = Array.from({ length: 60 }, (_, i) => cat({ id: `c${i}`, cost: i }));
+  assert.equal(exportCategories(resultOf(many)).length, 40);
+  // sorted BEFORE slicing: the cap keeps the 40 most expensive, deterministically
+  assert.equal(exportCategories(resultOf(many))[0].id, 'c59');
+  assert.deepEqual(exportCategories(resultOf(many)), exportCategories(resultOf([...many].reverse())));
+});
+
+test('export categories carry ONLY the allowlisted aggregate fields', () => {
+  const out = exportCategories(resultOf([cat({})]));
+  assert.deepEqual(
+    Object.keys(out[0]).sort(),
+    ['cost', 'duplicate', 'estimated', 'id', 'name', 'projects', 'sessions', 'terms', 'tokens'],
+  );
+  assert.ok(out[0].terms.length <= 8);
+});
+
+test('signed export with categories round-trips verification; tampering fails', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tm-keys-'));
+  const ex: ExportV1 = {
+    version: 1, user: 'alice', host: 'h', generatedAt: '2026-06-01T00:00:00.000Z', days: 30,
+    overall: metricsOf({ session_id: 'a', activity: 'coding' }),
+    byProject: {},
+    categories: exportCategories(resultOf([cat({})])),
+    categorizeDays: 30,
+  };
+  assert.equal(ex.version, 1); // additive fields — the wire version must NOT bump
+  const signed = signObject(ex as unknown as Record<string, unknown>, dir);
+  assert.equal(verifyObject(signed as unknown as Record<string, unknown>).ok, true);
+  const tampered = JSON.parse(JSON.stringify(signed));
+  tampered.categories[0].terms[0] = 'forged';
+  assert.equal(verifyObject(tampered).ok, false);
+});


### PR DESCRIPTION
## What

Three coupled features, designed via multi-agent panel and amended by dogfooding on real data:

### 1. Project families (fixes real fragmentation)
One session that \`cd\`-s into monorepo subdirs no longer fragments into per-subdir pseudo-projects (\`backend\`/\`frontend\`/\`db\` — a four-figure chunk of one real month mislabeled). Each session gets ONE project: the **dominant per-event cwd label after descendant adoption** (\`src/project-family.ts\`) — pure path grouping, zero disk access, identical for deleted dirs. Guards: near-root launch dirs (home, drive roots, WSL mounts) never donate or win the vote; \`/workspaces/<repo>\` devcontainer mounts may. **Git-root resolution was built, dogfooded, and rejected**: on an umbrella repo it folded five distinct products into one row and split families between live/dead paths — a wrong merge corrupts the duplicate-work signal where a missed merge only under-reports.

Backfill: collect IS the migration — historical rows converge on every collect (idempotent, steady state 0 changes), originals audited in the new \`project_raw\` column (one-line revert). Dead worktrees fold via \`~/.token-monitor/project-aliases.json\`, composed into the relabel target so aliases for live projects can't flip-flop.

### 2. Aggregate-only category exports
\`report --json\` / \`push\` now carry the member's task categories — **labels only** (≤8 redacted keyword terms, counts, $; hasText-only; top-40-by-cost sorted-before-cap for signature determinism). Wire version stays 1 (additive fields, both directions compatible). Opt out with \`--no-categories\`.

### 3. Cross-user duplicate detection at merge
\`merge\` re-clusters member categories across people (reuses \`cluster.ts\` verbatim, identity in the inert project slot): same task by ≥2 identities → cross-user duplicate headline; org-skill candidates ranked by sessions × users. Unsigned exports flagged \`(unsigned)\` so one person on two machines can't silently read as two. Honors \`--threshold\` / \`--min-cluster\`; terminal + \`--json\` + \`--html\` parity.

## Verification
- 202 tests (was 167): resolver units, adapter regression (the exact real-world fragmentation case), migration/idempotency, alias steady-state e2e, v1/v2 merge mix, XSS, privacy canaries (secrets grepped out of exports, merge stdout/json/html, and raw sqlite bytes incl. \`project_raw\`), byte-determinism of merge output.
- Dogfooded 3× on a copy of a real 30-day multi-project database: fragmented rows re-attribute correctly, all products preserved, second collect silent.
- Adversarially reviewed by a 24-agent workflow: 18 confirmed findings (deduped to 12) all fixed — incl. Windows/WSL home-dir donation, alias/relabel flip-flop, source-scoped intent sync, hostile-export NaN poisoning.

## Privacy
Raw prompt text never reaches the DB, exports, or merge surfaces — enforced by canary e2e. Terms deliberately not hashed (dictionary-reversible false comfort); README privacy section documents the full export field list.
