### PR TITLE
feat: subagent accounting — collect reads sidechain transcripts (#63)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ npm install -g @ryandemelo/token-monitor
 token-monitor collect && token-monitor report
 ```
 
-`collect` reads the user's local agent session logs (`~/.claude/projects/`, `~/.gemini/tmp/`, `~/.codex/sessions/`, Cursor's `state.vscdb`, `~/.gemini/antigravity-cli/`, VS Code `chatSessions/`) into `~/.token-monitor/token-monitor.sqlite`. It is idempotent — safe to re-run any time. `report` prints the analysis; `html` writes a dashboard file; nothing makes network calls.
+`collect` reads the user's local agent session logs (`~/.claude/projects/` — including each session's `subagents/` transcripts, which hold a large share of Claude Code spend — `~/.gemini/tmp/`, `~/.codex/sessions/`, Cursor's `state.vscdb`, `~/.gemini/antigravity-cli/`, VS Code `chatSessions/`) into `~/.token-monitor/token-monitor.sqlite`. It is idempotent — safe to re-run any time. `report` prints the analysis; `html` writes a dashboard file; nothing makes network calls.
 
 After installing, run `collect` then `report` and walk the user through their activity breakdown, cache hit ratio, rework ratio, and persona.
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Fan-out is reported, not judged: delegating heavily can be exactly the right cal
 
 Two signals are deliberately scoped to the main loop on **both** sides of their ratio: **context bloat** and **cold restarts**. Their remedies — compact, start fresh, batch prompts, split idle work — cannot be applied to a run that is spawned, works back-to-back and exits, and subagent runs outnumber conversations by roughly 14:1, so including them would bury a real hygiene problem in a denominator nobody can act on. Everything that measures *spend* — activity mix, cost, rework, retries, premium routing, per-project totals — counts subagent turns in full.
 
-One-time re-basing: on the first collect after upgrading, spend-share metrics (rework, retry, premium) step because their denominators finally include the fan-out. If you are tracking a recommendation through follow-through across that boundary, treat that single move as a measurement correction, not as your intervention working.
+One-time re-basing: on the first collect after upgrading, spend-share metrics (rework, retry, premium) and **cache hit ratio** step because their denominators finally include the fan-out. If you are tracking a recommendation through follow-through across that boundary, treat that single move as a measurement correction, not as your intervention working.
 
 Add `--llm` and the aggregates go to a coding agent you already have installed (`claude`, `gemini`, or `codex` — auto-detected, override with `--agent`), which returns prioritized interventions with the evidence, the workflow change, and the metric to watch:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The repo ships [`AGENTS.md`](AGENTS.md) and [`llms.txt`](llms.txt) so agents can
 | **Rework ratio** | Share of tokens spent on code/test turns *after* the first failed turn in a session. High rework usually means skipped planning. Distinct from `analyze`'s **fix iterations**, which counts testing→coding transitions — sessions that barely test can have high rework but zero visible fix loops. User-declined permission prompts are *not* counted as failures. |
 | **Think:code ratio** | Planning+exploration tokens per coding token. Too low correlates with high rework. |
 | **Model mix** | Premium-model tokens on turns a cheaper tier would handle. |
+| **Subagent share** | Spend from Task/Agent fan-out rather than the main loop. Descriptive, not a verdict — but every other number is wrong without it, and a fan-out of 40 agents still counts as the one session someone actually had. |
 | **Estimated cost** | API-equivalent USD from a built-in price table (`src/pricing.ts`). Non-Anthropic prices are placeholders marked `~` — edit to match your contract. |
 
 ## Personas
@@ -74,7 +75,7 @@ Personas are computed per-project and overall, so one expensive workflow can't h
 
 | Agent | Source | Status |
 |---|---|---|
-| **Claude Code** | `~/.claude/projects/**/*.jsonl` | ✅ Verified — per-turn tokens, cache split, model, tools, git branch |
+| **Claude Code** | `~/.claude/projects/**/*.jsonl`, incl. `<session>/subagents/**/agent-*.jsonl` | ✅ Verified — per-turn tokens, cache split, model, tools, git branch, **subagent runs** |
 | **Gemini CLI** | `~/.gemini/tmp/*/chats/*.json` | ✅ Verified — per-turn tokens incl. thoughts, tool calls |
 | **Codex CLI** | `~/.codex/sessions/**/rollout-*.jsonl` | ⚠️ Experimental — diffs cumulative `token_count` events; verify against Codex's own usage screens |
 | **Cursor** | `Cursor/User/globalStorage/state.vscdb` (SQLite) | ✅ Verified — per-turn tokens on completed turns, tool calls, agent/chat sessions. Cursor doesn't persist cache tokens or the resolved backend model (Auto mode reports as `cursor-auto`) |
@@ -82,6 +83,8 @@ Personas are computed per-project and overall, so one expensive workflow can't h
 | **Copilot Chat** (VS Code) | `Code/User/workspaceStorage/*/chatSessions/*` | ⚠️ Experimental — Copilot doesn't record token usage locally, so counts are **estimated** from text length (~4 chars/token) and models are suffixed `(est)`. Turn counts, timestamps, tools, and errors are real |
 
 Adapters skip gracefully when a tool isn't installed. The Cursor adapter reads only composer/bubble keys — never the auth entries that live in the same database.
+
+**Subagent coverage.** Claude Code writes each Task/Agent run to its own transcript under the session directory, and the main transcript never mentions what those runs spent. token-monitor reads them: on the maintainer's own 30-day window that is 24% of spend across 2,027 runs — invisible to every version before 0.12, and to any tool that reads only the top level. The format is vendor-internal and undocumented, so parsing is fail-soft (a reshaped or unreadable agent file costs its own turns, never the collect). Only Claude Code is known to persist this; the other five sources report no sidechain data, so their subagent share reads as absent rather than zero.
 
 ## IDE extension
 
@@ -161,8 +164,11 @@ Identity is the **signing fingerprint**, not the OS username: two different "rya
 - **Context bloat trend** — sessions whose late-half context grew ≥2× without cache reads keeping pace (start fresh / compact earlier)
 - **Cold restarts** — turns resuming after the ~5-min cache TTL that re-paid their context as fresh input (batch prompts, split idle work)
 - **Tool error rates** — tools that keep failing, plus the token cost of their retry loops
+- **Subagent fan-out** — which sessions delegated, what their agent runs cost next to the driver's own turns, and the spend per subagent type (Claude Code only)
 
-The report and dashboard surface the same signals in one line (context bloat, cold restarts, premium tokens on exploration/conversation, retry-loop spend), and each one becomes a tracked recommendation when it crosses its threshold.
+The report and dashboard surface the same signals in one line (context bloat, cold restarts, premium tokens on exploration/conversation, retry-loop spend, subagent share), and each one becomes a tracked recommendation when it crosses its threshold.
+
+Fan-out is reported, not judged: delegating heavily can be exactly the right call, so there is no "too many subagents" finding. Read the ratio against what the fan-out produced. Subagent **type** names stay on your machine — a custom agent can be named after something private — so exports and `--llm` payloads carry the share and the counts only.
 
 Add `--llm` and the aggregates go to a coding agent you already have installed (`claude`, `gemini`, or `codex` — auto-detected, override with `--agent`), which returns prioritized interventions with the evidence, the workflow change, and the metric to watch:
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ The report and dashboard surface the same signals in one line (context bloat, co
 
 Fan-out is reported, not judged: delegating heavily can be exactly the right call, so there is no "too many subagents" finding. Read the ratio against what the fan-out produced. Subagent **type** names stay on your machine — a custom agent can be named after something private — so exports and `--llm` payloads carry the share and the counts only.
 
+Two signals are deliberately scoped to the main loop on **both** sides of their ratio: **context bloat** and **cold restarts**. Their remedies — compact, start fresh, batch prompts, split idle work — cannot be applied to a run that is spawned, works back-to-back and exits, and subagent runs outnumber conversations by roughly 14:1, so including them would bury a real hygiene problem in a denominator nobody can act on. Everything that measures *spend* — activity mix, cost, rework, retries, premium routing, per-project totals — counts subagent turns in full.
+
+One-time re-basing: on the first collect after upgrading, spend-share metrics (rework, retry, premium) step because their denominators finally include the fan-out. If you are tracking a recommendation through follow-through across that boundary, treat that single move as a measurement correction, not as your intervention working.
+
 Add `--llm` and the aggregates go to a coding agent you already have installed (`claude`, `gemini`, or `codex` — auto-detected, override with `--agent`), which returns prioritized interventions with the evidence, the workflow change, and the metric to watch:
 
 ```sh

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -35,6 +35,13 @@ interface ClaudeLine {
   /** Subagent transcripts only: the run's own id, and the type that spawned it. */
   agentId?: string;
   attributionAgent?: string;
+  /**
+   * Current Claude Code writes this false on every main-loop line and true in
+   * agent files. Older versions inlined sidechain turns into the main
+   * transcript with this flag set; honouring it keeps those turns out of the
+   * main-loop-scoped hygiene metrics.
+   */
+  isSidechain?: boolean;
   message?: {
     model?: string;
     usage?: {
@@ -171,6 +178,13 @@ function parseTranscript(text: string, opts: TranscriptOpts): ParsedTurn[] {
       ev.isSidechain = true;
       ev.parentSessionId = opts.sidechain.parentSessionId;
       if (typeof d.attributionAgent === 'string' && d.attributionAgent) ev.agentType = d.attributionAgent;
+    } else if (d.isSidechain === true) {
+      // Legacy inline format: the turn belongs to a fan-out even though it
+      // lives in the main transcript. It keeps the main session's id (there
+      // is no separate transcript to key on) but must not count as main-loop
+      // context for the hygiene ratios.
+      ev.isSidechain = true;
+      ev.parentSessionId = ev.sessionId;
     }
     ev.activity = classify(ev);
     turns.push({ ev, cwd: d.cwd });
@@ -303,7 +317,12 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
     }
 
     for (const ent of entries) {
-      if (!ent.isDirectory()) continue;
+      // Symlinked session directories count too, for the same archive-and-
+      // link workflow the main-transcript scan supports: collecting a
+      // session's main loop while silently dropping its whole fan-out is the
+      // exact undercount this adapter exists to fix. The cycle guard lives in
+      // agentTranscripts, which only recurses into real directories.
+      if (ent.isFile()) continue;
       const subRoot = join(dirPath, ent.name, 'subagents');
       if (!existsSync(subRoot)) continue;
       const parentSessionId = ent.name; // the session directory IS the session id

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -221,7 +221,7 @@ function* agentTranscripts(dir: string, depth = 0): Generator<string> {
   for (const ent of entries) {
     const p = join(dir, ent.name);
     if (ent.isDirectory()) yield* agentTranscripts(p, depth + 1);
-    else if (ent.isFile() && ent.name.startsWith('agent-') && ent.name.endsWith('.jsonl')) yield p;
+    else if (ent.name.startsWith('agent-') && ent.name.endsWith('.jsonl')) yield p;
   }
 }
 
@@ -284,7 +284,11 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
     // subagent runs below inherit.
     const mainTurns: ParsedTurn[] = [];
     for (const ent of entries) {
-      if (!ent.isFile() || !ent.name.endsWith('.jsonl')) continue;
+      // Anything that isn't a directory: Dirent types are lstat-based, so an
+      // archived transcript symlinked back into place reports as neither file
+      // nor directory, and an isFile() test would silently drop the whole
+      // session. readText's try/catch handles a dangling link.
+      if (ent.isDirectory() || !ent.name.endsWith('.jsonl')) continue;
       filesScanned++;
       const text = readText(join(dirPath, ent.name));
       if (text === undefined) continue;

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { UsageEvent, CollectResult } from '../types.js';
 import { classify } from '../classify.js';
@@ -32,6 +32,9 @@ interface ClaudeLine {
   cwd?: string;
   gitBranch?: string;
   timestamp?: string;
+  /** Subagent transcripts only: the run's own id, and the type that spawned it. */
+  agentId?: string;
+  attributionAgent?: string;
   message?: {
     model?: string;
     usage?: {
@@ -67,7 +70,200 @@ function userText(content: string | ContentBlock[] | undefined): string {
     .join('\n');
 }
 
-/** Parse Claude Code session transcripts: ~/.claude/projects/<dir>/<session>.jsonl */
+/** One parsed turn, still carrying the raw cwd its project is resolved from. */
+interface ParsedTurn {
+  ev: UsageEvent;
+  cwd?: string;
+}
+
+interface TranscriptOpts {
+  /** Session id for lines that omit one — the transcript's own file id. */
+  fallbackSessionId: string;
+  /**
+   * Present for a subagent transcript. The run gets its OWN session id
+   * (`agentId`) plus a link to the session that spawned it — see the comment
+   * on collectClaudeCode for why the file's `sessionId` can't be used as-is.
+   */
+  sidechain?: { agentId: string; parentSessionId: string };
+}
+
+/** Parse one JSONL transcript (main-loop or subagent) into usage turns. */
+function parseTranscript(text: string, opts: TranscriptOpts): ParsedTurn[] {
+  // tool_use id -> event, so a failed tool_result can flag its turn
+  const byToolUseId = new Map<string, UsageEvent>();
+  // The most recent genuine user prompt, carried forward onto the assistant
+  // turns it triggered (transient — used only by `categorize`).
+  let lastUserText = '';
+  const turns: ParsedTurn[] = [];
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let d: ClaudeLine;
+    try {
+      d = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (d.type === 'user') {
+      const content = d.message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (
+            block.type === 'tool_result' &&
+            block.is_error &&
+            block.tool_use_id &&
+            !isDeclination(block.content)
+          ) {
+            const ev = byToolUseId.get(block.tool_use_id);
+            if (ev) ev.isError = true;
+          }
+        }
+      }
+      const t = userText(content).trim();
+      if (t) lastUserText = t;
+      continue;
+    }
+    if (d.type !== 'assistant' || !d.message?.usage || !d.uuid) continue;
+    const u = d.message.usage;
+    const total = (u.input_tokens ?? 0) + (u.output_tokens ?? 0);
+    if (total === 0 && !(u.cache_read_input_tokens || u.cache_creation_input_tokens)) continue;
+
+    const tools: string[] = [];
+    const commands: string[] = [];
+    let hasThinking = false;
+    const toolUseIds: string[] = [];
+    const blocks = Array.isArray(d.message.content) ? d.message.content : [];
+    for (const block of blocks) {
+      if (block.type === 'tool_use' && block.name) {
+        tools.push(block.name);
+        if (block.id) toolUseIds.push(block.id);
+        if (typeof block.input?.command === 'string') commands.push(block.input.command);
+      } else if (block.type === 'thinking') {
+        hasThinking = true;
+      }
+    }
+
+    const ev: UsageEvent = {
+      source: 'claude-code',
+      eventKey: d.uuid,
+      sessionId: opts.sidechain
+        ? d.agentId || opts.sidechain.agentId
+        : (d.sessionId ?? opts.fallbackSessionId),
+      project: '', // assigned per-session by the caller, see collectClaudeCode
+      timestamp: d.timestamp ?? new Date(0).toISOString(),
+      model: d.message.model ?? 'unknown',
+      inputTokens: u.input_tokens ?? 0,
+      outputTokens: u.output_tokens ?? 0,
+      cacheReadTokens: u.cache_read_input_tokens ?? 0,
+      cacheCreationTokens: u.cache_creation_input_tokens ?? 0,
+      thinkingTokens: 0,
+      tools,
+      commands,
+      hasThinking,
+      isError: false,
+      gitBranch: d.gitBranch,
+      // A subagent's "user" prompt is written by the parent agent, not by the
+      // human, so it is deliberately NOT carried as intent text: feeding
+      // machine-authored task briefs into categorize would drown the handful
+      // of sentences the person actually typed.
+      intentText: opts.sidechain ? undefined : lastUserText || undefined,
+    };
+    if (opts.sidechain) {
+      ev.isSidechain = true;
+      ev.parentSessionId = opts.sidechain.parentSessionId;
+      if (typeof d.attributionAgent === 'string' && d.attributionAgent) ev.agentType = d.attributionAgent;
+    }
+    ev.activity = classify(ev);
+    turns.push({ ev, cwd: d.cwd });
+    for (const id of toolUseIds) byToolUseId.set(id, ev);
+  }
+  return turns;
+}
+
+/**
+ * One project per session: the dominant per-event cwd label after descendant
+ * adoption (see project-family.ts). A single-cwd session stays byte-identical
+ * to plain basename(cwd). Sessions with no cwd at all are simply absent, and
+ * the caller falls back to the log directory name.
+ */
+function projectsBySession(turns: ParsedTurn[]): Map<string, string> {
+  const cwdsBySession = new Map<string, string[]>();
+  for (const { ev, cwd } of turns) {
+    if (!cwd) continue;
+    let list = cwdsBySession.get(ev.sessionId);
+    if (!list) cwdsBySession.set(ev.sessionId, (list = []));
+    list.push(cwd); // one entry PER EVENT — dominance needs the counts
+  }
+  const out = new Map<string, string>();
+  for (const [sessionId, cwds] of cwdsBySession) {
+    const project = sessionProjectOf(cwds);
+    if (project) out.set(sessionId, project);
+  }
+  return out;
+}
+
+/**
+ * Depth bound for the subagent walk. Observed shapes are `subagents/agent-*`
+ * and `subagents/workflows/<run>/agent-*`; the bound just stops an unexpected
+ * layout (or a hand-made symlink farm) from turning a collect into a full
+ * disk crawl. Dirent.isDirectory() is lstat-based, so symlinked directories
+ * are skipped outright and cycles are impossible.
+ */
+const MAX_SUBAGENT_DEPTH = 6;
+
+function* agentTranscripts(dir: string, depth = 0): Generator<string> {
+  if (depth > MAX_SUBAGENT_DEPTH) return;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const ent of entries) {
+    const p = join(dir, ent.name);
+    if (ent.isDirectory()) yield* agentTranscripts(p, depth + 1);
+    else if (ent.isFile() && ent.name.startsWith('agent-') && ent.name.endsWith('.jsonl')) yield p;
+  }
+}
+
+function readText(path: string): string | undefined {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Parse Claude Code transcripts under ~/.claude/projects/<dir>/:
+ *
+ *   <session>.jsonl                              main loop
+ *   <session>/subagents/agent-<id>.jsonl         one Task/Agent run
+ *   <session>/subagents/workflows/<run>/agent-*  workflow fan-out
+ *
+ * The subagent files are real spend that appears NOWHERE else: current Claude
+ * Code stopped inlining sidechain turns into the main transcript (every
+ * main-loop line now carries `isSidechain: false`), so a collect that reads
+ * only the top level undercounts by however much the fan-out cost — a fifth
+ * of a heavy month, measured. Format is vendor-internal and undocumented, so
+ * every field is optional and parsing is fail-soft (the Antigravity
+ * precedent): an unreadable or reshaped agent file costs its own turns, never
+ * the run.
+ *
+ * Two attribution decisions, both empirical:
+ *
+ * - **Session id.** An agent transcript's `sessionId` field is the PARENT's,
+ *   not its own, so it cannot be used as the session key: folding a fan-out's
+ *   interleaved turns into the parent would corrupt every chronology-based
+ *   metric (fix loops, cold restarts, context-bloat trend). Each run keys on
+ *   its `agentId` instead — a coherent little conversation of its own — and
+ *   records the parent in `parentSessionId`, which is what `sessions` counts
+ *   and what `categorize` aggregates by.
+ * - **Project.** Agent turns inherit the parent session's resolved project
+ *   rather than voting with their own cwd, because an isolated agent runs in
+ *   a scratch git worktree whose basename would mint a pseudo-project. Their
+ *   own cwds are the fallback for the case where the parent transcript is
+ *   gone (rotated away) but its subagent directory survives.
+ */
 export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; result: CollectResult } {
   const events: UsageEvent[] = [];
   let filesScanned = 0;
@@ -77,118 +273,50 @@ export function collectClaudeCode(root: string = ROOT): { events: UsageEvent[]; 
 
   for (const dir of readdirSync(root)) {
     const dirPath = join(root, dir);
-    let files: string[];
+    let entries;
     try {
-      files = readdirSync(dirPath).filter((f) => f.endsWith('.jsonl'));
+      entries = readdirSync(dirPath, { withFileTypes: true });
     } catch {
       continue;
     }
-    for (const file of files) {
+
+    // Main-loop transcripts first: their per-session projects are what the
+    // subagent runs below inherit.
+    const mainTurns: ParsedTurn[] = [];
+    for (const ent of entries) {
+      if (!ent.isFile() || !ent.name.endsWith('.jsonl')) continue;
       filesScanned++;
-      let text: string;
-      try {
-        text = readFileSync(join(dirPath, file), 'utf8');
-      } catch {
-        continue;
-      }
-      // tool_use id -> event, so a failed tool_result can flag its turn
-      const byToolUseId = new Map<string, UsageEvent>();
-      // The most recent genuine user prompt, carried forward onto the assistant
-      // turns it triggered (transient — used only by `categorize`).
-      let lastUserText = '';
-      // Events buffered with their raw cwd: the project is assigned ONCE per
-      // session at end-of-file, so a session that cd-s into monorepo subdirs
-      // ("backend", "frontend") can't fragment into per-subdir pseudo-projects.
-      const fileEvents: Array<{ ev: UsageEvent; cwd?: string }> = [];
-      for (const line of text.split('\n')) {
-        if (!line.trim()) continue;
-        let d: ClaudeLine;
-        try {
-          d = JSON.parse(line);
-        } catch {
-          continue;
-        }
-        if (d.type === 'user') {
-          const content = d.message?.content;
-          if (Array.isArray(content)) {
-            for (const block of content) {
-              if (
-                block.type === 'tool_result' &&
-                block.is_error &&
-                block.tool_use_id &&
-                !isDeclination(block.content)
-              ) {
-                const ev = byToolUseId.get(block.tool_use_id);
-                if (ev) ev.isError = true;
-              }
-            }
-          }
-          const t = userText(content).trim();
-          if (t) lastUserText = t;
-          continue;
-        }
-        if (d.type !== 'assistant' || !d.message?.usage || !d.uuid) continue;
-        const u = d.message.usage;
-        const total = (u.input_tokens ?? 0) + (u.output_tokens ?? 0);
-        if (total === 0 && !(u.cache_read_input_tokens || u.cache_creation_input_tokens)) continue;
+      const text = readText(join(dirPath, ent.name));
+      if (text === undefined) continue;
+      mainTurns.push(
+        ...parseTranscript(text, { fallbackSessionId: ent.name.replace(/\.jsonl$/, '') }),
+      );
+    }
+    const projectBySession = projectsBySession(mainTurns);
+    for (const { ev } of mainTurns) {
+      ev.project = projectBySession.get(ev.sessionId) ?? dir;
+      events.push(ev);
+    }
 
-        const tools: string[] = [];
-        const commands: string[] = [];
-        let hasThinking = false;
-        const toolUseIds: string[] = [];
-        const blocks = Array.isArray(d.message.content) ? d.message.content : [];
-        for (const block of blocks) {
-          if (block.type === 'tool_use' && block.name) {
-            tools.push(block.name);
-            if (block.id) toolUseIds.push(block.id);
-            if (typeof block.input?.command === 'string') commands.push(block.input.command);
-          } else if (block.type === 'thinking') {
-            hasThinking = true;
-          }
+    for (const ent of entries) {
+      if (!ent.isDirectory()) continue;
+      const subRoot = join(dirPath, ent.name, 'subagents');
+      if (!existsSync(subRoot)) continue;
+      const parentSessionId = ent.name; // the session directory IS the session id
+      for (const file of agentTranscripts(subRoot)) {
+        filesScanned++;
+        const text = readText(file);
+        if (text === undefined) continue;
+        const agentId = basename(file).replace(/^agent-/, '').replace(/\.jsonl$/, '');
+        const turns = parseTranscript(text, {
+          fallbackSessionId: agentId,
+          sidechain: { agentId, parentSessionId },
+        });
+        const own = projectBySession.has(parentSessionId) ? undefined : projectsBySession(turns);
+        for (const { ev } of turns) {
+          ev.project = projectBySession.get(parentSessionId) ?? own?.get(ev.sessionId) ?? dir;
+          events.push(ev);
         }
-
-        const ev: UsageEvent = {
-          source: 'claude-code',
-          eventKey: d.uuid,
-          sessionId: d.sessionId ?? file.replace('.jsonl', ''),
-          project: '', // assigned per-session at end-of-file, see below
-          timestamp: d.timestamp ?? new Date(0).toISOString(),
-          model: d.message.model ?? 'unknown',
-          inputTokens: u.input_tokens ?? 0,
-          outputTokens: u.output_tokens ?? 0,
-          cacheReadTokens: u.cache_read_input_tokens ?? 0,
-          cacheCreationTokens: u.cache_creation_input_tokens ?? 0,
-          thinkingTokens: 0,
-          tools,
-          commands,
-          hasThinking,
-          isError: false,
-          gitBranch: d.gitBranch,
-          intentText: lastUserText || undefined,
-        };
-        ev.activity = classify(ev);
-        fileEvents.push({ ev, cwd: d.cwd });
-        for (const id of toolUseIds) byToolUseId.set(id, ev);
-      }
-
-      // One project per session: the dominant per-event cwd label after
-      // descendant adoption (see project-family.ts) — the log dir name when
-      // no event carried a cwd. A single-cwd session stays byte-identical to
-      // the old basename(cwd) behavior.
-      const cwdsBySession = new Map<string, string[]>();
-      for (const { ev, cwd } of fileEvents) {
-        if (!cwd) continue;
-        let list = cwdsBySession.get(ev.sessionId);
-        if (!list) cwdsBySession.set(ev.sessionId, (list = []));
-        list.push(cwd); // one entry PER EVENT — dominance needs the counts
-      }
-      const projectBySession = new Map<string, string>();
-      for (const [sessionId, cwds] of cwdsBySession) {
-        projectBySession.set(sessionId, sessionProjectOf(cwds) ?? dir);
-      }
-      for (const { ev } of fileEvents) {
-        ev.project = projectBySession.get(ev.sessionId) ?? dir;
-        events.push(ev);
       }
     }
   }

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -57,7 +57,9 @@ export function computeSessionStats(events: StoredEvent[]): SessionStat[] {
       if (prev === 'testing' && e.activity === 'coding') fixes++;
       prev = e.activity;
       const ts = Date.parse(e.ts);
-      if (prevTs !== undefined && ts - prevTs > CACHE_TTL_MS) {
+      // Cold restarts are a main-loop signal on both sides of the ratio (see
+      // Metrics.coldRestartShare); a subagent run never idles.
+      if (prevTs !== undefined && !e.is_sidechain && ts - prevTs > CACHE_TTL_MS) {
         coldTurns++;
         coldTokens += e.input_tokens + e.cache_creation_tokens;
       }
@@ -225,7 +227,10 @@ export function deepAnalysis(events: StoredEvent[]): DeepAnalysis {
       .sort((a, b) => b.fixIterations - a.fixIterations)
       .slice(0, 8),
     contextHeavySessions: stats
-      .filter((s) => s.turns >= 10)
+      // avgContextTokens is a bloat proxy, so this list follows the same rule
+      // as the trend: agent runs outnumber conversations ~14:1 and would
+      // otherwise fill every row with sessions nobody can compact.
+      .filter((s) => !s.isSidechain && s.turns >= 10)
       .sort((a, b) => b.avgContextTokens - a.avgContextTokens)
       .slice(0, 8),
     bloatTrendSessions: stats
@@ -269,6 +274,9 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
     coldRestartTokens: s.coldRestartTokens,
     durationMin: s.durationMin,
     dominant: s.dominant,
+    // A boolean, not a type name: the model must not read a 40-turn agent run
+    // as a 40-turn conversation and prescribe "compact this session".
+    isSidechain: s.isSidechain,
   });
   return {
     windowDays: days,
@@ -340,7 +348,7 @@ export const TRACKABLE_METRICS: MetricKey[] = [
 ];
 
 const METRIC_DEFINITIONS =
-  'Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). contextGrowth = late-half avg context / early half per session; contextBloatShare = share of long sessions growing >=2x without cache keeping pace. coldRestartTokens = input re-paid on turns resuming after the ~5-min cache TTL; coldRestartShare = that over all fresh-paid input. premiumWasteShare = premium-model tokens on exploration/conversation turns / all spend. retryShare/retryTokens = spend on turns re-running a tool right after it errored. subagentShare = share of spend from subagent (Task/Agent fan-out) runs rather than the main loop; fanOutSessions lists the sessions that delegated most, with the subagent-to-main-loop spend ratio. Fan-out is not waste by default — flag it only when the delegated spend has nothing to show for it. Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.';
+  'Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). contextGrowth = late-half avg context / early half per session; contextBloatShare = share of long sessions growing >=2x without cache keeping pace. coldRestartTokens = input re-paid on turns resuming after the ~5-min cache TTL; coldRestartShare = that over all fresh-paid input. premiumWasteShare = premium-model tokens on exploration/conversation turns / all spend. retryShare/retryTokens = spend on turns re-running a tool right after it errored. subagentShare = share of spend from subagent (Task/Agent fan-out) runs rather than the main loop; fanOutSessions lists the sessions that delegated most, with the subagent-to-main-loop spend ratio. Fan-out is not waste by default — flag it only when the delegated spend has nothing to show for it. Session rows with isSidechain=true are ONE subagent run, not a conversation: never advise compacting, restarting or batching them (they are spawned fresh and exit), and note that contextBloatShare and coldRestartShare are measured over main-loop sessions only. Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.';
 
 export function buildLlmPrompt(events: StoredEvent[], days: number): string {
   return `You are an engineering-efficiency analyst. The JSON below contains AGGREGATE token-usage telemetry from AI coding agents (Claude Code / Gemini CLI / Codex) for one developer or team over ${days} days. There is no prompt or code content — only counts, ratios, tool names, and project names.

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import type { StoredEvent } from './store.js';
-import { computeMetrics, groupBy, contextGrowthOf, parseTools, CACHE_TTL_MS } from './metrics.js';
+import { computeMetrics, groupBy, contextGrowthOf, parseTools, rootSessionOf, CACHE_TTL_MS } from './metrics.js';
 import { costOf } from './pricing.js';
 import { assignPersona } from './personas.js';
 import { structuredFindings, fmtMetric } from './followthrough.js';
@@ -36,6 +36,10 @@ export interface SessionStat {
   coldRestartTokens: number;
   durationMin: number;
   dominant: Activity;
+  /** This "session" is one subagent run, not a conversation someone had. */
+  isSidechain: boolean;
+  /** Subagent type, when the transcript named one. Local display only. */
+  agentType?: string;
 }
 
 export function computeSessionStats(events: StoredEvent[]): SessionStat[] {
@@ -80,9 +84,89 @@ export function computeSessionStats(events: StoredEvent[]): SessionStat[] {
       coldRestartTokens: coldTokens,
       durationMin: Math.max(0, Math.round((last - first) / 60_000)),
       dominant: ACTIVITIES.reduce((b, a) => (actTokens[a] > actTokens[b] ? a : b)),
+      isSidechain: evs[0].is_sidechain === 1,
+      agentType: evs.find((e) => e.agent_type)?.agent_type ?? undefined,
     });
   }
   return out;
+}
+
+/** One session's fan-out: what its subagent runs cost next to its own turns. */
+export interface FanOutStat {
+  sessionId: string;
+  project: string;
+  source: string;
+  agents: number;
+  agentSpendTokens: number;
+  agentCostUsd: number;
+  mainSpendTokens: number;
+  /** Subagent spend per main-loop token — 3.0 means the fan-out cost 3× the driver. */
+  ratio: number;
+}
+
+/**
+ * Fan-out per spawning session. Sessions with no subagent runs are omitted:
+ * the table exists to show where delegation concentrates, and a zero row says
+ * nothing. `ratio` divides by main-loop spend, so a session whose transcript
+ * has rotated away (agents on disk, driver gone) reports 0 rather than
+ * dividing by zero.
+ */
+export function computeFanOut(events: StoredEvent[]): FanOutStat[] {
+  const byRoot = new Map<string, { project: string; source: string; agents: Set<string>; agentSpend: number; agentCost: number; mainSpend: number }>();
+  for (const e of events) {
+    const root = rootSessionOf(e);
+    let s = byRoot.get(root);
+    if (!s) {
+      byRoot.set(root, (s = { project: e.project, source: e.source, agents: new Set(), agentSpend: 0, agentCost: 0, mainSpend: 0 }));
+    }
+    const spend = e.input_tokens + e.output_tokens;
+    if (e.is_sidechain) {
+      s.agents.add(e.session_id);
+      s.agentSpend += spend;
+      s.agentCost += costOf(e.model, e.input_tokens, e.output_tokens, e.cache_read_tokens, e.cache_creation_tokens).usd;
+    } else {
+      s.mainSpend += spend;
+      s.project = e.project; // the driver's own project label wins
+      s.source = e.source;
+    }
+  }
+  return [...byRoot.entries()]
+    .filter(([, s]) => s.agents.size > 0)
+    .map(([sessionId, s]) => ({
+      sessionId,
+      project: s.project,
+      source: s.source,
+      agents: s.agents.size,
+      agentSpendTokens: s.agentSpend,
+      agentCostUsd: s.agentCost,
+      mainSpendTokens: s.mainSpend,
+      ratio: s.mainSpend ? s.agentSpend / s.mainSpend : 0,
+    }))
+    .sort((a, b) => b.agentSpendTokens - a.agentSpendTokens);
+}
+
+/** Spend per subagent type. Local terminal only — see UsageEvent.agentType. */
+export interface AgentTypeStat {
+  agentType: string;
+  runs: number;
+  spendTokens: number;
+  costUsd: number;
+}
+
+export function computeAgentTypes(events: StoredEvent[]): AgentTypeStat[] {
+  const map = new Map<string, { runs: Set<string>; spendTokens: number; costUsd: number }>();
+  for (const e of events) {
+    if (!e.is_sidechain) continue;
+    const key = e.agent_type || 'unlabelled';
+    let s = map.get(key);
+    if (!s) map.set(key, (s = { runs: new Set(), spendTokens: 0, costUsd: 0 }));
+    s.runs.add(e.session_id);
+    s.spendTokens += e.input_tokens + e.output_tokens;
+    s.costUsd += costOf(e.model, e.input_tokens, e.output_tokens, e.cache_read_tokens, e.cache_creation_tokens).usd;
+  }
+  return [...map.entries()]
+    .map(([agentType, s]) => ({ agentType, runs: s.runs.size, spendTokens: s.spendTokens, costUsd: s.costUsd }))
+    .sort((a, b) => b.spendTokens - a.spendTokens);
 }
 
 export interface ToolStat {
@@ -128,6 +212,8 @@ export interface DeepAnalysis {
   bloatTrendSessions: SessionStat[];
   coldRestartSessions: SessionStat[];
   toolStats: ToolStat[];
+  fanOutSessions: FanOutStat[];
+  agentTypes: AgentTypeStat[];
 }
 
 export function deepAnalysis(events: StoredEvent[]): DeepAnalysis {
@@ -143,7 +229,9 @@ export function deepAnalysis(events: StoredEvent[]): DeepAnalysis {
       .sort((a, b) => b.avgContextTokens - a.avgContextTokens)
       .slice(0, 8),
     bloatTrendSessions: stats
-      .filter((s) => s.contextGrowth >= 2)
+      // Same exclusion as computeMetrics' trend denominator, for the same
+      // reason: you cannot compact a subagent run.
+      .filter((s) => !s.isSidechain && s.contextGrowth >= 2)
       .sort((a, b) => b.contextGrowth - a.contextGrowth)
       .slice(0, 8),
     coldRestartSessions: stats
@@ -151,6 +239,8 @@ export function deepAnalysis(events: StoredEvent[]): DeepAnalysis {
       .sort((a, b) => b.coldRestartTokens - a.coldRestartTokens)
       .slice(0, 8),
     toolStats: computeToolStats(events).slice(0, 15),
+    fanOutSessions: computeFanOut(events).slice(0, 8),
+    agentTypes: computeAgentTypes(events).slice(0, 10),
   };
 }
 
@@ -194,6 +284,9 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
       coldRestartShare: round(m.coldRestartShare),
       premiumWasteShare: round(m.premiumWasteShare),
       retryShare: round(m.retryShare),
+      subagentShare: round(m.subagentShare),
+      subagentSpendTokens: m.subagentSpendTokens,
+      subagentRuns: m.subagentSessions,
       activityShares: Object.fromEntries(
         ACTIVITIES.filter((a) => m.byActivity[a].tokens > 0).map((a) => [a, round(m.byActivity[a].share)]),
       ),
@@ -220,6 +313,16 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
     contextHeavySessions: deep.contextHeavySessions.map(slim),
     bloatTrendSessions: deep.bloatTrendSessions.map(slim),
     coldRestartSessions: deep.coldRestartSessions.map(slim),
+    // Fan-out carries no session ids and no agent-TYPE names: a custom
+    // subagent can be named after something private, so the type breakdown
+    // stays on the machine (see UsageEvent.agentType).
+    fanOutSessions: deep.fanOutSessions.slice(0, 5).map((f) => ({
+      project: f.project,
+      agents: f.agents,
+      agentSpendTokens: f.agentSpendTokens,
+      mainSpendTokens: f.mainSpendTokens,
+      ratio: round(f.ratio, 1),
+    })),
     toolErrorRates: deep.toolStats
       .filter((t) => t.errorRate > 0.05 && t.turns >= 20)
       .map((t) => ({ tool: t.tool, turns: t.turns, errorRate: round(t.errorRate, 2), retryTokens: t.retryTokens })),
@@ -237,7 +340,7 @@ export const TRACKABLE_METRICS: MetricKey[] = [
 ];
 
 const METRIC_DEFINITIONS =
-  'Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). contextGrowth = late-half avg context / early half per session; contextBloatShare = share of long sessions growing >=2x without cache keeping pace. coldRestartTokens = input re-paid on turns resuming after the ~5-min cache TTL; coldRestartShare = that over all fresh-paid input. premiumWasteShare = premium-model tokens on exploration/conversation turns / all spend. retryShare/retryTokens = spend on turns re-running a tool right after it errored. Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.';
+  'Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). contextGrowth = late-half avg context / early half per session; contextBloatShare = share of long sessions growing >=2x without cache keeping pace. coldRestartTokens = input re-paid on turns resuming after the ~5-min cache TTL; coldRestartShare = that over all fresh-paid input. premiumWasteShare = premium-model tokens on exploration/conversation turns / all spend. retryShare/retryTokens = spend on turns re-running a tool right after it errored. subagentShare = share of spend from subagent (Task/Agent fan-out) runs rather than the main loop; fanOutSessions lists the sessions that delegated most, with the subagent-to-main-loop spend ratio. Fan-out is not waste by default — flag it only when the delegated spend has nothing to show for it. Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.';
 
 export function buildLlmPrompt(events: StoredEvent[], days: number): string {
   return `You are an engineering-efficiency analyst. The JSON below contains AGGREGATE token-usage telemetry from AI coding agents (Claude Code / Gemini CLI / Codex) for one developer or team over ${days} days. There is no prompt or code content — only counts, ratios, tool names, and project names.
@@ -398,8 +501,14 @@ export function renderAnalysis(events: StoredEvent[], days: number): string {
   const deep = deepAnalysis(events);
   const m = computeMetrics(events);
   const out: string[] = [];
+  // A subagent run is a "session" only in the bookkeeping sense; mark it so a
+  // 40-agent fan-out doesn't read as 40 people-sized conversations.
+  const projCell = (s: SessionStat) => {
+    const p = s.project.length > 24 ? s.project.slice(0, 23) + '…' : s.project;
+    return s.isSidechain ? `↳ ${p}` : p;
+  };
   const sessRow = (s: SessionStat) => [
-    s.project.length > 24 ? s.project.slice(0, 23) + '…' : s.project,
+    projCell(s),
     s.source,
     String(s.turns),
     fmtTokens(s.spendTokens),
@@ -433,7 +542,7 @@ export function renderAnalysis(events: StoredEvent[], days: number): string {
       table(
         ['Project', 'Source', 'Turns', 'Ctx/turn', 'Growth', 'Span', 'Dominant'],
         deep.bloatTrendSessions.map((s) => [
-          s.project.length > 24 ? s.project.slice(0, 23) + '…' : s.project,
+          projCell(s),
           s.source,
           String(s.turns),
           fmtTokens(s.avgContextTokens),
@@ -450,7 +559,7 @@ export function renderAnalysis(events: StoredEvent[], days: number): string {
       table(
         ['Project', 'Source', 'Turns', 'Cold turns', 'Re-paid tokens', 'Span'],
         deep.coldRestartSessions.map((s) => [
-          s.project.length > 24 ? s.project.slice(0, 23) + '…' : s.project,
+          projCell(s),
           s.source,
           String(s.turns),
           String(s.coldRestartTurns),
@@ -458,6 +567,42 @@ export function renderAnalysis(events: StoredEvent[], days: number): string {
           s.durationMin + 'm',
         ]),
       ),
+    );
+  }
+  if (deep.fanOutSessions.length) {
+    out.push(
+      `\n${'\x1b[1m'}Subagent fan-out (spend the main transcript never mentions)${'\x1b[0m'}`,
+    );
+    out.push(
+      table(
+        ['Project', 'Source', 'Agents', 'Agent tokens', 'Agent cost', 'Main tokens', 'Agent:main'],
+        deep.fanOutSessions.map((f) => [
+          f.project.length > 24 ? f.project.slice(0, 23) + '…' : f.project,
+          f.source,
+          String(f.agents),
+          fmtTokens(f.agentSpendTokens),
+          '$' + f.agentCostUsd.toFixed(2),
+          fmtTokens(f.mainSpendTokens),
+          f.mainSpendTokens ? f.ratio.toFixed(1) + '×' : '—',
+        ]),
+      ),
+    );
+    if (deep.agentTypes.length) {
+      out.push(`\n${'\x1b[1m'}By subagent type${'\x1b[0m'}`);
+      out.push(
+        table(
+          ['Type', 'Runs', 'Tokens', 'Cost'],
+          deep.agentTypes.map((a) => [
+            a.agentType,
+            String(a.runs),
+            fmtTokens(a.spendTokens),
+            '$' + a.costUsd.toFixed(2),
+          ]),
+        ),
+      );
+    }
+    out.push(
+      `\n  ${'\x1b[2m'}${(m.subagentShare * 100).toFixed(1)}% of spend, ${m.subagentSessions} run(s). Delegation is not waste by itself — read it against what the fan-out produced. Subagent type names stay local; exports carry the share and counts only.${'\x1b[0m'}`,
     );
   }
   const failing = deep.toolStats.filter((t) => t.errorRate > 0.05 && t.turns >= 20);

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -220,26 +220,26 @@ export interface DeepAnalysis {
 
 export function deepAnalysis(events: StoredEvent[]): DeepAnalysis {
   const stats = computeSessionStats(events);
+  // Every list here describes a CONVERSATION. Subagent runs outnumber them
+  // ~14:1 and would otherwise fill all eight rows of the tables that are the
+  // only session-level evidence the terminal and the --llm payload get; their
+  // spend is reported in the fan-out and by-type tables instead.
+  const conversations = stats.filter((s) => !s.isSidechain);
   return {
-    expensiveSessions: [...stats].sort((a, b) => b.spendTokens - a.spendTokens).slice(0, 8),
-    fixLoopSessions: stats
+    expensiveSessions: [...conversations].sort((a, b) => b.spendTokens - a.spendTokens).slice(0, 8),
+    fixLoopSessions: conversations
       .filter((s) => s.fixIterations >= 2)
       .sort((a, b) => b.fixIterations - a.fixIterations)
       .slice(0, 8),
-    contextHeavySessions: stats
-      // avgContextTokens is a bloat proxy, so this list follows the same rule
-      // as the trend: agent runs outnumber conversations ~14:1 and would
-      // otherwise fill every row with sessions nobody can compact.
-      .filter((s) => !s.isSidechain && s.turns >= 10)
+    contextHeavySessions: conversations
+      .filter((s) => s.turns >= 10)
       .sort((a, b) => b.avgContextTokens - a.avgContextTokens)
       .slice(0, 8),
-    bloatTrendSessions: stats
-      // Same exclusion as computeMetrics' trend denominator, for the same
-      // reason: you cannot compact a subagent run.
-      .filter((s) => !s.isSidechain && s.contextGrowth >= 2)
+    bloatTrendSessions: conversations
+      .filter((s) => s.contextGrowth >= 2)
       .sort((a, b) => b.contextGrowth - a.contextGrowth)
       .slice(0, 8),
-    coldRestartSessions: stats
+    coldRestartSessions: conversations
       .filter((s) => s.coldRestartTurns > 0)
       .sort((a, b) => b.coldRestartTokens - a.coldRestartTokens)
       .slice(0, 8),
@@ -274,9 +274,6 @@ export function buildLlmPayload(events: StoredEvent[], days: number): object {
     coldRestartTokens: s.coldRestartTokens,
     durationMin: s.durationMin,
     dominant: s.dominant,
-    // A boolean, not a type name: the model must not read a 40-turn agent run
-    // as a 40-turn conversation and prescribe "compact this session".
-    isSidechain: s.isSidechain,
   });
   return {
     windowDays: days,
@@ -348,7 +345,7 @@ export const TRACKABLE_METRICS: MetricKey[] = [
 ];
 
 const METRIC_DEFINITIONS =
-  'Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). contextGrowth = late-half avg context / early half per session; contextBloatShare = share of long sessions growing >=2x without cache keeping pace. coldRestartTokens = input re-paid on turns resuming after the ~5-min cache TTL; coldRestartShare = that over all fresh-paid input. premiumWasteShare = premium-model tokens on exploration/conversation turns / all spend. retryShare/retryTokens = spend on turns re-running a tool right after it errored. subagentShare = share of spend from subagent (Task/Agent fan-out) runs rather than the main loop; fanOutSessions lists the sessions that delegated most, with the subagent-to-main-loop spend ratio. Fan-out is not waste by default — flag it only when the delegated spend has nothing to show for it. Session rows with isSidechain=true are ONE subagent run, not a conversation: never advise compacting, restarting or batching them (they are spawned fresh and exit), and note that contextBloatShare and coldRestartShare are measured over main-loop sessions only. Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.';
+  'Definitions: reworkRatio = share of tokens spent on coding/testing turns after the first failed turn in a session (fix loops). cacheHitRatio = cache reads / all input-side tokens (reads cost ~10% of fresh input). thinkToCodeRatio = (planning+exploration tokens) / coding tokens. fixIterations = testing->coding transitions in one session. avgContextTokens = mean context fed per turn (bloat proxy). contextGrowth = late-half avg context / early half per session; contextBloatShare = share of long sessions growing >=2x without cache keeping pace. coldRestartTokens = input re-paid on turns resuming after the ~5-min cache TTL; coldRestartShare = that over MAIN-LOOP fresh-paid input (subagent runs are excluded from both sides). premiumWasteShare = premium-model tokens on exploration/conversation turns / all spend. retryShare/retryTokens = spend on turns re-running a tool right after it errored. subagentShare = share of spend from subagent (Task/Agent fan-out) runs rather than the main loop; fanOutSessions lists the sessions that delegated most, with the subagent-to-main-loop spend ratio. Fan-out is not waste by default — flag it only when the delegated spend has nothing to show for it. Every per-session list (expensiveSessions, fixLoopSessions, contextHeavySessions, bloatTrendSessions, coldRestartSessions) contains CONVERSATIONS only; subagent runs appear solely as aggregates in fanOutSessions, so never advise compacting, restarting or batching a subagent run. contextBloatShare and coldRestartShare are measured over main-loop sessions only. Personas: architect (plans first), surgeon (precise, low waste), explorer (heavy reading), sprinter (codes first, reworks later), firefighter (test-fail loops), balanced.';
 
 export function buildLlmPrompt(events: StoredEvent[], days: number): string {
   return `You are an engineering-efficiency analyst. The JSON below contains AGGREGATE token-usage telemetry from AI coding agents (Claude Code / Gemini CLI / Codex) for one developer or team over ${days} days. There is no prompt or code content — only counts, ratios, tool names, and project names.

--- a/src/categorize.ts
+++ b/src/categorize.ts
@@ -18,7 +18,7 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { loadEvents, recordIntents, loadIntents } from './store.js';
 import type { StoredEvent, IntentRow } from './store.js';
-import { groupBy, parseTools } from './metrics.js';
+import { groupByRootSession, parseTools } from './metrics.js';
 import { costOf } from './pricing.js';
 import { ADAPTERS } from './adapters/index.js';
 import type { Source } from './types.js';
@@ -63,6 +63,13 @@ interface SessionAgg {
   tools: string[];
 }
 
+/**
+ * Aggregate ONE task: a session's own turns plus the subagent runs it spawned
+ * (groupByRootSession). Fan-out cost belongs to the task that delegated it —
+ * otherwise a category's $ silently omits whatever the agents spent, and a
+ * duplicate-work finding under-prices itself by exactly the delegated share.
+ * The session id stays the human session's, so the frozen intent still joins.
+ */
 function aggregateSession(sessionId: string, evs: StoredEvent[]): SessionAgg {
   let tokens = 0, cost = 0, estimated = false;
   const tools = new Set<string>();
@@ -128,7 +135,7 @@ export function runCategorize(
   const events = loadEvents(db, { days: opts.days, project: opts.project, source: opts.source });
   const days = opts.days ?? 30;
 
-  const aggs = [...groupBy(events, 'session_id').entries()].map(([id, evs]) => aggregateSession(id, evs));
+  const aggs = [...groupByRootSession(events).entries()].map(([id, evs]) => aggregateSession(id, evs));
   if (aggs.length === 0) {
     return { days, totalSessions: 0, textSessions: 0, categories: [], duplicates: [], skillCandidates: [] };
   }
@@ -254,7 +261,7 @@ export function categorizeSummary(
 ): CategorizeSummary | undefined {
   const events = loadEvents(db, { days: opts.days, project: opts.project, source: opts.source });
   if (events.length === 0) return undefined;
-  const aggs = [...groupBy(events, 'session_id').entries()].map(([id, evs]) => aggregateSession(id, evs));
+  const aggs = [...groupByRootSession(events).entries()].map(([id, evs]) => aggregateSession(id, evs));
   const frozen = loadIntents(db, aggs.map((a) => a.sessionId));
   if (frozen.size === 0) return undefined;
   const { duplicates } = buildResult(aggs, frozen, opts.days ?? 30, opts);

--- a/src/causes.ts
+++ b/src/causes.ts
@@ -52,8 +52,13 @@ const spendOf = (e: StoredEvent) => e.input_tokens + e.output_tokens;
 function decomposeCacheHit(sessions: StoredEvent[][]): Cause[] {
   const b = { cold: 0, short: 0, churn: 0, steady: 0 };
   for (const arr of sessions) {
-    const short = arr.length < SHORT_SESSION_TURNS;
-    const growth = contextGrowthOf(arr);
+    // Mirror metrics.ts on subagent runs too: they never idle and cannot be
+    // compacted, so their fresh input is steady-state here rather than a cold
+    // restart or context churn. Without this the same report can print "cold
+    // restarts 0%" and "dominant cause: cold restarts (83%)".
+    const sidechain = arr.some((e) => e.is_sidechain === 1);
+    const short = !sidechain && arr.length < SHORT_SESSION_TURNS;
+    const growth = sidechain ? undefined : contextGrowthOf(arr);
     // Mirror metrics.ts exactly: late-half growth only counts as churn when it
     // is re-paid FRESH, not served from cache. Otherwise a well-cached session
     // would be mislabelled, contradicting the tool's own contextBloatShare.
@@ -63,7 +68,7 @@ function decomposeCacheHit(sessions: StoredEvent[][]): Cause[] {
     for (let i = 0; i < arr.length; i++) {
       const f = freshOf(arr[i]);
       if (f === 0) continue;
-      if (i > 0 && Date.parse(arr[i].ts) - Date.parse(arr[i - 1].ts) > CACHE_TTL_MS) {
+      if (!sidechain && i > 0 && Date.parse(arr[i].ts) - Date.parse(arr[i - 1].ts) > CACHE_TTL_MS) {
         b.cold += f;
       } else if (short) {
         b.short += f;

--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -96,12 +96,15 @@ export function structuredFindings(m: Metrics): Finding[] {
       message: `${m.bloatedSessions} of ${m.trendSessions} long sessions grow their context ≥2× without cache reads keeping pace — start a fresh session or compact at task boundaries before the context balloons.`,
     });
   }
-  if (m.coldRestartShare >= 0.2 && m.spendTokens > 100_000) {
+  // Volume gate on MAIN-LOOP spend: the ratio is measured over main-loop
+  // fresh input, so a 20k-token conversation must not clear the bar on the
+  // back of 500k spent by its subagents.
+  if (m.coldRestartShare >= 0.2 && m.spendTokens - (m.subagentSpendTokens ?? 0) > 100_000) {
     out.push({
       key: 'cold-restarts',
       metric: 'coldRestartShare',
       direction: 'down',
-      message: `${(m.coldRestartShare * 100).toFixed(0)}% of fresh input tokens were re-paid on ${m.coldRestartTurns} turns that resumed after the ~5-min cache TTL. Batch prompts within the cache window, or split long-idle work into new sessions.`,
+      message: `${(m.coldRestartShare * 100).toFixed(0)}% of main-loop fresh input tokens were re-paid on ${m.coldRestartTurns} turns that resumed after the ~5-min cache TTL. Batch prompts within the cache window, or split long-idle work into new sessions.`,
     });
   }
   if (m.premiumWasteShare >= 0.3 && m.spendTokens > 100_000) {

--- a/src/html.ts
+++ b/src/html.ts
@@ -5,7 +5,7 @@ import { ACTIVITIES } from './types.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
-import { fmtTokens } from './report.js';
+import { fmtTokens, fmtSubagents } from './report.js';
 import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
 import { mergeMetrics, rollupExports, displayName } from './team.js';
 import { enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
@@ -72,6 +72,9 @@ export function renderHtml(
     ['Spend tokens', fmtTokens(m.spendTokens)],
     ['Cache hit', pct(m.cacheHitRatio)],
     ['Rework', pct(m.reworkRatio)],
+    // Only when there IS fan-out — see fmtSubagents on why a standing 0% card
+    // would be noise on the five sources that never write sidechain turns.
+    ...(m.subagentSessions ? [['Subagent spend', pct(m.subagentShare)]] : []),
     ['Est. cost', cost(m)],
   ]
     .map(([k, v]) => `<div class="card"><div class="k">${k}</div><div class="v">${v}</div></div>`)
@@ -143,7 +146,7 @@ export function renderHtml(
 ${stackedBar(m)}
 <div class="legend">${legend}</div>
 <p class="muted">rework ${pct(m.reworkRatio)} · think:code ${m.thinkToCodeRatio.toFixed(2)} · ${m.errorEvents} turns hit tool errors</p>
-<p class="muted">signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions · cold restarts ${pct(m.coldRestartShare)} of fresh input · premium on exploration/chat ${pct(m.premiumWasteShare)} · retry loops ${pct(m.retryShare)}</p>
+<p class="muted">signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions · cold restarts ${pct(m.coldRestartShare)} of fresh input · premium on exploration/chat ${pct(m.premiumWasteShare)} · retry loops ${pct(m.retryShare)}${esc(fmtSubagents(m))}</p>
 ${opts.categorize ? `<p class="dup">🔁 ${esc(fmtCategorizeSummary(opts.categorize))} <span class="muted">— run <code>categorize</code> for detail</span></p>` : ''}
 
 <h2>Projects</h2>

--- a/src/html.ts
+++ b/src/html.ts
@@ -146,7 +146,7 @@ export function renderHtml(
 ${stackedBar(m)}
 <div class="legend">${legend}</div>
 <p class="muted">rework ${pct(m.reworkRatio)} · think:code ${m.thinkToCodeRatio.toFixed(2)} · ${m.errorEvents} turns hit tool errors</p>
-<p class="muted">signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions · cold restarts ${pct(m.coldRestartShare)} of fresh input · premium on exploration/chat ${pct(m.premiumWasteShare)} · retry loops ${pct(m.retryShare)}${esc(fmtSubagents(m))}</p>
+<p class="muted">signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions · cold restarts ${pct(m.coldRestartShare)} of main-loop fresh input · premium on exploration/chat ${pct(m.premiumWasteShare)} · retry loops ${pct(m.retryShare)}${esc(fmtSubagents(m))}</p>
 ${opts.categorize ? `<p class="dup">🔁 ${esc(fmtCategorizeSummary(opts.categorize))} <span class="muted">— run <code>categorize</code> for detail</span></p>` : ''}
 
 <h2>Projects</h2>

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -99,7 +99,9 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
   for (const e of events) {
     sessions.add(rootSessionOf(e));
     if (e.is_sidechain) {
-      subagentSessions.add(e.session_id);
+      // A legacy inlined sidechain turn has no transcript of its own, so its
+      // session id IS the parent's — counting it would invent a run.
+      if (e.session_id !== e.parent_session_id) subagentSessions.add(e.session_id);
       subagentSpendTokens += e.input_tokens + e.output_tokens;
     } else {
       mainFreshPaid += e.input_tokens + e.cache_creation_tokens;
@@ -155,15 +157,19 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
       }
     }
 
+    // Both hygiene signals below describe the CONVERSATION, so they run over
+    // the group's main-loop turns only. Filtering per row rather than per
+    // group also handles the legacy transcripts that inlined sidechain turns
+    // under the main session id, where the group is mixed.
+    const mainRows = arr.some((e) => e.is_sidechain) ? arr.filter((e) => !e.is_sidechain) : arr;
+
     // Session hygiene: a gap past the cache TTL means this turn re-paid its
     // context as fresh input / a new cache write instead of a cheap read.
     // Subagent runs sit out both sides of this ratio — see coldRestartShare.
-    if (!arr[0].is_sidechain) {
-      for (let i = 1; i < arr.length; i++) {
-        if (Date.parse(arr[i].ts) - Date.parse(arr[i - 1].ts) > CACHE_TTL_MS) {
-          coldRestartTurns++;
-          coldRestartTokens += arr[i].input_tokens + arr[i].cache_creation_tokens;
-        }
+    for (let i = 1; i < mainRows.length; i++) {
+      if (Date.parse(mainRows[i].ts) - Date.parse(mainRows[i - 1].ts) > CACHE_TTL_MS) {
+        coldRestartTurns++;
+        coldRestartTokens += mainRows[i].input_tokens + mainRows[i].cache_creation_tokens;
       }
     }
 
@@ -174,7 +180,7 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
     // the remedy for bloat is to compact or restart, and a subagent is spawned
     // fresh, does one job, and exits. (Their spend still counts everywhere
     // else — this is about which sessions the ratio describes.)
-    const growth = arr[0].is_sidechain ? undefined : contextGrowthOf(arr);
+    const growth = mainRows.length ? contextGrowthOf(mainRows) : undefined;
     if (growth !== undefined) {
       trendSessions++;
       if (growth.ratio >= BLOAT_GROWTH && growth.lateFreshShare >= BLOAT_FRESH_SHARE) bloatedSessions++;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -47,11 +47,20 @@ export interface Metrics {
   /** Trend sessions whose late-half context grew ≥2× without cache keeping pace. */
   bloatedSessions: number;
   contextBloatShare: number;
-  /** Turns arriving after a gap past the cache TTL, and the input-side tokens they re-paid. */
+  /**
+   * Turns arriving after a gap past the cache TTL, and the input-side tokens
+   * they re-paid. Main-loop only, numerator AND denominator: a subagent run is
+   * a back-to-back burst that never idles, so counting its fresh input in the
+   * denominator would dilute the ratio toward zero while contributing almost
+   * nothing to the top — and its remedy (batch prompts, split idle work) is
+   * not something anyone can apply to a run that is spawned and exits.
+   */
   coldRestartTurns: number;
   coldRestartTokens: number;
-  /** Re-paid tokens as a share of all fresh-paid input (input + cache writes). */
+  /** Re-paid tokens as a share of main-loop fresh-paid input (input + cache writes). */
   coldRestartShare: number;
+  /** That denominator, carried so a team merge can recombine the ratio exactly. */
+  coldRestartBaseTokens: number;
   /** Premium-model tokens spent on exploration/conversation turns. */
   premiumWasteTokens: number;
   premiumWasteShare: number;
@@ -81,6 +90,7 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
   let costUsd = 0, costEstimated = false, unpriced = 0, errorEvents = 0;
   let premiumWasteTokens = 0;
   let subagentSpendTokens = 0;
+  let mainFreshPaid = 0;
   const subagentSessions = new Set<string>();
 
   // Rework: group by session, walk chronologically, count spend after first failed event.
@@ -91,6 +101,8 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
     if (e.is_sidechain) {
       subagentSessions.add(e.session_id);
       subagentSpendTokens += e.input_tokens + e.output_tokens;
+    } else {
+      mainFreshPaid += e.input_tokens + e.cache_creation_tokens;
     }
     input += e.input_tokens;
     output += e.output_tokens;
@@ -145,10 +157,13 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
 
     // Session hygiene: a gap past the cache TTL means this turn re-paid its
     // context as fresh input / a new cache write instead of a cheap read.
-    for (let i = 1; i < arr.length; i++) {
-      if (Date.parse(arr[i].ts) - Date.parse(arr[i - 1].ts) > CACHE_TTL_MS) {
-        coldRestartTurns++;
-        coldRestartTokens += arr[i].input_tokens + arr[i].cache_creation_tokens;
+    // Subagent runs sit out both sides of this ratio — see coldRestartShare.
+    if (!arr[0].is_sidechain) {
+      for (let i = 1; i < arr.length; i++) {
+        if (Date.parse(arr[i].ts) - Date.parse(arr[i - 1].ts) > CACHE_TTL_MS) {
+          coldRestartTurns++;
+          coldRestartTokens += arr[i].input_tokens + arr[i].cache_creation_tokens;
+        }
       }
     }
 
@@ -201,7 +216,8 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
     contextBloatShare: trendSessions ? bloatedSessions / trendSessions : 0,
     coldRestartTurns,
     coldRestartTokens,
-    coldRestartShare: input + cacheCreate ? coldRestartTokens / (input + cacheCreate) : 0,
+    coldRestartShare: mainFreshPaid ? coldRestartTokens / mainFreshPaid : 0,
+    coldRestartBaseTokens: mainFreshPaid,
     premiumWasteTokens,
     premiumWasteShare: spendTokens ? premiumWasteTokens / spendTokens : 0,
     retryTokens,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -10,6 +10,16 @@ export const BLOAT_MIN_TURNS = 8;
 export const BLOAT_GROWTH = 2; // late-half avg context ≥ 2× early half
 export const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-paid fresh
 
+/**
+ * The conversation a turn belongs to from the user's point of view: a subagent
+ * run counts under the session that spawned it, everything else under itself.
+ * `sessions` counts these, so a fan-out of 40 agents stays ONE session in the
+ * report while each run keeps its own chronology for per-session math.
+ */
+export function rootSessionOf(e: StoredEvent): string {
+  return e.parent_session_id || e.session_id;
+}
+
 export interface Metrics {
   events: number;
   sessions: number;
@@ -48,6 +58,16 @@ export interface Metrics {
   /** Tokens on turns re-running a tool that errored in the immediately previous turn. */
   retryTokens: number;
   retryShare: number;
+  /** Subagent (sidechain) runs seen in the window, and what they spent. */
+  subagentSessions: number;
+  subagentSpendTokens: number;
+  /**
+   * Subagent spend as a share of all spend. Descriptive, NOT a waste signal:
+   * fan-out is often exactly the right way to do the work. It is here because
+   * every other number moves when it is counted — and until this release it
+   * was not counted at all.
+   */
+  subagentShare: number;
 }
 
 export function computeMetrics(events: StoredEvent[]): Metrics {
@@ -60,12 +80,18 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
   let input = 0, output = 0, cacheRead = 0, cacheCreate = 0, thinking = 0;
   let costUsd = 0, costEstimated = false, unpriced = 0, errorEvents = 0;
   let premiumWasteTokens = 0;
+  let subagentSpendTokens = 0;
+  const subagentSessions = new Set<string>();
 
   // Rework: group by session, walk chronologically, count spend after first failed event.
   const bySession = new Map<string, StoredEvent[]>();
 
   for (const e of events) {
-    sessions.add(e.session_id);
+    sessions.add(rootSessionOf(e));
+    if (e.is_sidechain) {
+      subagentSessions.add(e.session_id);
+      subagentSpendTokens += e.input_tokens + e.output_tokens;
+    }
     input += e.input_tokens;
     output += e.output_tokens;
     cacheRead += e.cache_read_tokens;
@@ -126,8 +152,14 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
       }
     }
 
-    // Context bloat trend: late-half avg context vs early half.
-    const growth = contextGrowthOf(arr);
+    // Context bloat trend: late-half avg context vs early half. Subagent runs
+    // are deliberately NOT trend sessions. They are long enough to qualify and
+    // there are far more of them than there are conversations, so counting
+    // them would bury the signal in a denominator of runs nobody can act on:
+    // the remedy for bloat is to compact or restart, and a subagent is spawned
+    // fresh, does one job, and exits. (Their spend still counts everywhere
+    // else — this is about which sessions the ratio describes.)
+    const growth = arr[0].is_sidechain ? undefined : contextGrowthOf(arr);
     if (growth !== undefined) {
       trendSessions++;
       if (growth.ratio >= BLOAT_GROWTH && growth.lateFreshShare >= BLOAT_FRESH_SHARE) bloatedSessions++;
@@ -174,6 +206,9 @@ export function computeMetrics(events: StoredEvent[]): Metrics {
     premiumWasteShare: spendTokens ? premiumWasteTokens / spendTokens : 0,
     retryTokens,
     retryShare: spendTokens ? retryTokens / spendTokens : 0,
+    subagentSessions: subagentSessions.size,
+    subagentSpendTokens,
+    subagentShare: spendTokens ? subagentSpendTokens / spendTokens : 0,
   };
 }
 
@@ -204,6 +239,23 @@ export function contextGrowthOf(
   if (!earlyCtx || !lateCtxTotal) return undefined;
   const lateFresh = late.reduce((s, e) => s + e.input_tokens + e.cache_creation_tokens, 0);
   return { ratio: lateCtxTotal / half / earlyCtx, lateFreshShare: lateFresh / lateCtxTotal };
+}
+
+/**
+ * Group turns under the conversation a person actually had: a session plus
+ * every subagent run it spawned. Used where the unit of analysis is the TASK
+ * (what did this piece of work cost, what was it about) rather than the
+ * chronology of one transcript.
+ */
+export function groupByRootSession(events: StoredEvent[]): Map<string, StoredEvent[]> {
+  const map = new Map<string, StoredEvent[]>();
+  for (const e of events) {
+    const k = rootSessionOf(e);
+    let arr = map.get(k);
+    if (!arr) map.set(k, (arr = []));
+    arr.push(e);
+  }
+  return map;
 }
 
 export function groupBy<K extends keyof StoredEvent>(events: StoredEvent[], key: K): Map<string, StoredEvent[]> {

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -24,7 +24,11 @@ export interface ModelPrice {
 // cacheWrite is 0 for both (their adapters report cacheCreationTokens 0).
 export const PRICES: ModelPrice[] = [
   { match: /claude-fable-5|claude-mythos-5/, input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  { match: /claude-opus-5/, input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   { match: /claude-opus-4/, input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  // Standard rate. An introductory $2/$10 runs through 2026-08-31; the table
+  // carries the durable number rather than one that silently goes stale.
+  { match: /claude-sonnet-5/, input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   { match: /claude-sonnet-4/, input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   { match: /claude-haiku-4/, input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
 

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -79,7 +79,12 @@ export function targetFor(key: string, sessions: SessionInfo[]): Target | undefi
   const spec = PERSONAL_TARGET[key];
   if (spec) {
     const values = sessions
-      .filter((s) => s.m.spendTokens >= PERSONAL_MIN_SPEND)
+      // "Your own best sessions prove this is reachable" is a claim about the
+      // user's conversations. A subagent run reports 0 on the main-loop-scoped
+      // hygiene ratios by construction (its denominator is empty), so leaving
+      // runs in would drag every personal target to 0 and tell the user their
+      // top quartile already runs perfectly.
+      .filter((s) => !s.isSidechain && s.m.spendTokens >= PERSONAL_MIN_SPEND)
       .map((s) => spec.metric(s.m))
       .sort((a, b) => a - b);
     if (values.length >= PERSONAL_MIN_SESSIONS) {
@@ -194,7 +199,7 @@ const SCORERS: Record<string, (s: SessionInfo) => { score: number; label: string
     label: `${fmtTokens(premiumTokensOf(s.m))} premium tok`,
   }),
   'context-bloat': (s) => {
-    const growth = s.isSidechain ? undefined : contextGrowthOf(s.events);
+    const growth = contextGrowthOf(s.events);
     return {
       score: growth && growth.ratio >= 2 ? bloatAvoidableTokens(s.events) : 0,
       label: `ctx ×${growth ? growth.ratio.toFixed(1) : '?'} · ${fmtTokens(bloatAvoidableTokens(s.events))} avoidable`,
@@ -238,7 +243,12 @@ function savingsUsd(
     case 'premium-misroute':
       return m.premiumWasteTokens * Math.max(0, rates.premium - rates.cheap);
     case 'cold-restarts': {
-      const saved = Math.max(0, m.coldRestartShare - (target?.value ?? 0)) * (m.inputTokens + m.cacheCreationTokens);
+      // Price against the SAME population the ratio is measured over
+      // (main-loop fresh-paid input), or the number is inflated by the whole
+      // fan-out. Pre-0.12 exports have no base and no subagent rows either,
+      // so their own fresh-paid input is the right one.
+      const base = m.coldRestartBaseTokens ?? m.inputTokens + m.cacheCreationTokens;
+      const saved = Math.max(0, m.coldRestartShare - (target?.value ?? 0)) * base;
       return saved * (rates.input - rates.cacheRead);
     }
     case 'context-bloat': {
@@ -273,8 +283,14 @@ export function enrichFindings(events: StoredEvent[], m: Metrics, days: number):
   return findings
     .map((f) => {
       const scorer = SCORERS[f.key];
+      // Evidence names sessions the user can go and change, so it ranks
+      // conversations only. Subagent runs outnumber them ~14:1 and each turn
+      // carries more absolute context, so leaving them in fills every "worst
+      // 3 sessions" line with anonymous runs nobody can act on — their spend
+      // is accounted for in the metric itself and in analyze's fan-out table.
       const evidence = scorer
         ? sessions
+            .filter((s) => !s.isSidechain)
             .map((s) => ({ s, ...scorer(s) }))
             .filter((x) => x.score > 0)
             .sort((a, b) => b.score - a.score)
@@ -382,7 +398,8 @@ function unitValuePerPoint(metric: MetricKey, m: Metrics, rates: BlendedRates): 
     case 'premiumWasteShare':
       return m.spendTokens * Math.max(0, rates.premium - rates.cheap);
     case 'coldRestartShare':
-      return (m.inputTokens + m.cacheCreationTokens) * (rates.input - rates.cacheRead);
+      // Same population as the ratio — see savingsUsd('cold-restarts').
+      return (m.coldRestartBaseTokens ?? m.inputTokens + m.cacheCreationTokens) * (rates.input - rates.cacheRead);
     default:
       return undefined; // thinkToCodeRatio, contextBloatShare: not $-translatable
   }

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -96,6 +96,13 @@ interface SessionInfo {
   date: string;
   m: Metrics;
   events: StoredEvent[];
+  /**
+   * One subagent run rather than a conversation. Context-bloat pricing and
+   * evidence skip these, because `contextBloatShare` — the metric that gates
+   * the finding — excludes them: scoring a fan-out here would bill the user
+   * for sessions the gate never counted and cite runs nobody can compact.
+   */
+  isSidechain: boolean;
 }
 
 /** $/token rates blended over the user's actual model mix in the window. */
@@ -187,7 +194,7 @@ const SCORERS: Record<string, (s: SessionInfo) => { score: number; label: string
     label: `${fmtTokens(premiumTokensOf(s.m))} premium tok`,
   }),
   'context-bloat': (s) => {
-    const growth = contextGrowthOf(s.events);
+    const growth = s.isSidechain ? undefined : contextGrowthOf(s.events);
     return {
       score: growth && growth.ratio >= 2 ? bloatAvoidableTokens(s.events) : 0,
       label: `ctx ×${growth ? growth.ratio.toFixed(1) : '?'} · ${fmtTokens(bloatAvoidableTokens(s.events))} avoidable`,
@@ -236,7 +243,7 @@ function savingsUsd(
     }
     case 'context-bloat': {
       const avoidable = sessions.reduce((s, info) => {
-        const g = contextGrowthOf(info.events);
+        const g = info.isSidechain ? undefined : contextGrowthOf(info.events);
         return g && g.ratio >= 2 ? s + bloatAvoidableTokens(info.events) : s;
       }, 0);
       // Conservative: avoided fresh context would have been cache reads at best.
@@ -258,6 +265,7 @@ export function enrichFindings(events: StoredEvent[], m: Metrics, days: number):
     date: evs[0].ts.slice(0, 10),
     m: computeMetrics(evs),
     events: evs,
+    isSidechain: evs[0].is_sidechain === 1,
   }));
   const rates = blendedRates(m);
   const monthly = days > 0 ? 30 / days : 1;

--- a/src/report.ts
+++ b/src/report.ts
@@ -117,7 +117,7 @@ export function renderReport(
     `\n  ${DIM}rework ratio ${(m.reworkRatio * 100).toFixed(1)}%  ·  think:code ${m.thinkToCodeRatio.toFixed(2)}  ·  ${m.errorEvents} turns hit tool errors${RESET}`,
   );
   out.push(
-    `  ${DIM}signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions  ·  cold restarts ${(m.coldRestartShare * 100).toFixed(0)}% of fresh input  ·  premium on exploration/chat ${(m.premiumWasteShare * 100).toFixed(0)}%  ·  retry loops ${(m.retryShare * 100).toFixed(1)}%${fmtSubagents(m)}${RESET}`,
+    `  ${DIM}signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions  ·  cold restarts ${(m.coldRestartShare * 100).toFixed(0)}% of main-loop fresh input  ·  premium on exploration/chat ${(m.premiumWasteShare * 100).toFixed(0)}%  ·  retry loops ${(m.retryShare * 100).toFixed(1)}%${fmtSubagents(m)}${RESET}`,
   );
   if (opts.categorize) {
     out.push(

--- a/src/report.ts
+++ b/src/report.ts
@@ -36,6 +36,17 @@ function fmtCost(m: Metrics): string {
   return s;
 }
 
+/**
+ * Subagent clause for the signals line, empty when no fan-out was collected —
+ * five of six sources never produce sidechain turns, and a permanent "0%" on
+ * their reports would be noise pretending to be a measurement.
+ */
+export function fmtSubagents(m: Metrics): string {
+  if (!m.subagentSessions) return '';
+  const runs = m.subagentSessions === 1 ? '1 run' : `${m.subagentSessions} runs`;
+  return `  ·  subagents ${(m.subagentShare * 100).toFixed(0)}% of spend (${runs})`;
+}
+
 function bar(share: number, width = 24): string {
   const filled = Math.round(share * width);
   return '█'.repeat(filled) + DIM + '░'.repeat(width - filled) + RESET;
@@ -106,7 +117,7 @@ export function renderReport(
     `\n  ${DIM}rework ratio ${(m.reworkRatio * 100).toFixed(1)}%  ·  think:code ${m.thinkToCodeRatio.toFixed(2)}  ·  ${m.errorEvents} turns hit tool errors${RESET}`,
   );
   out.push(
-    `  ${DIM}signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions  ·  cold restarts ${(m.coldRestartShare * 100).toFixed(0)}% of fresh input  ·  premium on exploration/chat ${(m.premiumWasteShare * 100).toFixed(0)}%  ·  retry loops ${(m.retryShare * 100).toFixed(1)}%${RESET}`,
+    `  ${DIM}signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions  ·  cold restarts ${(m.coldRestartShare * 100).toFixed(0)}% of fresh input  ·  premium on exploration/chat ${(m.premiumWasteShare * 100).toFixed(0)}%  ·  retry loops ${(m.retryShare * 100).toFixed(1)}%${fmtSubagents(m)}${RESET}`,
   );
   if (opts.categorize) {
     out.push(

--- a/src/store.ts
+++ b/src/store.ts
@@ -32,6 +32,11 @@ export function openDb(path: string = DEFAULT_DB): DatabaseSync {
     );
     CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
     CREATE INDEX IF NOT EXISTS idx_events_project ON events(project);
+    -- relabelEvents and syncIntentProjects look rows up one session at a time.
+    -- Without this every collect ran a full table scan PER SESSION, which was
+    -- survivable at ~150 sessions and became minutes once subagent runs made
+    -- it thousands: measured 8m16s -> 17s on a 165k-row database.
+    CREATE INDEX IF NOT EXISTS idx_events_session ON events(source, session_id);
   `);
   migrate(db);
   return db;

--- a/src/store.ts
+++ b/src/store.ts
@@ -32,11 +32,6 @@ export function openDb(path: string = DEFAULT_DB): DatabaseSync {
     );
     CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
     CREATE INDEX IF NOT EXISTS idx_events_project ON events(project);
-    -- relabelEvents and syncIntentProjects look rows up one session at a time.
-    -- Without this every collect ran a full table scan PER SESSION, which was
-    -- survivable at ~150 sessions and became minutes once subagent runs made
-    -- it thousands: measured 8m16s -> 17s on a 165k-row database.
-    CREATE INDEX IF NOT EXISTS idx_events_session ON events(source, session_id);
   `);
   migrate(db);
   return db;
@@ -66,6 +61,16 @@ function migrate(db: DatabaseSync): void {
     ['parent_session_id', 'TEXT'],
     ['agent_type', 'TEXT'],
   ];
+  // relabelEvents and syncIntentProjects look rows up one session at a time.
+  // Without this every collect ran a full table scan PER SESSION — survivable
+  // at ~150 sessions, minutes once subagent runs make it thousands (measured
+  // 8m16s -> 5.2s on a 165k-row database). Same try/catch as the ALTERs
+  // below: a DB that can't be written must still open for reading.
+  try {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_events_session ON events(source, session_id)`);
+  } catch {
+    /* read-only DB: reads still work, the index appears on the first writable open */
+  }
   for (const [name, type] of wanted) {
     if (cols.has(name)) continue;
     try {

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,20 +33,44 @@ export function openDb(path: string = DEFAULT_DB): DatabaseSync {
     CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
     CREATE INDEX IF NOT EXISTS idx_events_project ON events(project);
   `);
-  // Migrate dbs created before project-family relabeling: project_raw keeps
-  // the pre-relabel label so every relabel is auditable and reversible in one
-  // statement (UPDATE events SET project = project_raw WHERE project_raw IS
-  // NOT NULL). Mirrors the followthrough `origin` PRAGMA-guard precedent.
-  const cols = db.prepare(`PRAGMA table_info(events)`).all() as Array<{ name: string }>;
-  if (!cols.some((c) => c.name === 'project_raw')) {
+  migrate(db);
+  return db;
+}
+
+/**
+ * Additive column migrations, PRAGMA-guarded (the followthrough `origin`
+ * precedent). Each is nullable or has a constant default, so an old row keeps
+ * a truthful value without a backfill:
+ *
+ * - `project_raw` — the pre-relabel project label, so every project-family
+ *   relabel is auditable and reversible in one statement (UPDATE events SET
+ *   project = project_raw WHERE project_raw IS NOT NULL).
+ * - `is_sidechain` / `parent_session_id` / `agent_type` — subagent accounting.
+ *   Defaulting old rows to 0/NULL is correct rather than merely convenient:
+ *   before this version `collect` never read a subagent transcript, so every
+ *   pre-existing row genuinely IS a main-loop turn. The missing subagent rows
+ *   backfill themselves on the next collect from the transcripts still on disk.
+ */
+function migrate(db: DatabaseSync): void {
+  const cols = new Set(
+    (db.prepare(`PRAGMA table_info(events)`).all() as Array<{ name: string }>).map((c) => c.name),
+  );
+  const wanted: Array<[string, string]> = [
+    ['project_raw', 'TEXT'],
+    ['is_sidechain', 'INTEGER NOT NULL DEFAULT 0'],
+    ['parent_session_id', 'TEXT'],
+    ['agent_type', 'TEXT'],
+  ];
+  for (const [name, type] of wanted) {
+    if (cols.has(name)) continue;
     try {
-      db.exec(`ALTER TABLE events ADD COLUMN project_raw TEXT`);
+      db.exec(`ALTER TABLE events ADD COLUMN ${name} ${type}`);
     } catch {
-      // Read-only pre-0.11 DB: skip the migration so read paths still work;
-      // the column appears on the first writable open.
+      // Read-only or otherwise locked older DB: skip the migration so read
+      // paths still work (loadEvents substitutes defaults for columns that
+      // aren't there); the column appears on the first writable open.
     }
   }
-  return db;
 }
 
 export function insertEvents(db: DatabaseSync, events: UsageEvent[]): number {
@@ -54,8 +78,9 @@ export function insertEvents(db: DatabaseSync, events: UsageEvent[]): number {
     INSERT OR IGNORE INTO events
       (source, event_key, session_id, project, ts, model,
        input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, thinking_tokens,
-       tools, has_thinking, is_error, git_branch, activity)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       tools, has_thinking, is_error, git_branch, activity,
+       is_sidechain, parent_session_id, agent_type)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   let inserted = 0;
   db.exec('BEGIN');
@@ -66,6 +91,7 @@ export function insertEvents(db: DatabaseSync, events: UsageEvent[]): number {
         e.inputTokens, e.outputTokens, e.cacheReadTokens, e.cacheCreationTokens, e.thinkingTokens,
         JSON.stringify(e.tools), e.hasThinking ? 1 : 0, e.isError ? 1 : 0,
         e.gitBranch ?? null, e.activity ?? 'conversation',
+        e.isSidechain ? 1 : 0, e.parentSessionId ?? null, e.agentType ?? null,
       );
       inserted += Number(res.changes);
     }
@@ -93,6 +119,12 @@ export interface StoredEvent {
   has_thinking: number;
   is_error: number;
   activity: string;
+  /** 1 when the turn came from a subagent transcript (see UsageEvent.isSidechain). */
+  is_sidechain: number;
+  /** Spawning session for a sidechain turn; NULL for main-loop turns. */
+  parent_session_id: string | null;
+  /** Subagent type label; NULL for main-loop turns. Never leaves the machine. */
+  agent_type: string | null;
 }
 
 /**
@@ -305,9 +337,17 @@ export function loadEvents(
     where.push(`source = ?`);
     params.push(opts.source);
   }
+  // Subagent columns are selected defensively: a DB whose migration couldn't
+  // run (read-only, older binary holding it) must still read, and the defaults
+  // it substitutes are the truth for pre-subagent rows anyway.
+  const cols = new Set(
+    (db.prepare(`PRAGMA table_info(events)`).all() as Array<{ name: string }>).map((c) => c.name),
+  );
+  const col = (name: string, fallback: string) => (cols.has(name) ? name : `${fallback} AS ${name}`);
   const sql = `SELECT source, session_id, project, ts, model,
       input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, thinking_tokens,
-      tools, has_thinking, is_error, activity
+      tools, has_thinking, is_error, activity,
+      ${col('is_sidechain', '0')}, ${col('parent_session_id', 'NULL')}, ${col('agent_type', 'NULL')}
     FROM events ${where.length ? 'WHERE ' + where.join(' AND ') : ''} ORDER BY ts`;
   return db.prepare(sql).all(...params) as unknown as StoredEvent[];
 }

--- a/src/team.ts
+++ b/src/team.ts
@@ -188,7 +188,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     cacheHitRatio: 0, reworkTokens: 0, reworkRatio: 0, errorEvents: 0,
     byActivity, byModel, thinkToCodeRatio: 0,
     trendSessions: 0, bloatedSessions: 0, contextBloatShare: 0,
-    coldRestartTurns: 0, coldRestartTokens: 0, coldRestartShare: 0,
+    coldRestartTurns: 0, coldRestartTokens: 0, coldRestartShare: 0, coldRestartBaseTokens: 0,
     premiumWasteTokens: 0, premiumWasteShare: 0,
     retryTokens: 0, retryShare: 0,
     subagentSessions: 0, subagentSpendTokens: 0, subagentShare: 0,
@@ -212,6 +212,9 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.bloatedSessions += m.bloatedSessions ?? 0;
     out.coldRestartTurns += m.coldRestartTurns ?? 0;
     out.coldRestartTokens += m.coldRestartTokens ?? 0;
+    // Pre-0.12 exports have no main-loop denominator because they had no
+    // subagent data at all — their own fresh-paid input IS the right base.
+    out.coldRestartBaseTokens += m.coldRestartBaseTokens ?? (m.inputTokens + m.cacheCreationTokens);
     out.premiumWasteTokens += m.premiumWasteTokens ?? 0;
     out.retryTokens += m.retryTokens ?? 0;
     out.subagentSessions += m.subagentSessions ?? 0;
@@ -233,8 +236,9 @@ export function mergeMetrics(list: Metrics[]): Metrics {
   out.cacheHitRatio = denom ? out.cacheReadTokens / denom : 0;
   out.reworkRatio = out.spendTokens ? out.reworkTokens / out.spendTokens : 0;
   out.contextBloatShare = out.trendSessions ? out.bloatedSessions / out.trendSessions : 0;
-  const freshPaid = out.inputTokens + out.cacheCreationTokens;
-  out.coldRestartShare = freshPaid ? out.coldRestartTokens / freshPaid : 0;
+  out.coldRestartShare = out.coldRestartBaseTokens
+    ? out.coldRestartTokens / out.coldRestartBaseTokens
+    : 0;
   out.premiumWasteShare = out.spendTokens ? out.premiumWasteTokens / out.spendTokens : 0;
   out.retryShare = out.spendTokens ? out.retryTokens / out.spendTokens : 0;
   // Pre-0.12 exports carry no subagent fields at all, so a team share is a

--- a/src/team.ts
+++ b/src/team.ts
@@ -191,6 +191,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     coldRestartTurns: 0, coldRestartTokens: 0, coldRestartShare: 0,
     premiumWasteTokens: 0, premiumWasteShare: 0,
     retryTokens: 0, retryShare: 0,
+    subagentSessions: 0, subagentSpendTokens: 0, subagentShare: 0,
   };
   for (const m of list) {
     out.events += m.events;
@@ -213,6 +214,8 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.coldRestartTokens += m.coldRestartTokens ?? 0;
     out.premiumWasteTokens += m.premiumWasteTokens ?? 0;
     out.retryTokens += m.retryTokens ?? 0;
+    out.subagentSessions += m.subagentSessions ?? 0;
+    out.subagentSpendTokens += m.subagentSpendTokens ?? 0;
     for (const a of ACTIVITIES) {
       byActivity[a].tokens += m.byActivity[a]?.tokens ?? 0;
       byActivity[a].events += m.byActivity[a]?.events ?? 0;
@@ -234,6 +237,9 @@ export function mergeMetrics(list: Metrics[]): Metrics {
   out.coldRestartShare = freshPaid ? out.coldRestartTokens / freshPaid : 0;
   out.premiumWasteShare = out.spendTokens ? out.premiumWasteTokens / out.spendTokens : 0;
   out.retryShare = out.spendTokens ? out.retryTokens / out.spendTokens : 0;
+  // Pre-0.12 exports carry no subagent fields at all, so a team share is a
+  // floor over the members who can actually see their fan-out.
+  out.subagentShare = out.spendTokens ? out.subagentSpendTokens / out.spendTokens : 0;
   out.thinkToCodeRatio =
     (byActivity.thinking.tokens + byActivity.exploration.tokens) / (byActivity.coding.tokens || 1);
   return out;

--- a/src/trends.ts
+++ b/src/trends.ts
@@ -42,6 +42,11 @@ export function trendRows(now: Metrics, prev: Metrics): TrendRow[] {
     { label: 'Cold restarts', prev: prev.coldRestartShare, now: now.coldRestartShare, fmt: 'pct', good: 'down' },
     { label: 'Premium on exploration/chat', prev: prev.premiumWasteShare, now: now.premiumWasteShare, fmt: 'pct', good: 'down' },
     { label: 'Retry loops', prev: prev.retryShare, now: now.retryShare, fmt: 'pct', good: 'down' },
+    // Volume, not verdict: delegating more is neither good nor bad on its own,
+    // so no `good` direction. Appears only once a window has fan-out in it.
+    ...(now.subagentSessions || prev.subagentSessions
+      ? [{ label: 'Subagent share', prev: prev.subagentShare, now: now.subagentShare, fmt: 'pct' } as TrendRow]
+      : []),
   ];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,21 @@ export interface UsageEvent {
   gitBranch?: string;
   activity?: Activity;
   /**
+   * Turn came from a subagent (sidechain) transcript rather than the main
+   * loop. Claude Code writes each Task/Agent run to its own file under
+   * `<session>/subagents/**`; those turns are real spend the main transcript
+   * never mentions.
+   */
+  isSidechain?: boolean;
+  /** The session that spawned this one — set only on sidechain turns. */
+  parentSessionId?: string;
+  /**
+   * Subagent type as the harness labelled it ("general-purpose", "Explore").
+   * Local-only: it can name a user's private custom agent, so it never enters
+   * an export or an LLM payload.
+   */
+  agentType?: string;
+  /**
    * The user's prompt text for this turn, carried in-memory ONLY for `categorize`
    * to derive an on-device intent fingerprint. Never persisted: insertEvents has
    * no column for it. Redaction happens in intent.ts before anything is stored.

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -303,3 +303,124 @@ test('claude-code: two sessions in one dir label independently', () => {
   assert.equal(byKey.get('a2'), 'repo-a');
   assert.equal(byKey.get('b1'), 'repo-b');
 });
+
+// ---- subagent accounting (#63) ----------------------------------------------
+
+/**
+ * One line of a subagent transcript. Mirrors the real shape: `sessionId` is
+ * the PARENT's (the agent's own identity lives in `agentId`), `isSidechain` is
+ * true, and `attributionAgent` names the type that was spawned.
+ */
+function agentLine(
+  uuid: string,
+  parentSessionId: string,
+  agentId: string,
+  cwd: string,
+  agentType = 'general-purpose',
+): string {
+  return JSON.stringify({
+    type: 'assistant', uuid, sessionId: parentSessionId, agentId, isSidechain: true,
+    attributionAgent: agentType, cwd, timestamp: '2026-06-01T10:05:00.000Z',
+    message: { model: 'claude-opus-4-7', usage: { input_tokens: 40, output_tokens: 60 }, content: [] },
+  });
+}
+
+function writeAgent(dir: string, name: string, lines: string[]): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), lines.join('\n'));
+}
+
+test('claude-code: subagent transcripts are collected, flagged and parent-linked', () => {
+  const base = mkdtempSync(join(tmpdir(), 'cc-sub-'));
+  const dir = join(base, 'enc');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 's1.jsonl'), claudeLine('m1', 's1', '/w/dev/repo-a'));
+  writeAgent(join(dir, 's1', 'subagents'), 'agent-aaa111.jsonl', [
+    agentLine('g1', 's1', 'aaa111', '/w/dev/repo-a'),
+    agentLine('g2', 's1', 'aaa111', '/w/dev/repo-a'),
+  ]);
+  // Nested fan-out: workflow runs land a level deeper, under the same session.
+  writeAgent(join(dir, 's1', 'subagents', 'workflows', 'wf_1'), 'agent-bbb222.jsonl', [
+    agentLine('g3', 's1', 'bbb222', '/w/dev/repo-a', 'Explore'),
+  ]);
+
+  const { events, result } = collectClaudeCode(base);
+  assert.equal(events.length, 4); // 1 main + 3 agent turns that were invisible before
+  assert.equal(result.filesScanned, 3);
+
+  const main = events.find((e) => e.eventKey === 'm1')!;
+  assert.equal(main.isSidechain, undefined);
+  assert.equal(main.parentSessionId, undefined);
+
+  const agents = events.filter((e) => e.eventKey !== 'm1');
+  for (const e of agents) {
+    assert.equal(e.isSidechain, true);
+    assert.equal(e.parentSessionId, 's1'); // links back to the spawning session
+    assert.equal(e.project, 'repo-a');
+  }
+  // Own session id per run — NOT the parent's, which is what the file says.
+  assert.deepEqual(
+    agents.map((e) => e.sessionId).sort(),
+    ['aaa111', 'aaa111', 'bbb222'],
+  );
+  assert.equal(agents.find((e) => e.eventKey === 'g3')!.agentType, 'Explore');
+});
+
+test('claude-code: an isolated agent inherits the parent project, not its worktree', () => {
+  const base = mkdtempSync(join(tmpdir(), 'cc-sub-wt-'));
+  const dir = join(base, 'enc');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 's2.jsonl'), claudeLine('m1', 's2', '/w/dev/myapp'));
+  // isolation: 'worktree' puts the agent in a scratch checkout whose basename
+  // would otherwise mint a pseudo-project.
+  writeAgent(join(dir, 's2', 'subagents'), 'agent-ccc333.jsonl', [
+    agentLine('g1', 's2', 'ccc333', '/tmp/wt/myapp-agent-7'),
+  ]);
+  const { events } = collectClaudeCode(base);
+  assert.equal(events.length, 2);
+  for (const e of events) assert.equal(e.project, 'myapp');
+});
+
+test('claude-code: orphaned agent files fall back to their own cwd', () => {
+  const base = mkdtempSync(join(tmpdir(), 'cc-sub-orphan-'));
+  const dir = join(base, 'enc');
+  // The driver transcript rotated away; only its subagents survive on disk.
+  writeAgent(join(dir, 's3', 'subagents'), 'agent-ddd444.jsonl', [
+    agentLine('g1', 's3', 'ddd444', '/w/dev/repo-z'),
+  ]);
+  const { events } = collectClaudeCode(base);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].project, 'repo-z');
+  assert.equal(events[0].parentSessionId, 's3');
+});
+
+test('claude-code: a subagent prompt is never carried as user intent', () => {
+  const base = mkdtempSync(join(tmpdir(), 'cc-sub-intent-'));
+  const dir = join(base, 'enc');
+  mkdirSync(dir, { recursive: true });
+  const userLine = (sessionId: string, text: string) =>
+    JSON.stringify({ type: 'user', sessionId, timestamp: '2026-06-01T10:00:00.000Z', message: { content: text } });
+  writeFileSync(join(dir, 's4.jsonl'), [
+    userLine('s4', 'ship the invoice importer'),
+    claudeLine('m1', 's4', '/w/dev/repo-b'),
+  ].join('\n'));
+  writeAgent(join(dir, 's4', 'subagents'), 'agent-eee555.jsonl', [
+    userLine('s4', 'You are a subagent. Grep the repo for retry handling and report back.'),
+    agentLine('g1', 's4', 'eee555', '/w/dev/repo-b'),
+  ]);
+  const { events } = collectClaudeCode(base);
+  assert.equal(events.find((e) => e.eventKey === 'm1')!.intentText, 'ship the invoice importer');
+  // Machine-written briefs must not become the human's task fingerprint.
+  assert.equal(events.find((e) => e.eventKey === 'g1')!.intentText, undefined);
+});
+
+test('claude-code: a malformed agent file costs its own turns, not the collect', () => {
+  const base = mkdtempSync(join(tmpdir(), 'cc-sub-bad-'));
+  const dir = join(base, 'enc');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 's5.jsonl'), claudeLine('m1', 's5', '/w/dev/repo-c'));
+  writeAgent(join(dir, 's5', 'subagents'), 'agent-fff666.jsonl', ['{"type":"assistant" not json', '']);
+  writeAgent(join(dir, 's5', 'subagents'), 'agent-ggg777.jsonl', [agentLine('g1', 's5', 'ggg777', '/w/dev/repo-c')]);
+  const { events } = collectClaudeCode(base);
+  assert.deepEqual(events.map((e) => e.eventKey).sort(), ['g1', 'm1']);
+});

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -9,7 +9,7 @@ import { collectCursor } from '../src/adapters/cursor.js';
 import { collectAntigravity } from '../src/adapters/antigravity.js';
 import { collectCopilot } from '../src/adapters/copilot.js';
 import { makeCursorFixture, makeAntigravityFixture } from './helpers.js';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 // dist/test/ -> repo root -> test/fixtures
@@ -423,4 +423,21 @@ test('claude-code: a malformed agent file costs its own turns, not the collect',
   writeAgent(join(dir, 's5', 'subagents'), 'agent-ggg777.jsonl', [agentLine('g1', 's5', 'ggg777', '/w/dev/repo-c')]);
   const { events } = collectClaudeCode(base);
   assert.deepEqual(events.map((e) => e.eventKey).sort(), ['g1', 'm1']);
+});
+
+test('claude-code: a symlinked transcript is still collected', () => {
+  // Archived sessions symlinked back into place: Dirent types are lstat-based,
+  // so an isFile() gate would drop the whole session with no note.
+  const base = mkdtempSync(join(tmpdir(), 'cc-symlink-'));
+  const dir = join(base, 'enc');
+  mkdirSync(dir, { recursive: true });
+  const archive = join(base, 'archive.jsonl');
+  writeFileSync(archive, claudeLine('s61', 's6', '/w/dev/repo-arch'));
+  symlinkSync(archive, join(dir, 's6.jsonl'));
+  // A dangling link must be skipped, not thrown on.
+  symlinkSync(join(base, 'gone.jsonl'), join(dir, 's7.jsonl'));
+
+  const { events } = collectClaudeCode(base);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].project, 'repo-arch');
 });

--- a/test/analyze.test.ts
+++ b/test/analyze.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { computeSessionStats, computeToolStats, deepAnalysis, buildLlmPayload, buildLlmPrompt, buildLlmTrackPrompt, parseLlmFindings, extractJson } from '../src/analyze.js';
+import { computeSessionStats, computeToolStats, computeFanOut, computeAgentTypes, deepAnalysis, buildLlmPayload, buildLlmPrompt, buildLlmTrackPrompt, parseLlmFindings, extractJson } from '../src/analyze.js';
 import { makeStored } from './helpers.js';
 
 const fixLoopSession = [
@@ -150,4 +150,61 @@ test('parseLlmFindings: bare array, drops untrackable / duplicate / titleless it
 
 test('parseLlmFindings: no JSON present yields an empty, non-throwing result', () => {
   assert.deepEqual(parseLlmFindings('I could not analyze this.'), { interventions: [], dropped: 0 });
+});
+
+// ---- subagent fan-out (#63) -------------------------------------------------
+
+const fanOutEvents = [
+  makeStored({ session_id: 'p1', project: 'repo-a', ts: '2026-06-01T10:00:00Z', input_tokens: 400, output_tokens: 100 }),
+  makeStored({ session_id: 'g1', parent_session_id: 'p1', is_sidechain: 1, agent_type: 'Explore', project: 'repo-a', ts: '2026-06-01T10:05:00Z', input_tokens: 600, output_tokens: 400 }),
+  makeStored({ session_id: 'g2', parent_session_id: 'p1', is_sidechain: 1, agent_type: 'general-purpose', project: 'repo-a', ts: '2026-06-01T10:06:00Z', input_tokens: 400, output_tokens: 100 }),
+  makeStored({ session_id: 'p2', project: 'repo-b', ts: '2026-06-01T11:00:00Z', input_tokens: 100, output_tokens: 100 }),
+];
+
+test('computeFanOut attributes agent spend to the session that delegated it', () => {
+  const rows = computeFanOut(fanOutEvents);
+  assert.equal(rows.length, 1); // p2 delegated nothing, so it has no row
+  const [f] = rows;
+  assert.equal(f.sessionId, 'p1');
+  assert.equal(f.project, 'repo-a');
+  assert.equal(f.agents, 2);
+  assert.equal(f.agentSpendTokens, 1500);
+  assert.equal(f.mainSpendTokens, 500);
+  assert.equal(f.ratio, 3); // the fan-out cost 3x the driver
+});
+
+test('computeFanOut survives a session whose driver transcript is gone', () => {
+  const [f] = computeFanOut([
+    makeStored({ session_id: 'g9', parent_session_id: 'lost', is_sidechain: 1, input_tokens: 100, output_tokens: 100 }),
+  ]);
+  assert.equal(f.mainSpendTokens, 0);
+  assert.equal(f.ratio, 0); // reported as 0, never Infinity
+});
+
+test('computeAgentTypes ranks spend by subagent type', () => {
+  const types = computeAgentTypes(fanOutEvents);
+  assert.deepEqual(types.map((t) => t.agentType), ['Explore', 'general-purpose']);
+  assert.equal(types[0].spendTokens, 1000);
+  assert.equal(types[0].runs, 1);
+  // Unlabelled runs are counted, not dropped: the spend is real either way.
+  const unlabelled = computeAgentTypes([
+    makeStored({ session_id: 'g0', parent_session_id: 'p', is_sidechain: 1 }),
+  ]);
+  assert.deepEqual(unlabelled.map((t) => t.agentType), ['unlabelled']);
+});
+
+test('the LLM payload carries the subagent share but never agent-type names', () => {
+  const payload = buildLlmPayload(fanOutEvents, 30) as {
+    overall: { subagentShare: number; subagentRuns: number };
+    fanOutSessions: Array<{ project: string; agents: number }>;
+  };
+  assert.equal(payload.overall.subagentRuns, 2);
+  assert.equal(payload.overall.subagentShare, 0.682);
+  assert.deepEqual(payload.fanOutSessions, [
+    { project: 'repo-a', agents: 2, agentSpendTokens: 1500, mainSpendTokens: 500, ratio: 3 },
+  ]);
+  const json = JSON.stringify(payload);
+  assert.ok(!json.includes('Explore'));
+  assert.ok(!json.includes('general-purpose'));
+  assert.ok(!json.includes('p1')); // no session ids either
 });

--- a/test/analyze.test.ts
+++ b/test/analyze.test.ts
@@ -208,3 +208,27 @@ test('the LLM payload carries the subagent share but never agent-type names', ()
   assert.ok(!json.includes('general-purpose'));
   assert.ok(!json.includes('p1')); // no session ids either
 });
+
+test('the LLM payload marks subagent runs and keeps them out of the bloat lists', () => {
+  const turnsOf = (id: string, sidechain: boolean, n: number) =>
+    Array.from({ length: n }, (_, i) =>
+      makeStored({
+        session_id: id,
+        is_sidechain: sidechain ? 1 : 0,
+        parent_session_id: sidechain ? 'human' : null,
+        ts: `2026-06-01T1${Math.floor(i / 10)}:${String(i % 10).padStart(2, '0')}:00Z`,
+        input_tokens: 50_000,
+        output_tokens: 100,
+      }),
+    );
+  const events = [...turnsOf('human', false, 12), ...Array.from({ length: 20 }, (_, i) => turnsOf(`a${i}`, true, 40)).flat()];
+  const deep = deepAnalysis(events);
+  // Context-heavy is a bloat proxy: agent runs never appear, however chatty.
+  assert.ok(deep.contextHeavySessions.every((s) => !s.isSidechain));
+  assert.ok(deep.coldRestartSessions.every((s) => !s.isSidechain));
+  // Expensive sessions stay inclusive — a runaway run is worth seeing — but
+  // every emitted row says which kind it is.
+  const payload = buildLlmPayload(events, 30) as { expensiveSessions: Array<{ isSidechain: boolean }> };
+  assert.ok(payload.expensiveSessions.some((s) => s.isSidechain));
+  assert.ok(payload.expensiveSessions.every((s) => typeof s.isSidechain === 'boolean'));
+});

--- a/test/analyze.test.ts
+++ b/test/analyze.test.ts
@@ -209,7 +209,7 @@ test('the LLM payload carries the subagent share but never agent-type names', ()
   assert.ok(!json.includes('p1')); // no session ids either
 });
 
-test('the LLM payload marks subagent runs and keeps them out of the bloat lists', () => {
+test('session lists describe conversations only; fan-out is reported as an aggregate', () => {
   const turnsOf = (id: string, sidechain: boolean, n: number) =>
     Array.from({ length: n }, (_, i) =>
       makeStored({
@@ -223,12 +223,13 @@ test('the LLM payload marks subagent runs and keeps them out of the bloat lists'
     );
   const events = [...turnsOf('human', false, 12), ...Array.from({ length: 20 }, (_, i) => turnsOf(`a${i}`, true, 40)).flat()];
   const deep = deepAnalysis(events);
-  // Context-heavy is a bloat proxy: agent runs never appear, however chatty.
-  assert.ok(deep.contextHeavySessions.every((s) => !s.isSidechain));
-  assert.ok(deep.coldRestartSessions.every((s) => !s.isSidechain));
-  // Expensive sessions stay inclusive — a runaway run is worth seeing — but
-  // every emitted row says which kind it is.
-  const payload = buildLlmPayload(events, 30) as { expensiveSessions: Array<{ isSidechain: boolean }> };
-  assert.ok(payload.expensiveSessions.some((s) => s.isSidechain));
-  assert.ok(payload.expensiveSessions.every((s) => typeof s.isSidechain === 'boolean'));
+  // Every per-session list describes a conversation. 20 chatty agent runs
+  // against 1 conversation must not crowd out the only session-level
+  // evidence the terminal and the LLM payload get.
+  for (const list of [deep.expensiveSessions, deep.fixLoopSessions, deep.contextHeavySessions, deep.bloatTrendSessions, deep.coldRestartSessions]) {
+    assert.ok(list.every((s) => !s.isSidechain));
+  }
+  assert.equal(deep.expensiveSessions.length, 1);
+  // ...and the fan-out is still reported, as an aggregate.
+  assert.equal(deep.fanOutSessions[0].agents, 20);
 });

--- a/test/categorize.test.ts
+++ b/test/categorize.test.ts
@@ -63,3 +63,41 @@ test('fmtCategorizeSummary: singular/plural wording and the estimated marker', (
     '3 recurring tasks spanning ≥2 projects (~$48.50)',
   );
 });
+
+// ---- subagent accounting (#63) ----------------------------------------------
+
+test('a task is priced with the fan-out it delegated, and agent runs are not tasks', () => {
+  const db = freshDb();
+  const agentSpend = { inputTokens: 3000, outputTokens: 1000 };
+  insertEvents(db, [
+    makeEvent({ source: 'claude-code', eventKey: 'k1', sessionId: 's1', project: 'proj-a', activity: 'coding' }),
+    makeEvent({ source: 'claude-code', eventKey: 'g1', sessionId: 'a1', parentSessionId: 's1', isSidechain: true, project: 'proj-a', activity: 'coding', ...agentSpend }),
+    makeEvent({ source: 'claude-code', eventKey: 'k2', sessionId: 's2', project: 'proj-b', activity: 'coding' }),
+  ]);
+  const fp = ['jwt', 'auth', 'login', 'rest', 'api'];
+  recordIntents(db, [
+    { sessionId: 's1', source: 'claude-code', project: 'proj-a', intentId: 'i1', label: 'jwt auth login', fingerprint: fp, hasText: true, firstSeen: '2026-06-01T10:00:00.000Z' },
+    { sessionId: 's2', source: 'claude-code', project: 'proj-b', intentId: 'i2', label: 'jwt auth login', fingerprint: fp, hasText: true, firstSeen: '2026-06-01T10:00:00.000Z' },
+  ]);
+
+  const s = categorizeSummary(db, DAYS);
+  assert.ok(s);
+  // Still two sessions doing one duplicated task — the agent run is part of
+  // s1's work, never a third participant.
+  assert.equal(s!.duplicateSessions, 2);
+
+  // ...and the delegated spend is priced into the task, so the duplicate-work
+  // headline can't under-report by exactly the fan-out share.
+  const withoutFanOut = freshDb();
+  insertEvents(withoutFanOut, [
+    makeEvent({ source: 'claude-code', eventKey: 'k1', sessionId: 's1', project: 'proj-a', activity: 'coding' }),
+    makeEvent({ source: 'claude-code', eventKey: 'k2', sessionId: 's2', project: 'proj-b', activity: 'coding' }),
+  ]);
+  recordIntents(withoutFanOut, [
+    { sessionId: 's1', source: 'claude-code', project: 'proj-a', intentId: 'i1', label: 'jwt auth login', fingerprint: fp, hasText: true, firstSeen: '2026-06-01T10:00:00.000Z' },
+    { sessionId: 's2', source: 'claude-code', project: 'proj-b', intentId: 'i2', label: 'jwt auth login', fingerprint: fp, hasText: true, firstSeen: '2026-06-01T10:00:00.000Z' },
+  ]);
+  assert.ok(s!.duplicateCost > categorizeSummary(withoutFanOut, DAYS)!.duplicateCost);
+  db.close();
+  withoutFanOut.close();
+});

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -650,3 +650,63 @@ test('e2e: an alias for a live project reaches steady state (no relabel flip-flo
   assert.ok(third.stdout.includes('"myapp"'), 'aliased project must appear in the export');
   assert.ok(!JSON.parse(third.stdout).byProject['myapp-wt1'], 'raw worktree label must be gone');
 });
+
+test('e2e: subagent transcripts are collected, priced, and reported as fan-out', () => {
+  // One session that delegates to two agents — the shape `collect` was blind
+  // to before #63: the driver's transcript never mentions their spend.
+  const home = mkdtempSync(join(tmpdir(), 'tm-e2e-subagents-'));
+  const projDir = join(home, '.claude', 'projects', '-Users-dev-fanout-app');
+  const cwd = '/Users/dev/fanout-app';
+  mkdirSync(projDir, { recursive: true });
+  writeFileSync(join(projDir, 'sess-1.jsonl'), [
+    JSON.stringify({ type: 'user', sessionId: 'sess-1', timestamp: '2026-06-01T10:00:00.000Z', message: { content: [{ type: 'text', text: 'Audit the payment module for retry bugs' }] } }),
+    JSON.stringify({ type: 'assistant', uuid: 'main-1', sessionId: 'sess-1', isSidechain: false, cwd, timestamp: '2026-06-01T10:00:05.000Z',
+      message: { model: 'claude-opus-4-7', usage: { input_tokens: 1000, output_tokens: 200 }, content: [{ type: 'tool_use', id: 'tu1', name: 'Task', input: {} }] } }),
+  ].join('\n') + '\n');
+
+  const agentFile = (dir: string, agentId: string, uuid: string, agentType: string, worktree: string) => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `agent-${agentId}.jsonl`), JSON.stringify({
+      type: 'assistant', uuid, sessionId: 'sess-1', agentId, isSidechain: true, attributionAgent: agentType,
+      cwd: worktree, timestamp: '2026-06-01T10:01:00.000Z',
+      message: { model: 'claude-opus-4-7', usage: { input_tokens: 4000, output_tokens: 800 }, content: [{ type: 'tool_use', id: uuid + 't', name: 'Grep', input: {} }] },
+    }) + '\n');
+  };
+  const subagents = join(projDir, 'sess-1', 'subagents');
+  agentFile(subagents, 'a1a1a1', 'agent-u1', 'Explore', cwd);
+  // Nested workflow run, in an isolated worktree whose basename must NOT
+  // become a project of its own.
+  agentFile(join(subagents, 'workflows', 'wf_1'), 'b2b2b2', 'agent-u2', 'general-purpose', '/tmp/wt/fanout-app-2');
+
+  const collected = run(['collect', '--source', 'claude-code'], { home });
+  assert.equal(collected.code, 0, collected.stderr);
+  assert.match(collected.stdout, /claude-code\s+3 files\s+3 turns\s+3 new/);
+
+  const json = JSON.parse(run(['report', '--json', '--no-categories', ...DAYS], { home }).stdout);
+  assert.equal(json.overall.sessions, 1, 'a fan-out is one conversation, not three');
+  assert.equal(json.overall.subagentSessions, 2);
+  assert.equal(json.overall.spendTokens, 10800);
+  assert.equal(json.overall.subagentSpendTokens, 9600);
+  assert.ok(Math.abs(json.overall.subagentShare - 9600 / 10800) < 1e-9);
+  assert.deepEqual(Object.keys(json.byProject), ['fanout-app'], 'the worktree must not mint a project');
+  // Agent-type names never cross the wire. ("Explore" is matched as a JSON
+  // value — the Explorer persona legitimately contains it as a substring.)
+  const wire = JSON.stringify(json);
+  assert.ok(!wire.includes('"Explore"'), 'agent type leaked into the export');
+  assert.ok(!wire.includes('general-purpose'), 'agent type leaked into the export');
+
+  const report = run(['report', ...DAYS], { home });
+  assert.match(report.stdout, /subagents 89% of spend \(2 runs\)/);
+
+  const analyze = run(['analyze', ...DAYS], { home });
+  assert.ok(analyze.stdout.includes('Subagent fan-out'), 'missing fan-out table');
+  assert.ok(analyze.stdout.includes('By subagent type'), 'missing subagent type table');
+  assert.match(analyze.stdout, /Explore/);
+  assert.match(analyze.stdout, /8\.0×/, 'agent:main ratio missing');
+
+  const htmlPath = join(home, 'r.html');
+  assert.equal(run(['html', '--out', htmlPath, ...DAYS], { home }).code, 0);
+  const html = readFileSync(htmlPath, 'utf8');
+  assert.ok(html.includes('Subagent spend'), 'missing subagent card');
+  assert.ok(html.includes('subagents 89% of spend'), 'missing subagent signal line');
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -118,6 +118,9 @@ export function makeStored(partial: Partial<StoredEvent> = {}): StoredEvent {
     has_thinking: 0,
     is_error: 0,
     activity: 'coding',
+    is_sidechain: 0,
+    parent_session_id: null,
+    agent_type: null,
     ...partial,
   };
 }

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -165,17 +165,47 @@ test('a window with no fan-out reports a zero subagent share, not NaN', () => {
   assert.equal(computeMetrics([]).subagentShare, 0);
 });
 
-test('per-session hygiene math stays per-transcript: a fan-out is not one long session', () => {
-  // Two agent runs interleaved in time under one parent. Folded into the
-  // parent they would look like cold restarts; kept apart they are not.
+test('per-session hygiene math stays per-transcript, not per root session', () => {
+  // Two conversations interleaved in time. Grouped per transcript each shows
+  // one gap; merged on a single timeline they would show three.
   const m = computeMetrics([
-    makeStored({ session_id: 'a1', parent_session_id: 'p', is_sidechain: 1, ts: '2026-06-01T10:00:00Z' }),
-    makeStored({ session_id: 'a2', parent_session_id: 'p', is_sidechain: 1, ts: '2026-06-01T10:20:00Z' }),
-    makeStored({ session_id: 'a1', parent_session_id: 'p', is_sidechain: 1, ts: '2026-06-01T10:40:00Z' }),
-    makeStored({ session_id: 'a2', parent_session_id: 'p', is_sidechain: 1, ts: '2026-06-01T11:00:00Z' }),
+    makeStored({ session_id: 's1', ts: '2026-06-01T10:00:00Z' }),
+    makeStored({ session_id: 's2', ts: '2026-06-01T10:20:00Z' }),
+    makeStored({ session_id: 's1', ts: '2026-06-01T10:40:00Z' }),
+    makeStored({ session_id: 's2', ts: '2026-06-01T11:00:00Z' }),
   ]);
-  assert.equal(m.sessions, 1);
-  assert.equal(m.coldRestartTurns, 2); // one per run, not three across a merged timeline
+  assert.equal(m.coldRestartTurns, 2);
+});
+
+test('cold restarts exclude subagent runs on BOTH sides of the ratio', () => {
+  const human = [
+    makeStored({ session_id: 's1', ts: '2026-06-01T10:00:00Z', input_tokens: 100, cache_creation_tokens: 0 }),
+    makeStored({ session_id: 's1', ts: '2026-06-01T11:00:00Z', input_tokens: 300, cache_creation_tokens: 0 }),
+  ];
+  const alone = computeMetrics(human);
+  assert.equal(alone.coldRestartTurns, 1);
+  assert.equal(alone.coldRestartTokens, 300);
+  assert.equal(alone.coldRestartShare, 0.75); // 300 re-paid of 400 fresh-paid
+
+  // A fan-out of gap-free runs carrying far more fresh input must not move it:
+  // an agent run is a burst that never idles, so counting its input in the
+  // denominator would push a real hygiene problem below its finding threshold.
+  const withFanOut = computeMetrics([
+    ...human,
+    ...Array.from({ length: 10 }, (_, i) =>
+      makeStored({
+        session_id: `a${i}`,
+        parent_session_id: 's1',
+        is_sidechain: 1,
+        ts: `2026-06-01T12:0${i}:00Z`,
+        input_tokens: 1000,
+        cache_creation_tokens: 0,
+      }),
+    ),
+  ]);
+  assert.equal(withFanOut.coldRestartTurns, 1);
+  assert.equal(withFanOut.coldRestartShare, 0.75);
+  assert.equal(withFanOut.coldRestartBaseTokens, 400);
 });
 
 test('subagent runs are excluded from the context-bloat denominator', () => {

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -187,21 +187,22 @@ test('cold restarts exclude subagent runs on BOTH sides of the ratio', () => {
   assert.equal(alone.coldRestartTokens, 300);
   assert.equal(alone.coldRestartShare, 0.75); // 300 re-paid of 400 fresh-paid
 
-  // A fan-out of gap-free runs carrying far more fresh input must not move it:
-  // an agent run is a burst that never idles, so counting its input in the
-  // denominator would push a real hygiene problem below its finding threshold.
+  // A fan-out carrying far more fresh input must not move it, and its OWN
+  // gaps must not enter the numerator either — each run below has a 1-hour
+  // gap between its two turns, which would count as a cold restart if the
+  // numerator guard were dropped.
   const withFanOut = computeMetrics([
     ...human,
-    ...Array.from({ length: 10 }, (_, i) =>
+    ...Array.from({ length: 10 }, (_, i) => [
       makeStored({
-        session_id: `a${i}`,
-        parent_session_id: 's1',
-        is_sidechain: 1,
-        ts: `2026-06-01T12:0${i}:00Z`,
-        input_tokens: 1000,
-        cache_creation_tokens: 0,
+        session_id: `a${i}`, parent_session_id: 's1', is_sidechain: 1,
+        ts: `2026-06-01T12:0${i}:00Z`, input_tokens: 1000, cache_creation_tokens: 0,
       }),
-    ),
+      makeStored({
+        session_id: `a${i}`, parent_session_id: 's1', is_sidechain: 1,
+        ts: `2026-06-01T13:0${i}:00Z`, input_tokens: 1000, cache_creation_tokens: 0,
+      }),
+    ]).flat(),
   ]);
   assert.equal(withFanOut.coldRestartTurns, 1);
   assert.equal(withFanOut.coldRestartShare, 0.75);

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -141,3 +141,59 @@ test('anthropic models are priced exactly, unknown models counted as unpriced', 
   assert.equal(unknown.costUsd, 0);
   assert.equal(unknown.costUnpricedTokens, 200);
 });
+
+// ---- subagent accounting (#63) ----------------------------------------------
+
+test('subagent turns count as spend but not as extra sessions', () => {
+  const m = computeMetrics([
+    makeStored({ session_id: 's1', input_tokens: 400, output_tokens: 100 }),
+    makeStored({ session_id: 'a1', parent_session_id: 's1', is_sidechain: 1, input_tokens: 60, output_tokens: 40 }),
+    makeStored({ session_id: 'a2', parent_session_id: 's1', is_sidechain: 1, input_tokens: 60, output_tokens: 40 }),
+    makeStored({ session_id: 'a2', parent_session_id: 's1', is_sidechain: 1, input_tokens: 30, output_tokens: 70 }),
+  ]);
+  assert.equal(m.sessions, 1); // one conversation, not four
+  assert.equal(m.subagentSessions, 2); // ...that fanned out into two runs
+  assert.equal(m.spendTokens, 800);
+  assert.equal(m.subagentSpendTokens, 300);
+  assert.equal(m.subagentShare, 0.375);
+});
+
+test('a window with no fan-out reports a zero subagent share, not NaN', () => {
+  const m = computeMetrics([makeStored({ session_id: 's1' })]);
+  assert.equal(m.subagentSessions, 0);
+  assert.equal(m.subagentShare, 0);
+  assert.equal(computeMetrics([]).subagentShare, 0);
+});
+
+test('per-session hygiene math stays per-transcript: a fan-out is not one long session', () => {
+  // Two agent runs interleaved in time under one parent. Folded into the
+  // parent they would look like cold restarts; kept apart they are not.
+  const m = computeMetrics([
+    makeStored({ session_id: 'a1', parent_session_id: 'p', is_sidechain: 1, ts: '2026-06-01T10:00:00Z' }),
+    makeStored({ session_id: 'a2', parent_session_id: 'p', is_sidechain: 1, ts: '2026-06-01T10:20:00Z' }),
+    makeStored({ session_id: 'a1', parent_session_id: 'p', is_sidechain: 1, ts: '2026-06-01T10:40:00Z' }),
+    makeStored({ session_id: 'a2', parent_session_id: 'p', is_sidechain: 1, ts: '2026-06-01T11:00:00Z' }),
+  ]);
+  assert.equal(m.sessions, 1);
+  assert.equal(m.coldRestartTurns, 2); // one per run, not three across a merged timeline
+});
+
+test('subagent runs are excluded from the context-bloat denominator', () => {
+  const growing = (session: string, sidechain: boolean) =>
+    Array.from({ length: 8 }, (_, i) =>
+      makeStored({
+        session_id: session,
+        is_sidechain: sidechain ? 1 : 0,
+        parent_session_id: sidechain ? 'p' : null,
+        ts: `2026-06-01T10:0${i}:00Z`,
+        input_tokens: 1000 * (i + 1),
+        cache_read_tokens: 0,
+      }),
+    );
+  const m = computeMetrics([...growing('human', false), ...growing('a1', true), ...growing('a2', true)]);
+  // One conversation is measurable for bloat; the two agent runs are not
+  // sessions anyone can compact, so they never dilute the ratio.
+  assert.equal(m.trendSessions, 1);
+  assert.equal(m.bloatedSessions, 1);
+  assert.equal(m.contextBloatShare, 1);
+});

--- a/test/pricing.test.ts
+++ b/test/pricing.test.ts
@@ -39,3 +39,30 @@ test('every model seen by the adapters resolves to some row or is knowingly unpr
     assert.ok(!PRICES.some((p) => p.match.test(knowinglyUnpriced)), `${knowinglyUnpriced} unexpectedly priced`);
   }
 });
+
+test('Claude 5 family is priced, including the 1M-context variant id', () => {
+  // claude-opus-5 / claude-sonnet-5 read as unpriced before these rows existed,
+  // which showed up as $0.00 cost columns on real data.
+  for (const [model, input, output] of [
+    ['claude-opus-5', 5, 25],
+    ['claude-opus-5[1m]', 5, 25],
+    ['claude-sonnet-5', 3, 15],
+    ['claude-fable-5', 10, 50],
+    ['claude-haiku-4-5-20251001', 1, 5],
+  ] as const) {
+    const c = costOf(model, 1_000_000, 0, 0, 0);
+    assert.equal(c.priced, true, `${model} must be priced`);
+    assert.ok(Math.abs(c.usd - input) < 1e-9, `${model} input rate`);
+    assert.ok(Math.abs(costOf(model, 0, 1_000_000, 0, 0).usd - output) < 1e-9, `${model} output rate`);
+    // Cache read is 10% of input; a 5-minute cache write is 1.25x.
+    assert.ok(Math.abs(costOf(model, 0, 0, 1_000_000, 0).usd - input * 0.1) < 1e-9, `${model} cache read`);
+    assert.ok(Math.abs(costOf(model, 0, 0, 0, 1_000_000).usd - input * 1.25) < 1e-9, `${model} cache write`);
+  }
+});
+
+test('generation-specific rows win over older ones', () => {
+  // /claude-opus-4/ must not swallow claude-opus-5, and vice versa.
+  assert.equal(costOf('claude-opus-4-8', 1_000_000, 0, 0, 0).usd, 5);
+  assert.equal(costOf('claude-sonnet-4-5', 1_000_000, 0, 0, 0).usd, 3);
+  assert.equal(costOf('claude-sonnet-5', 1_000_000, 0, 0, 0).usd, 3);
+});

--- a/test/recommendations.test.ts
+++ b/test/recommendations.test.ts
@@ -196,3 +196,36 @@ test('low-think-code stays unquantified but keeps its message and key', () => {
   assert.equal(rec.savingsUsdPerMonth, undefined);
   assert.equal(fmtSavings(rec), undefined);
 });
+
+// ---- subagent accounting (#63) ----------------------------------------------
+
+test('context-bloat savings and evidence ignore subagent runs', () => {
+  // A session whose late-half context grows sharply and is paid fresh.
+  const bloated = (id: string, sidechain: boolean) =>
+    Array.from({ length: 8 }, (_, i) =>
+      makeStored({
+        session_id: id,
+        is_sidechain: sidechain ? 1 : 0,
+        parent_session_id: sidechain ? 'human' : null,
+        project: sidechain ? 'agentville' : 'humanville',
+        ts: `2026-06-01T10:0${i}:00Z`,
+        input_tokens: i < 4 ? 100 : 50_000,
+        output_tokens: 0,
+      }),
+    );
+  // The finding needs >=3 measurable conversations to fire at all.
+  const human = [...bloated('h1', false), ...bloated('h2', false), ...bloated('h3', false)];
+  const alone = computeMetrics(human);
+  const before = enrichFindings(human, alone, 30).find((r) => r.key === 'context-bloat');
+  assert.ok(before, 'expected a context-bloat finding');
+
+  // Twenty identically-shaped agent runs must not multiply the estimate or
+  // take over the evidence: contextBloatShare, which gates the finding,
+  // never counted them.
+  const withFanOut = [...human, ...Array.from({ length: 20 }, (_, i) => bloated(`a${i}`, true)).flat()];
+  const after = enrichFindings(withFanOut, computeMetrics(withFanOut), 30)
+    .find((r) => r.key === 'context-bloat');
+  assert.ok(after);
+  assert.equal(after.savingsUsdPerMonth, before.savingsUsdPerMonth);
+  assert.ok(!JSON.stringify(after.evidence).includes('agentville'));
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -206,3 +206,25 @@ test('subagent fields survive the insert/load round trip and dedup by event key'
   assert.equal(agent.agent_type, 'Explore');
   assert.equal(rows.find((r) => r.session_id === 's1')!.is_sidechain, 0);
 });
+
+test('the session index exists on new and pre-existing dbs', () => {
+  // relabelEvents runs one UPDATE per session; without this index each one is
+  // a full table scan, which subagent runs multiply by the fan-out factor.
+  const path = join(mkdtempSync(join(tmpdir(), 'tm-idx-')), 'db.sqlite');
+  const legacy = new DatabaseSync(path);
+  legacy.exec(`CREATE TABLE events (
+    id INTEGER PRIMARY KEY, source TEXT NOT NULL, event_key TEXT NOT NULL,
+    session_id TEXT NOT NULL, project TEXT NOT NULL, ts TEXT NOT NULL,
+    model TEXT NOT NULL, input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL,
+    cache_read_tokens INTEGER NOT NULL, cache_creation_tokens INTEGER NOT NULL,
+    thinking_tokens INTEGER NOT NULL, tools TEXT NOT NULL, has_thinking INTEGER NOT NULL,
+    is_error INTEGER NOT NULL, git_branch TEXT, activity TEXT NOT NULL,
+    UNIQUE(source, event_key))`);
+  legacy.close();
+  for (const db of [openDb(path), openDb(':memory:')]) {
+    const plan = db.prepare(
+      `EXPLAIN QUERY PLAN UPDATE events SET project = 'x' WHERE source = 'claude-code' AND session_id = 's'`,
+    ).all() as Array<{ detail: string }>;
+    assert.match(plan.map((r) => r.detail).join(' '), /idx_events_session/);
+  }
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -138,3 +138,71 @@ test('syncIntentProjects is source-scoped: a cross-source session_id collision c
   assert.equal(syncIntentProjects(db), 0);
   assert.equal(loadIntents(db, ['shared']).get('shared')!.project, 'proc');
 });
+
+// ---- subagent accounting (#63) ----------------------------------------------
+
+test('openDb migrates a pre-0.12 db (no subagent columns) and defaults old rows to main-loop', () => {
+  const path = join(mkdtempSync(join(tmpdir(), 'tm-mig12-')), 'old.sqlite');
+  const legacy = new DatabaseSync(path);
+  legacy.exec(`CREATE TABLE events (
+    id INTEGER PRIMARY KEY, source TEXT NOT NULL, event_key TEXT NOT NULL,
+    session_id TEXT NOT NULL, project TEXT NOT NULL, ts TEXT NOT NULL,
+    model TEXT NOT NULL, input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL,
+    cache_read_tokens INTEGER NOT NULL, cache_creation_tokens INTEGER NOT NULL,
+    thinking_tokens INTEGER NOT NULL, tools TEXT NOT NULL, has_thinking INTEGER NOT NULL,
+    is_error INTEGER NOT NULL, git_branch TEXT, activity TEXT NOT NULL, project_raw TEXT,
+    UNIQUE(source, event_key))`);
+  legacy.prepare(`INSERT INTO events
+    (source, event_key, session_id, project, ts, model, input_tokens, output_tokens,
+     cache_read_tokens, cache_creation_tokens, thinking_tokens, tools, has_thinking, is_error, activity)
+    VALUES ('claude-code','pre1','s0','p0','2026-06-01T00:00:00.000Z','m',1,1,0,0,0,'[]',0,0,'coding')`).run();
+  legacy.close();
+
+  const db = openDb(path);
+  const cols = (db.prepare(`PRAGMA table_info(events)`).all() as Array<{ name: string }>).map((c) => c.name);
+  for (const c of ['is_sidechain', 'parent_session_id', 'agent_type']) assert.ok(cols.includes(c));
+  // Pre-existing rows are genuinely main-loop turns: collect never read a
+  // subagent transcript before this version, so 0/NULL is true, not a guess.
+  const [row] = loadEvents(db);
+  assert.equal(row.is_sidechain, 0);
+  assert.equal(row.parent_session_id, null);
+  openDb(path); // second open: ALTERs are not re-run
+});
+
+test('loadEvents still reads a db whose subagent migration never ran', () => {
+  const path = join(mkdtempSync(join(tmpdir(), 'tm-nomig-')), 'old.sqlite');
+  const legacy = new DatabaseSync(path);
+  legacy.exec(`CREATE TABLE events (
+    id INTEGER PRIMARY KEY, source TEXT NOT NULL, event_key TEXT NOT NULL,
+    session_id TEXT NOT NULL, project TEXT NOT NULL, ts TEXT NOT NULL,
+    model TEXT NOT NULL, input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL,
+    cache_read_tokens INTEGER NOT NULL, cache_creation_tokens INTEGER NOT NULL,
+    thinking_tokens INTEGER NOT NULL, tools TEXT NOT NULL, has_thinking INTEGER NOT NULL,
+    is_error INTEGER NOT NULL, git_branch TEXT, activity TEXT NOT NULL,
+    UNIQUE(source, event_key));
+    INSERT INTO events (source, event_key, session_id, project, ts, model, input_tokens,
+      output_tokens, cache_read_tokens, cache_creation_tokens, thinking_tokens, tools,
+      has_thinking, is_error, activity)
+    VALUES ('claude-code','x','s','p','2026-06-01T00:00:00.000Z','m',1,1,0,0,0,'[]',0,0,'coding')`);
+  // Read the un-migrated handle directly, as a locked/read-only DB would be.
+  const rows = loadEvents(legacy);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].is_sidechain, 0);
+  assert.equal(rows[0].agent_type, null);
+});
+
+test('subagent fields survive the insert/load round trip and dedup by event key', () => {
+  const db = openDb(':memory:');
+  const events = [
+    makeEvent({ eventKey: 'm1', sessionId: 's1' }),
+    makeEvent({ eventKey: 'g1', sessionId: 'a1', isSidechain: true, parentSessionId: 's1', agentType: 'Explore' }),
+  ];
+  assert.equal(insertEvents(db, events), 2);
+  assert.equal(insertEvents(db, events), 0);
+  const rows = loadEvents(db);
+  const agent = rows.find((r) => r.session_id === 'a1')!;
+  assert.equal(agent.is_sidechain, 1);
+  assert.equal(agent.parent_session_id, 's1');
+  assert.equal(agent.agent_type, 'Explore');
+  assert.equal(rows.find((r) => r.session_id === 's1')!.is_sidechain, 0);
+});

--- a/test/team.test.ts
+++ b/test/team.test.ts
@@ -206,3 +206,25 @@ test('signed export with categories round-trips verification; tampering fails', 
   tampered.categories[0].terms[0] = 'forged';
   assert.equal(verifyObject(tampered).ok, false);
 });
+
+
+// ---- subagent accounting (#63) ----------------------------------------------
+
+test('mergeMetrics recombines coldRestartShare over main-loop input, incl. pre-0.12 exports', () => {
+  const modern = computeMetrics([
+    makeStored({ session_id: 's1', ts: '2026-06-01T10:00:00Z', input_tokens: 100, cache_creation_tokens: 0 }),
+    makeStored({ session_id: 's1', ts: '2026-06-01T11:00:00Z', input_tokens: 300, cache_creation_tokens: 0 }),
+    // Fan-out with lots of fresh input and no gaps: must not enter the base.
+    makeStored({ session_id: 'a1', parent_session_id: 's1', is_sidechain: 1, ts: '2026-06-01T12:00:00Z', input_tokens: 5000, cache_creation_tokens: 0 }),
+  ]);
+  assert.equal(modern.coldRestartBaseTokens, 400);
+  assert.equal(modern.coldRestartShare, 0.75);
+
+  // A pre-0.12 member export carries no base and no subagent rows at all, so
+  // its own fresh-paid input is the correct denominator.
+  const legacy = { ...modern, coldRestartBaseTokens: undefined as unknown as number, inputTokens: 1000, cacheCreationTokens: 0, coldRestartTokens: 250 };
+  const merged = mergeMetrics([modern, legacy]);
+  assert.equal(merged.coldRestartBaseTokens, 1400); // 400 main-loop + 1000 legacy
+  assert.equal(merged.coldRestartTokens, 550);
+  assert.ok(Math.abs(merged.coldRestartShare - 550 / 1400) < 1e-9);
+});


### PR DESCRIPTION
Closes #63. **Stacks on #61** — it branches from `feat/project-families-team-categories` because the adapter changes sit directly on top of the project-family resolver, which isn't in `main` yet. Merge #61 first; the diff against it is the three commits here.

## The bug

`collect` read only the top level of `~/.claude/projects/<dir>/`. Claude Code writes every Task/Agent run to its own transcript under the session directory:

```
<session>.jsonl                              main loop
<session>/subagents/agent-<id>.jsonl         one Task/Agent run
<session>/subagents/workflows/<run>/agent-*  workflow fan-out
```

None of it was ever read, and the main transcript no longer inlines sidechain turns (every main-loop line now carries `isSidechain: false`), so this was a total blind spot rather than partial undercounting. Measured on my own 30-day window: **24% of spend across 2,042 runs**, matching an independent raw scan of the same files (23.5%).

Coverage first, feature second — every savings estimate in the tool prices on totals this corrects.

## Two design amendments, from the transcripts rather than the issue

**Session id.** #63 assumed an agent transcript carries its own `sessionId`. It doesn't — the field holds the *parent's* id (verified on all 2,089 files on disk, zero mismatches). Using it as-is would fold a fan-out's interleaved turns into the parent and corrupt every chronology-based metric. Each run keys on its `agentId` (17 hex chars, unique across all files, structurally distinct from a session UUID) and records the parent in `parent_session_id`.

**Project.** #63 assumed agent `cwd` matches the parent's. It doesn't when an agent runs isolated in a scratch git worktree, whose basename would mint a pseudo-project. Agent turns inherit the parent session's resolved project; their own cwds are the fallback for when the driver transcript has rotated away but its subagent directory survives.

## Session-shaped consequences (all dogfooded)

- `sessions` counts **root** sessions, so a 40-agent fan-out stays the one conversation someone had. Without this the report read 2,000+ sessions where there were 146.
- **Context bloat** and **cold restarts** are scoped to the main loop on *both* sides of their ratios. Their remedies — compact, start fresh, batch prompts — cannot be applied to a run that is spawned, works back-to-back and exits, and runs outnumber conversations ~14:1. Left unscoped, bloat went 4/2076 and cold restarts fell 22.4% → 12.2% with no behaviour change, dropping the cold-restarts finding under its own 0.2 gate.
- `categorize` aggregates by root session, so a task is priced with the fan-out it delegated and 2,000 agent runs never become tasks of their own.
- Everything that measures **spend** — activity mix, cost, rework, retries, premium routing, per-project totals — counts subagent turns in full.

## Surfaces

`subagentShare` / `subagentSpendTokens` / `subagentSessions` in metrics; a **Subagent fan-out** table plus a by-type breakdown in `analyze`; a signals-line clause, dashboard card and trend row (all absent rather than a standing 0% on the five sources that never write sidechain data); share and counts in exports.

No finding fires on a high subagent share. Delegating heavily can be exactly right, and there is no defensible threshold yet — descriptive now, a `subagent-runaway` finding only if dogfooding produces one.

## Privacy

Subagent **type** names (`attributionAgent`) are stored locally and shown only in the terminal — a custom agent can be named after something private. Exports and `--llm` payloads carry the share and counts only; the e2e test asserts the names never reach the wire. Subagent prompts are machine-authored briefs, so they are never carried as user intent text — feeding them to `categorize` would drown the sentences a person actually typed.

## Performance

`relabelEvents` runs one UPDATE per session and `events` had no `session_id` index, so every collect did a full table scan per session. Invisible at ~150 sessions; at ~2,200 a real 165k-row collect took **8m16s**. With `idx_events_session` the same collect takes **5.2s** — also 3× faster than before subagents were counted at all (14.6s), because the missing index was already the dominant cost. `CREATE INDEX IF NOT EXISTS` applies to existing databases on open.

## Schema

Additive `is_sidechain` / `parent_session_id` / `agent_type` behind the PRAGMA guard. Old rows default to main-loop, which is what they are — `collect` never read a subagent transcript before this version. `loadEvents` substitutes those defaults when the migration can't run (read-only DB), so read paths survive.

## Review

Two adversarial passes, both against my own work.

**Pass 1** (over `d83a5a8`): 14 findings, 10 refuted, 4 reproduced and fixed in `51f7152` — context-bloat savings summing over agent runs while its gate excluded them, an unmarked `--llm` payload, cold-restart dilution, and a silent regression where `withFileTypes` made lstat-based `isFile()` drop symlinked transcripts.

**Pass 2** (over the whole branch, because `51f7152` was itself unreviewed): 15 findings, all real, all fixed in `0e4c187`. The theme was that `51f7152` rescoped the *metric* but not its *consumers*, which made parts of the report worse than before it — a ~17× inflated cold-restart savings figure, a personal target collapsed to 0%, and a report that could print "cold restarts 0%" next to "dominant cause: cold restarts (83%)". Plus two independent defects: the symlink fix reached only main transcripts (so a symlinked session dir kept its main loop and lost its whole fan-out), and the new `CREATE INDEX` sat outside `migrate()`'s try/catch, so a read-only DB threw on open.

Verified after the fixes on real data: personal target 0% → 1%, savings on a correct base, evidence lines naming conversations rather than agent runs.

## Testing

226 tests pass (24 new); CI green on Node 24/25 × ubuntu/macOS. Covers: recursion incl. nested workflow dirs, parent linkage, own-session-id derivation, worktree project inheritance, orphaned agent files, symlinked and dangling transcripts, malformed files, intent-text suppression, root-session counting, cold-restart and bloat scoping, categorize fan-out pricing, export/LLM-payload leak checks, the migration on a pre-0.12 DB, an un-migrated read path, the index query plan, the cold-restart numerator *and* denominator, and the mixed pre-0.12/post-0.12 merge path.

## Known, out of scope

`claude-opus-5` and `claude-sonnet-5` have no rows in `src/pricing.ts`, so ~28% of my window's tokens count as unpriced and some fan-out rows show `$0.00`. Pre-existing and unrelated to this change — worth its own issue.