### PR TITLE
feat: data-completeness meter (#68), resolve alias chains (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ token-monitor analyze --llm
 
 No API key management: it reuses your existing agent CLI and its subscription. The payload is the same aggregates-only data as `report --json` (token counts, ratios, tool names, project basenames — never prompts or code). It does leave your machine via that agent's provider, so skip `--llm` if even project names are sensitive.
 
+## Data completeness
+
+Agent tools rotate their logs — Claude Code deletes transcripts after `cleanupPeriodDays` (default 30) — so a window can be full of holes without anything saying so. Every report now opens with what it actually covers:
+
+```
+coverage: claude-code 26/30d ⚠ · 4d gap
+```
+
+Three things follow from it. A window reaching past retention gets an explanation rather than a shrug — *"history before ~35d ago was likely deleted by Claude Code's 30-day retention before it could be collected"* — worded as a likelihood, and only when the record actually runs out where deletion would have cut it. `report --trend` **suppresses its arrows** when the previous window has materially less data than the current one, printing `insufficient data` instead: an arrow drawn across a collection gap measures the gap, not your behavior, and a false "improving" costs more than a missing verdict. And exports carry per-source day counts and dates, so a lead's `merge` can flag a member whose scheduled push is still arriving faithfully while their adapter has collected nothing for weeks — previously indistinguishable from a genuinely quiet member.
+
+Coverage is counts and dates only. A quiet day is not proof of missing data, and the report says so rather than guessing.
+
 ## Trends
 
 `report --trend` compares the window against the previous same-length one — spend, cost, cache hit, rework, and the optimization signals, each with a direction arrow (green = improving, red = regressing), plus the top project movers by spend change. The HTML dashboard includes the trend automatically when two windows of data exist.

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -1,0 +1,173 @@
+/**
+ * Data completeness (#68) — how much of the window the numbers actually cover.
+ *
+ * Agent tools rotate their logs: Claude Code deletes transcripts after
+ * `cleanupPeriodDays` (default 30). A user who collects less often than
+ * retention silently loses history, and until now nothing said so — a report
+ * over a holey window read exactly like a report over a full one, and
+ * `--trend` drew confident arrows across windows that could be mostly empty.
+ * Silent truncation reading as "covered everything" is the failure this
+ * project's own no-silent-caps rule exists to prevent.
+ *
+ * Everything here is derived from stored events plus one optional local file
+ * read. No schema change, no network, and nothing that isn't already in the
+ * database: source names, day counts, and dates.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { StoredEvent } from './store.js';
+
+/**
+ * Claude Code's documented default transcript retention, used when
+ * settings.json is absent or unreadable. Source:
+ * code.claude.com/docs/en/settings (`cleanupPeriodDays`).
+ */
+export const DEFAULT_RETENTION_DAYS = 30;
+
+export interface SourceCoverage {
+  source: string;
+  /** Distinct calendar days (UTC) with at least one event. */
+  activeDays: number;
+  windowDays: number;
+  /** activeDays / windowDays — NOT a claim that the rest is missing data. */
+  ratio: number;
+  /** ISO dates (YYYY-MM-DD) of the first and last event seen in the window. */
+  first: string;
+  last: string;
+  /** Longest run of consecutive event-free days strictly inside first..last. */
+  largestGapDays: number;
+  /** Whole days between the last event and the end of the window. */
+  staleDays: number;
+}
+
+const DAY = 86_400_000;
+const dayOf = (ts: string) => ts.slice(0, 10);
+
+/**
+ * Per-source coverage over the window. A day with no events is not proof of
+ * missing data — people take weekends — so this reports what was observed and
+ * leaves the interpretation to the caller, who has the retention context.
+ */
+export function computeCoverage(
+  events: StoredEvent[],
+  windowDays: number,
+  now: number = Date.now(),
+): SourceCoverage[] {
+  const bySource = new Map<string, Set<string>>();
+  for (const e of events) {
+    let days = bySource.get(e.source);
+    if (!days) bySource.set(e.source, (days = new Set()));
+    days.add(dayOf(e.ts));
+  }
+  const endDay = dayOf(new Date(now).toISOString());
+  return [...bySource.entries()]
+    .map(([source, daySet]) => {
+      const days = [...daySet].sort();
+      let largestGapDays = 0;
+      for (let i = 1; i < days.length; i++) {
+        const gap = Math.round((Date.parse(days[i]) - Date.parse(days[i - 1])) / DAY) - 1;
+        if (gap > largestGapDays) largestGapDays = gap;
+      }
+      return {
+        source,
+        activeDays: days.length,
+        windowDays,
+        ratio: windowDays > 0 ? days.length / windowDays : 0,
+        first: days[0],
+        last: days[days.length - 1],
+        largestGapDays,
+        staleDays: Math.max(0, Math.round((Date.parse(endDay) - Date.parse(days[days.length - 1])) / DAY)),
+      };
+    })
+    .sort((a, b) => (a.source < b.source ? -1 : 1));
+}
+
+/**
+ * Claude Code's configured transcript retention. Read locally, fail-soft: a
+ * missing, unreadable, or malformed settings file falls back to the
+ * documented default rather than refusing to say anything.
+ */
+export function readRetentionDays(
+  path: string = join(homedir(), '.claude', 'settings.json'),
+): number {
+  try {
+    const v = JSON.parse(readFileSync(path, 'utf8'))?.cleanupPeriodDays;
+    return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : DEFAULT_RETENTION_DAYS;
+  } catch {
+    return DEFAULT_RETENTION_DAYS;
+  }
+}
+
+/**
+ * How far past nominal retention a record may reach and still look like it was
+ * truncated by deletion rather than simply being short.
+ */
+export const RETENTION_SLACK = 1.5;
+
+/** Coverage below this fraction of the window is called out rather than passed over. */
+export const COVERAGE_WARN_RATIO = 0.6;
+/** A source silent this long is probably a broken collect, not a quiet week. */
+export const STALE_WARN_DAYS = 3;
+
+/** One compact line for the report header; empty when there is nothing to show. */
+export function fmtCoverage(rows: SourceCoverage[]): string {
+  if (rows.length === 0) return '';
+  return rows
+    .map((r) => {
+      const flags = [
+        r.ratio < COVERAGE_WARN_RATIO || r.largestGapDays >= STALE_WARN_DAYS ? '⚠' : '',
+        r.largestGapDays >= STALE_WARN_DAYS ? `${r.largestGapDays}d gap` : '',
+        r.staleDays >= STALE_WARN_DAYS ? `last data ${r.staleDays}d ago` : '',
+      ].filter(Boolean);
+      return `${r.source} ${r.activeDays}/${r.windowDays}d${flags.length ? ' ' + flags.join(' · ') : ''}`;
+    })
+    .join('  ·  ');
+}
+
+/**
+ * The explanation for a window that starts abruptly: history the tool had
+ * already deleted before it was ever collected. Deliberately worded as a
+ * likelihood — a window can also start late because the user simply wasn't
+ * working — and only offered when the evidence fits: the requested window
+ * reaches past retention, and the record itself is no longer than retention
+ * plus slack, i.e. it runs out about where deletion would have cut it.
+ */
+export function retentionNote(
+  rows: SourceCoverage[],
+  windowDays: number,
+  retentionDays: number,
+  now: number = Date.now(),
+): string {
+  if (windowDays <= retentionDays) return '';
+  const claude = rows.find((r) => r.source === 'claude-code');
+  if (!claude) return '';
+  const age = Math.round((now - Date.parse(claude.first)) / DAY);
+  // Fire only when the record runs out roughly where retention would have cut
+  // it. Deletion is not punctual — files linger past the nominal window — so
+  // the test is "history is no longer than retention plus slack", not "starts
+  // exactly at the boundary". A user who collects regularly accumulates a
+  // record far longer than retention and never sees this.
+  if (age > retentionDays * RETENTION_SLACK) return '';
+  return `history before ~${age}d ago was likely deleted by Claude Code's ${retentionDays}-day retention before it could be collected — collect at least weekly (\`token-monitor schedule\` automates it) to keep a longer record`;
+}
+
+/**
+ * Whether a trend comparison is worth drawing. A previous window with far
+ * less coverage than the current one produces arrows that measure collection
+ * gaps, not behaviour change — and a false "improving" is worse than no
+ * arrow at all.
+ */
+export function trendIsComparable(
+  current: StoredEvent[],
+  previous: StoredEvent[],
+): { comparable: boolean; currentDays: number; previousDays: number } {
+  const days = (evs: StoredEvent[]) => new Set(evs.map((e) => dayOf(e.ts))).size;
+  const currentDays = days(current);
+  const previousDays = days(previous);
+  return {
+    comparable: previousDays >= currentDays * COVERAGE_WARN_RATIO,
+    currentDays,
+    previousDays,
+  };
+}

--- a/src/html.ts
+++ b/src/html.ts
@@ -6,6 +6,7 @@ import { assignPersona, generalRecommendations } from './personas.js';
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
 import { fmtTokens, fmtSubagents, fmtCacheTtl } from './report.js';
+import { computeCoverage, fmtCoverage, readRetentionDays, retentionNote } from './coverage.js';
 import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
 import { mergeMetrics, rollupExports, displayName } from './team.js';
 import { enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
@@ -126,6 +127,9 @@ export function renderHtml(
 <table><tr><th>Project</th><th>Previous</th><th>Now</th><th>Change</th></tr>${movers}</table>`;
   }
 
+  const coverage = computeCoverage(events, opts.days);
+  const coverageNote = retentionNote(coverage, opts.days, readRetentionDays());
+
   const rates = blendedRates(m);
   const followSection =
     opts.follow && opts.follow.length
@@ -145,6 +149,8 @@ export function renderHtml(
 <h2>Where the tokens go</h2>
 ${stackedBar(m)}
 <div class="legend">${legend}</div>
+<p class="muted">coverage: ${esc(fmtCoverage(coverage))}</p>
+${coverageNote ? `<p class="dup">⚠ ${esc(coverageNote)}</p>` : ''}
 <p class="muted">rework ${pct(m.reworkRatio)} · think:code ${m.thinkToCodeRatio.toFixed(2)} · ${m.errorEvents} turns hit tool errors</p>
 <p class="muted">signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions · cold restarts ${pct(m.coldRestartShare)} of main-loop fresh input · premium on exploration/chat ${pct(m.premiumWasteShare)} · retry loops ${pct(m.retryShare)}${esc(fmtSubagents(m))}${esc(fmtCacheTtl(m))}</p>
 ${opts.categorize ? `<p class="dup">🔁 ${esc(fmtCategorizeSummary(opts.categorize))} <span class="muted">— run <code>categorize</code> for detail</span></p>` : ''}

--- a/src/report.ts
+++ b/src/report.ts
@@ -4,13 +4,15 @@ import type { StoredEvent } from './store.js';
 import { ACTIVITIES } from './types.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
-import { mergeMetrics, rollupExports, dominantActivity, displayName } from './team.js';
+import { mergeMetrics, rollupExports, dominantActivity, displayName, staleMembers } from './team.js';
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
 import type { EnrichedRec } from './recommendations.js';
 import { enrichFindings, fmtSavings, fmtEvidence, fmtCause, potentialBill, fmtPotential, blendedRates, realizedMonthly, fmtUsdShort } from './recommendations.js';
 import type { TrendRow, TrendVerdict } from './trends.js';
 import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js';
+import type { SourceCoverage } from './coverage.js';
+import { computeCoverage, fmtCoverage, readRetentionDays, retentionNote, trendIsComparable } from './coverage.js';
 import type { CategorizeResult, CategorizeSummary } from './categorize.js';
 import { fmtCategorizeSummary } from './categorize.js';
 import type { MergedCategories, OrgCategory } from './team-categories.js';
@@ -125,8 +127,13 @@ export function renderReport(
     String(m.byActivity[a].events),
   ]);
   out.push(table(['Activity', '', 'Share', 'Tokens', 'Turns'], actRows));
+  const coverage = computeCoverage(events, opts.days);
+  out.push(`\n  ${DIM}coverage: ${fmtCoverage(coverage)}${RESET}`);
+  const note = retentionNote(coverage, opts.days, readRetentionDays());
+  if (note) out.push(`  ${YELLOW}⚠${RESET} ${DIM}${note}${RESET}`);
+
   out.push(
-    `\n  ${DIM}rework ratio ${(m.reworkRatio * 100).toFixed(1)}%  ·  think:code ${m.thinkToCodeRatio.toFixed(2)}  ·  ${m.errorEvents} turns hit tool errors${RESET}`,
+    `  ${DIM}rework ratio ${(m.reworkRatio * 100).toFixed(1)}%  ·  think:code ${m.thinkToCodeRatio.toFixed(2)}  ·  ${m.errorEvents} turns hit tool errors${RESET}`,
   );
   out.push(
     `  ${DIM}signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions  ·  cold restarts ${(m.coldRestartShare * 100).toFixed(0)}% of main-loop fresh input  ·  premium on exploration/chat ${(m.premiumWasteShare * 100).toFixed(0)}%  ·  retry loops ${(m.retryShare * 100).toFixed(1)}%${fmtSubagents(m)}${fmtCacheTtl(m)}${RESET}`,
@@ -223,12 +230,26 @@ export function renderTrend(
     return out.join('\n');
   }
   const rows = trendRows(computeMetrics(current), computeMetrics(previous));
+  // An arrow drawn across a previous window with far less data measures the
+  // collection gap, not the behaviour. Report the shortfall instead of a
+  // verdict — a false "improving" costs more than a missing arrow.
+  const cmp = trendIsComparable(current, previous);
   out.push(
     table(
       ['Metric', 'Previous', 'Now', 'Change'],
-      rows.map((r) => [r.label, fmtTrendValue(r, r.prev), fmtTrendValue(r, r.now), trendDelta(r)]),
+      rows.map((r) => [
+        r.label,
+        fmtTrendValue(r, r.prev),
+        fmtTrendValue(r, r.now),
+        cmp.comparable ? trendDelta(r) : `${DIM}insufficient data${RESET}`,
+      ]),
     ),
   );
+  if (!cmp.comparable) {
+    out.push(
+      `\n  ${YELLOW}⚠${RESET} ${DIM}the previous window has ${cmp.previousDays} day(s) of data against ${cmp.currentDays} now — too little to call a direction, so no arrows are drawn.${RESET}`,
+    );
+  }
   const movers = projectMovers(current, previous);
   if (movers.length) {
     out.push(`\n  ${BOLD}Top project movers (spend)${RESET}`);
@@ -436,6 +457,17 @@ export function renderTeamReport(
       if (m.byActivity[a].tokens === 0) continue;
       out.push(`    ${a.padEnd(13)} ${bar(m.byActivity[a].share)} ${(m.byActivity[a].share * 100).toFixed(1)}%`);
     }
+  }
+
+  const stale = staleMembers(exports, opts.keyring);
+  if (stale.length) {
+    out.push(section('Stale data'));
+    for (const s of stale) {
+      out.push(`  ${YELLOW}⚠${RESET} ${s.name} — newest ${s.source} data is ${s.staleDays}d old`);
+    }
+    out.push(
+      `  ${DIM}A quiet week and a broken collect look the same from here; ask before reading these members' numbers as low usage.${RESET}`,
+    );
   }
 
   if (opts.categories) out.push(...renderTeamCategoryLines(opts.categories, exports.length));

--- a/src/store.ts
+++ b/src/store.ts
@@ -278,14 +278,46 @@ export function loadProjectAliases(path: string = DEFAULT_ALIASES): Record<strin
   try {
     const data = JSON.parse(readFileSync(path, 'utf8'));
     if (typeof data !== 'object' || data === null || Array.isArray(data)) return {};
-    const out: Record<string, string> = {};
+    const raw: Record<string, string> = {};
     for (const [k, v] of Object.entries(data)) {
-      if (typeof v === 'string' && v && k) out[k] = v;
+      if (typeof v === 'string' && v && k) raw[k] = v;
     }
-    return out;
+    return resolveAliasChains(raw);
   } catch {
     return {};
   }
+}
+
+/**
+ * Collapse `{a: b, b: c}` to `{a: c, b: c}` (#74).
+ *
+ * The map is applied twice per collect — once composed into the relabel
+ * target, which resolves a single level, and once as a direct pass that can
+ * re-match rows the previous entry just rewrote. With a chain those two fight
+ * forever: every collect reports a relabel, and the answer depends on JSON key
+ * order. Resolving to a fixed point first makes both passes agree, so steady
+ * state is genuinely zero changes.
+ *
+ * A cycle (`a -> b -> a`) has no terminal target, so its keys collapse to
+ * themselves — a no-op that applyProjectAliases already skips. That beats
+ * picking an arbitrary winner, and it beats dropping the keys, which would
+ * change what `loadProjectAliases` returns for the self-maps a user may
+ * legitimately have written.
+ */
+export function resolveAliasChains(raw: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const from of Object.keys(raw)) {
+    let to = raw[from];
+    const seen = new Set([from]);
+    // Walk to the end of the chain, stopping if we return to where we started
+    // or revisit a node — either way there is no further terminal target.
+    while (to !== from && raw[to] !== undefined && !seen.has(to)) {
+      seen.add(to);
+      to = raw[to];
+    }
+    out[from] = to;
+  }
+  return out;
 }
 
 /** Apply alias relabels at collect time (same audit trail as relabelEvents). */

