### PR TITLE
chore: release 0.12.0

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "token-monitor",
   "displayName": "Token Monitor",
   "description": "Status-bar token/cost for the current project plus the token-monitor dashboard, for VS Code, Cursor, Windsurf, and Antigravity.",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "publisher": "ryan653133",
   "license": "MIT",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ryandemelo/token-monitor",
-      "version": "0.10.0",
+      "version": "0.12.0",
       "license": "MIT",
       "bin": {
         "token-monitor": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex, Cursor, Antigravity, Copilot Chat) — activity breakdowns, usage personas, and recommendations.",
   "license": "MIT",
   "author": "Ryan de Melo",


### PR DESCRIPTION

collect now reads subagent transcripts (#63, PR #73). Claude Code writes
every Task/Agent run to its own file under the session directory and
stops inlining those turns, so a collect that read only the top level
missed them entirely — 24% of a real 30-day window, across 2,042 runs.
Sessions count the conversation a person had, not the fan-out; the
context-bloat and cold-restart signals stay scoped to the main loop,
whose remedies are the only ones that apply there; and `analyze` gains a
fan-out table and a per-subagent-type breakdown. Subagent type names
never leave the machine.

Cold restarts are measured against the cache TTL a session actually used
(#64, PR #75). Sessions on the 1-hour ephemeral cache keep context warm
for an hour, so scoring their 20-minute pauses as re-paid invented a
problem and priced a fix for it. Each session is classified from its own
writes — necessarily per session, since a main loop on the 1-hour tier
and its subagents on the 5-minute one average to a figure that describes
neither. Sessions still on the 5-minute cache get the switch priced for
them, net of its higher write premium.

Reports say what they actually cover (#68, PR #76). Agent tools rotate
their logs, so a window can be full of holes and read like a full one: a
90-day report on a real database covers 29 days. Coverage is now on the
header line, `--trend` suppresses its arrows rather than drawing a
verdict across a collection gap, a window reaching past retention gets
the likely explanation, and exports carry per-source coverage so a lead
can tell a quiet member from a dead collect job.

Also: project families and cross-user duplicate detection (PR #61);
Claude 5 models priced, which had been counting as unpriced; alias chains
resolved to a fixed point so collects reach steady state (#74); and an
index on events(source, session_id) that takes a 165k-row collect from
8m16s to 5.2s — it was the dominant cost long before subagents made it
visible.

Additive schema migrations throughout; existing databases keep their
numbers. Zero new runtime deps.

---

**Not tagged.** `v0.12.0` is what triggers the marketplace publish, so the tag waits until `VSCE_PAT` has been rotated and `gh secret set VSCE_PAT` run — otherwise the release ships under a credential that was decided untrustworthy.

Release steps once that's done:
```sh
git tag v0.12.0 && git push origin v0.12.0   # marketplace publish (CI)
npm publish                                   # from your machine
```