--- a/src/team.ts
+++ b/src/team.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { userInfo, hostname } from 'node:os';
 import type { Metrics } from './metrics.js';
+import type { SourceCoverage } from './coverage.js';
+import { computeCoverage, STALE_WARN_DAYS } from './coverage.js';
 import { computeMetrics, groupBy } from './metrics.js';
 import type { StoredEvent } from './store.js';
 import { ACTIVITIES } from './types.js';
@@ -54,6 +56,14 @@ export interface ExportV1 {
   byProject: Record<string, Metrics>;
   categories?: ExportCategory[];
   categorizeDays?: number;
+  /**
+   * Per-source day counts and dates — additive on version 1, same as
+   * `categories`. This closes a real failure mode: `schedule`/`push` keeps
+   * delivering signed exports even when a member's adapter has collected
+   * nothing new for weeks, and until now the lead had no way to tell that
+   * apart from a genuinely quiet member.
+   */
+  coverage?: SourceCoverage[];
 }
 
 export function buildExport(events: StoredEvent[], days: number): ExportV1 {
@@ -64,6 +74,7 @@ export function buildExport(events: StoredEvent[], days: number): ExportV1 {
     generatedAt: new Date().toISOString(),
     days,
     overall: computeMetrics(events),
+    coverage: computeCoverage(events, days),
     byProject: Object.fromEntries(
       [...groupBy(events, 'project')].map(([p, evs]) => [p, computeMetrics(evs)]),
     ),
@@ -291,4 +302,25 @@ export function dominantActivity(m: Metrics): Activity {
   return ACTIVITIES.reduce((best, a) =>
     m.byActivity[a].tokens > m.byActivity[best].tokens ? a : best,
   );
+}
+
+/**
+ * Members whose newest data predates their export by more than a few days.
+ * Reported as an observation, not an accusation: a quiet week and a dead
+ * collect job look identical from here, and only the member can tell them
+ * apart. Exports without coverage (pre-0.12) are simply absent from the list.
+ */
+export function staleMembers(
+  exports: SignedExport[],
+  keyring?: Record<string, string>,
+): Array<{ name: string; source: string; staleDays: number }> {
+  const out: Array<{ name: string; source: string; staleDays: number }> = [];
+  for (const ex of exports) {
+    for (const c of ex.coverage ?? []) {
+      if (c.staleDays >= STALE_WARN_DAYS) {
+        out.push({ name: displayName(ex, keyring), source: c.source, staleDays: c.staleDays });
+      }
+    }
+  }
+  return out.sort((a, b) => b.staleDays - a.staleDays || (a.name < b.name ? -1 : 1));
 }

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  computeCoverage, fmtCoverage, readRetentionDays, retentionNote, trendIsComparable,
+  DEFAULT_RETENTION_DAYS,
+} from '../src/coverage.js';
+import { makeStored } from './helpers.js';
+
+const NOW = Date.parse('2026-06-30T12:00:00Z');
+const day = (d: string, source = 'claude-code') =>
+  makeStored({ source: source as never, ts: `${d}T10:00:00.000Z` });
+
+test('coverage counts active days, the largest internal gap, and staleness', () => {
+  const [c] = computeCoverage(
+    // 4 active days spanning the 10th to the 20th: an 6-day hole in the middle.
+    [day('2026-06-10'), day('2026-06-11'), day('2026-06-18'), day('2026-06-20')],
+    30, NOW,
+  );
+  assert.equal(c.source, 'claude-code');
+  assert.equal(c.activeDays, 4);
+  assert.equal(c.largestGapDays, 6); // 12th..17th inclusive
+  assert.equal(c.first, '2026-06-10');
+  assert.equal(c.last, '2026-06-20');
+  assert.equal(c.staleDays, 10);
+  assert.ok(Math.abs(c.ratio - 4 / 30) < 1e-9);
+});
+
+test('a duplicated day is one active day, and each source is measured separately', () => {
+  const rows = computeCoverage(
+    [day('2026-06-10'), day('2026-06-10'), day('2026-06-11'), day('2026-06-10', 'cursor')],
+    30, NOW,
+  );
+  assert.deepEqual(rows.map((r) => [r.source, r.activeDays]), [['claude-code', 2], ['cursor', 1]]);
+});
+
+test('the coverage line flags gaps and staleness, and stays quiet when healthy', () => {
+  const healthy = computeCoverage(
+    Array.from({ length: 30 }, (_, i) => day(`2026-06-${String(i + 1).padStart(2, '0')}`)),
+    30, Date.parse('2026-06-30T12:00:00Z'),
+  );
+  assert.equal(fmtCoverage(healthy), 'claude-code 30/30d');
+  assert.match(fmtCoverage(computeCoverage([day('2026-06-01'), day('2026-06-20')], 30, NOW)), /⚠/);
+  assert.equal(fmtCoverage([]), '');
+});
+
+test('retention note fires only when the record runs out where deletion would cut it', () => {
+  const short = computeCoverage([day('2026-06-01'), day('2026-06-29')], 90, NOW);
+  // Window reaches past retention and the record is ~30d long: consistent.
+  assert.match(retentionNote(short, 90, 30, NOW), /likely deleted .* 30-day retention/);
+  // Same data, but the window is inside retention — nothing to explain.
+  assert.equal(retentionNote(short, 30, 30, NOW), '');
+  // A user who collects regularly has a record far longer than retention.
+  const long = computeCoverage([day('2025-06-01'), day('2026-06-29')], 400, NOW);
+  assert.equal(retentionNote(long, 400, 30, NOW), '');
+  // No claude-code data: we don't know the other tools' retention, so silent.
+  assert.equal(retentionNote(computeCoverage([day('2026-06-01', 'cursor')], 90, NOW), 90, 30, NOW), '');
+});
+
+test('retention days read from settings.json, fail-soft to the documented default', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tm-ret-'));
+  writeFileSync(join(dir, 'ok.json'), JSON.stringify({ cleanupPeriodDays: 90 }));
+  writeFileSync(join(dir, 'bad.json'), '{not json');
+  writeFileSync(join(dir, 'wrong.json'), JSON.stringify({ cleanupPeriodDays: 'soon' }));
+  assert.equal(readRetentionDays(join(dir, 'ok.json')), 90);
+  assert.equal(readRetentionDays(join(dir, 'bad.json')), DEFAULT_RETENTION_DAYS);
+  assert.equal(readRetentionDays(join(dir, 'wrong.json')), DEFAULT_RETENTION_DAYS);
+  assert.equal(readRetentionDays(join(dir, 'missing.json')), DEFAULT_RETENTION_DAYS);
+});
+
+test('trend arrows are suppressed when the previous window is far thinner', () => {
+  const many = Array.from({ length: 10 }, (_, i) => day(`2026-06-${String(i + 10).padStart(2, '0')}`));
+  const few = [day('2026-05-01')];
+  assert.equal(trendIsComparable(many, few).comparable, false);
+  assert.equal(trendIsComparable(many, many).comparable, true);
+  // Exactly at the threshold (60%) still counts as comparable.
+  assert.equal(trendIsComparable(many, many.slice(0, 6)).comparable, true);
+  assert.equal(trendIsComparable(many, many.slice(0, 5)).comparable, false);
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -35,7 +35,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import {
-  relabelEvents, loadProjectAliases, applyProjectAliases, syncIntentProjects,
+  relabelEvents, loadProjectAliases, applyProjectAliases, syncIntentProjects, resolveAliasChains,
   recordIntents, loadIntents,
 } from '../src/store.js';
 
@@ -258,4 +258,36 @@ test('the cache-TTL split survives the round trip and migrates onto old dbs', ()
   const rows = loadEvents(db);
   assert.equal(rows.find((r) => r.cache_creation_tokens === 1000 && r.cache_creation_1h_tokens === 800)?.cache_creation_1h_tokens, 800);
   assert.equal(rows.filter((r) => r.cache_creation_1h_tokens === 0).length, 2);
+});
+
+test('alias chains resolve to a fixed point so collects reach steady state (#74)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tm-chain-'));
+  const write = (map: unknown) => {
+    const f = join(dir, `${Math.random().toString(36).slice(2)}.json`);
+    writeFileSync(f, JSON.stringify(map));
+    return loadProjectAliases(f);
+  };
+
+  // a -> b -> c collapses to a single terminal target...
+  assert.deepEqual(write({ a: 'b', b: 'c' }), { a: 'c', b: 'c' });
+  // ...and the answer no longer depends on JSON key order.
+  assert.deepEqual(write({ b: 'c', a: 'b' }), { b: 'c', a: 'c' });
+  // A cycle has no terminal target: each key collapses to itself, which
+  // applyProjectAliases skips — no loop, no arbitrary winner.
+  assert.deepEqual(write({ a: 'b', b: 'a' }), { a: 'a', b: 'b' });
+  // A self-map is a no-op, and unrelated entries are untouched.
+  assert.deepEqual(write({ x: 'x', p: 'q' }), { x: 'x', p: 'q' });
+
+  // The end-to-end property: with the chain resolved, the second collect is silent.
+  const aliases = write({ a: 'b', b: 'c' });
+  const db = openDb(':memory:');
+  insertEvents(db, [makeEvent({ eventKey: 'e1', sessionId: 's1', project: 'a' })]);
+  const collect = () => {
+    const sessions = new Map([[`claude-code\x1fs1`, aliases['a'] ?? 'a']]);
+    return relabelEvents(db, sessions) + applyProjectAliases(db, aliases);
+  };
+  assert.ok(collect() > 0, 'first collect does the relabel');
+  assert.equal(collect(), 0, 'second collect must be silent');
+  assert.equal(collect(), 0);
+  assert.equal(loadEvents(db)[0].project, 'c');
 });


### PR DESCRIPTION
Closes #68, closes #74. Last of the v0.12 "trust the numbers" batch, after #73 (subagent accounting) and #75 (cache-TTL).

## The problem, on real data

Claude Code deletes transcripts after `cleanupPeriodDays` (default 30). On a real 165k-row database:

| window | covered |
|---|---|
| 30 days | 26/30 days |
| 90 days | **29/90 days** |
| 180 days | 29/180 days |

The record starts hard at ~35 days back — right where retention would have cut it. A `--days 90` report was drawing conclusions over a window **68% empty**, and `--trend` was printing confident arrows comparing it against a previous window holding almost nothing. Silent truncation reading as "covered everything" is the exact failure this project's own no-silent-caps rule exists to prevent.

## What it does

Coverage is derived from stored events — **no schema change**: per source, distinct active days, first/last dates, largest internal gap, staleness.

```
coverage: claude-code 26/30d ⚠ · 4d gap
```

Three consequences, ordered by how much damage they were doing:

1. **`--trend` suppresses its arrows** when the previous window holds materially less data than the current one, printing `insufficient data`. An arrow drawn across a collection gap measures the gap, not behaviour — and a false "improving" costs more than a missing verdict.
2. **A window past retention gets an explanation**, not a shrug: *"history before ~35d ago was likely deleted by Claude Code's 30-day retention before it could be collected."* Worded as a likelihood, and offered only when the record runs out about where deletion would have cut it — someone who collects regularly accumulates a longer record and never sees it.
3. **Exports carry per-source coverage**, so `merge` can name a member whose scheduled push still arrives faithfully while their adapter has collected nothing for weeks. That was previously indistinguishable from a genuinely quiet member. Reported as an observation, not an accusation — only the member can tell a dead cron from a quiet week.

Retention comes from `~/.claude/settings.json`, fail-soft to the documented default. A quiet day is never treated as proof of missing data.

## #74 — alias chains (found reviewing #61)

The alias map is applied twice per collect: composed into the relabel target (one level), and again as a direct pass that can re-match rows the first just rewrote. With `{a:b, b:c}` those fought forever — one relabel every collect, indefinitely — and the answer depended on JSON key order.

`loadProjectAliases` now resolves to a fixed point. Probed through the real load path:

```
chain {a:b, b:c}            resolved={"a":"c","b":"c"}  collects=1/0 0/0 0/0  final=c
same chain, keys reversed   resolved={"b":"c","a":"c"}  collects=1/0 0/0 0/0  final=c
cycle {a:b, b:a}            resolved={"a":"a","b":"b"}  collects=0/0 0/0 0/0  final=a
```

Steady state is genuinely zero, and key order no longer changes the answer. Cycles collapse to self-maps, which `applyProjectAliases` already skips — my first attempt dropped them instead, which silently broke the self-map entries `loadProjectAliases` has always preserved. The existing test caught it.

## Deferred, deliberately

The `collect_log` table from #68's design. Coverage already answers "when did data last arrive"; the table would additionally separate *"collect ran and found nothing"* from *"collect never ran"* — a real distinction, but it needs its own write path and deserves its own change rather than riding along here.

## Testing

245 tests. New: active-day counting with duplicate days and multiple sources; largest-gap and staleness arithmetic; the coverage line flagging gaps and staying quiet when healthy; retention firing only when the record runs out at the boundary and staying silent for a long record, a short window, or non-Claude sources; `settings.json` parsing with valid, malformed, wrong-typed and missing files; trend suppression at and either side of the threshold; alias chains in both key orders, cycles, self-maps, and the end-to-end "second collect is silent" property.
