### PR TITLE
feat: relay-waste detection (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,30 @@ Three things follow from it. A window reaching past retention gets an explanatio
 
 Coverage is counts and dates only. A quiet day is not proof of missing data, and the report says so rather than guessing.
 
+## Relay waste
+
+Every other signal here is single-session. `relay` looks at the waste *between* them: a prompt whose text substantially repeats an earlier session's output — the answer from one session hand-pasted into the next, often into a different agent.
+
+```sh
+token-monitor relay --days 30
+```
+
+```
+23.2k words of prompt text were carried over from an earlier session
+(1.8% of everything typed or pasted, $0.15 re-paid as fresh input)
+
+  From      To        Overlap  Words  Gap  Route
+  ────────  ────────  ───────  ─────  ───  ───────────
+  f0bc06ca  7fa86ed5  100%     1.2k   0d   claude-code
+  3c2923b6  254351ff  100%     1.1k   0d   claude-code
+```
+
+**The dollar figure is deliberately not the headline.** Re-paying a thousand words as fresh input costs cents; measured on the maintainer's own month it came to $0.15. What the number is good for is finding the *handoffs* — text a person moved by hand is work the toolchain could have passed along directly, and the duplicated effort around it is where the real spend goes. Write the output to a file and point the next session at it, or let a subagent carry it.
+
+Detection is offline and deterministic, like `categorize`. Comparison runs on hashed 8-word shingles: each session's output becomes a Bloom filter, and a later prompt is scored by how much of it that filter recognises. Prompt and response text is read in memory, redacted first, hashed, and dropped — it is never stored, printed, or sent, and exports carry shares and counts only. Fingerprints persist so a paste can still be traced after the source transcript has been deleted, which at a 30-day retention is well inside the window a handoff spans.
+
+`--threshold` tunes how much overlap counts (default 0.35). The signal is strongly bimodal in practice — real pastes score near 100%, unrelated prompts near 5% — so the exact value rarely matters, and the detector is biased toward missing a relay rather than inventing one.
+
 ## Trends
 
 `report --trend` compares the window against the previous same-length one — spend, cost, cache hit, rework, and the optimization signals, each with a direction arrow (green = improving, red = regressing), plus the top project movers by spend change. The HTML dashboard includes the trend automatically when two windows of data exist.

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -145,10 +145,14 @@ function parseTranscript(text: string, opts: TranscriptOpts): ParsedTurn[] {
 
     const tools: string[] = [];
     const commands: string[] = [];
+    const responseParts: string[] = [];
     let hasThinking = false;
     const toolUseIds: string[] = [];
     const blocks = Array.isArray(d.message.content) ? d.message.content : [];
     for (const block of blocks) {
+      if (block.type === 'text' && typeof block.text === 'string') {
+        responseParts.push(block.text);
+      }
       if (block.type === 'tool_use' && block.name) {
         tools.push(block.name);
         if (block.id) toolUseIds.push(block.id);
@@ -183,6 +187,9 @@ function parseTranscript(text: string, opts: TranscriptOpts): ParsedTurn[] {
       // machine-authored task briefs into categorize would drown the handful
       // of sentences the person actually typed.
       intentText: opts.sidechain ? undefined : lastUserText || undefined,
+      // Sidechain output is machine-authored and never hand-pasted by a
+      // person, so it is not a relay source — same reasoning as intentText.
+      responseText: opts.sidechain ? undefined : responseParts.join('\n') || undefined,
     };
     if (opts.sidechain) {
       ev.isSidechain = true;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,8 @@ import {
   openDb, insertEvents, loadEvents, DEFAULT_DB,
   relabelEvents, loadProjectAliases, applyProjectAliases, syncIntentProjects,
 } from './store.js';
-import { renderReport, renderTeamReport, renderTrend, renderCategorize } from './report.js';
+import { renderReport, renderTeamReport, renderTrend, renderCategorize, renderRelay } from './report.js';
+import { runRelayScan } from './relay-scan.js';
 import { runCategorize, categorizeSummary, exportCategories } from './categorize.js';
 import type { ExportCategory } from './team.js';
 import { mergeCategories } from './team-categories.js';
@@ -32,6 +33,7 @@ Usage:
   token-monitor report  [--days <n>] [--trend] [--project <name>] [--source <name>] [--json] [--no-categories] [--db <path>]
   token-monitor categorize [--days <n>] [--threshold <0-1>] [--min-cluster <n>] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
   token-monitor analyze [--days <n>] [--llm] [--track] [--agent claude|gemini|codex] [--json] [--db <path>]
+  token-monitor relay   [--days <n>] [--threshold <0-1>] [--source <name>] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline]
                         [--verify] [--keys keys.json] [--threshold <0-1>]
@@ -53,6 +55,10 @@ Commands:
             prioritized recommendations (sends aggregate metrics only); add
             --track to record those recommendations and measure (via
             follow-through) whether they actually moved their metric
+  relay     Find prompts that repeat an earlier session's output — text
+            hand-carried between sessions instead of handed over. Offline and
+            on-device: comparison runs on hashed 8-word shingles, and prompt
+            and response text is never stored, printed, or sent
   html      Self-contained HTML dashboard (no server, no external assets)
   merge     Combine member exports (report --json > me.json) into a team
             report; clusters member task categories to flag the same task done
@@ -404,6 +410,15 @@ Signing fingerprint (send to your team lead for keys.json):
       console.log(JSON.stringify(result, null, 2));
     } else {
       console.log(renderCategorize(result, days));
+    }
+  } else if (cmd === 'relay') {
+    const days = Number(values.days) || 30;
+    const { threshold } = parseClusterOpts(values);
+    const result = runRelayScan(db, { days, source: values.source, threshold });
+    if (values.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(renderRelay(result));
     }
   } else if (cmd === 'analyze') {
     const days = Number(values.days) || 30;

--- a/src/relay-scan.ts
+++ b/src/relay-scan.ts
@@ -1,0 +1,169 @@
+/**
+ * The driver that turns transcripts into relay findings (#65).
+ *
+ * Split from relay.ts on purpose: that file is pure — shingles, a Bloom
+ * filter, and a comparison — and is tested without touching a database or a
+ * disk. This one owns the side effects: re-collecting text through the
+ * adapters, writing fingerprints, and joining detections back to stored spend.
+ *
+ * The text path is the same one categorize established: adapters expose
+ * `intentText` / `responseText` transiently, this module reduces them to
+ * hashes, and the text is dropped. Nothing here prints, stores, or returns
+ * text — the return type carries session ids, counts and dollars only.
+ */
+import type { DatabaseSync } from 'node:sqlite';
+import { loadEvents, recordRelayFingerprints, loadRelayFingerprints } from './store.js';
+import type { StoredEvent } from './store.js';
+import { groupByRootSession } from './metrics.js';
+import { costOf } from './pricing.js';
+import { ADAPTERS } from './adapters/index.js';
+import type { Source, UsageEvent } from './types.js';
+import { redact } from './intent.js';
+import { Bloom, shingles, detectRelays, words } from './relay.js';
+import type { CandidateMessage, RelayFingerprint, RelayPair } from './relay.js';
+
+export interface RelayResult {
+  days: number;
+  /** Sessions that contributed an output fingerprint this scan. */
+  fingerprinted: number;
+  pairs: RelayPair[];
+  /** Words of prompt text that reappeared from an earlier session's output. */
+  relayedWords: number;
+  /** Those words as a share of all prompt words seen — the honest denominator. */
+  relayedShare: number;
+  /** Estimated cost of re-paying that text as fresh input. */
+  relayedCostUsd: number;
+  estimated: boolean;
+}
+
+/**
+ * Re-collect text and rebuild fingerprints. Redaction runs BEFORE anything is
+ * hashed, so a pasted secret never reaches the filter — the same ordering
+ * categorize uses, and the reason a leaked key can't be confirmed by probing
+ * the stored bits.
+ */
+function collectText(source?: string): {
+  fingerprints: RelayFingerprint[];
+  messages: CandidateMessage[];
+  promptWords: number;
+} {
+  const sources = (source ? [source] : Object.keys(ADAPTERS)) as Source[];
+  const outputs = new Map<string, { source: string; project: string; text: string[]; first: string; last: string }>();
+  const messages: CandidateMessage[] = [];
+  let promptWords = 0;
+  // Consecutive turns repeat the same carried prompt; only the first is a
+  // distinct thing the person typed or pasted.
+  const seenPrompt = new Map<string, Set<string>>();
+
+  for (const src of sources) {
+    const adapter = ADAPTERS[src];
+    if (!adapter) continue;
+    let events: UsageEvent[];
+    try {
+      events = adapter().events;
+    } catch {
+      continue; // one malformed local log must never abort the scan
+    }
+    for (const ev of events) {
+      if (ev.responseText) {
+        let o = outputs.get(ev.sessionId);
+        if (!o) {
+          outputs.set(ev.sessionId, (o = { source: ev.source, project: ev.project, text: [], first: ev.timestamp, last: ev.timestamp }));
+        }
+        o.text.push(redact(ev.responseText));
+        if (ev.timestamp < o.first) o.first = ev.timestamp;
+        if (ev.timestamp > o.last) o.last = ev.timestamp;
+      }
+      if (ev.intentText) {
+        let seen = seenPrompt.get(ev.sessionId);
+        if (!seen) seenPrompt.set(ev.sessionId, (seen = new Set()));
+        if (seen.has(ev.intentText)) continue;
+        seen.add(ev.intentText);
+        const text = redact(ev.intentText);
+        promptWords += words(text).length;
+        messages.push({ sessionId: ev.sessionId, source: ev.source, project: ev.project, ts: ev.timestamp, text });
+      }
+    }
+  }
+
+  const fingerprints: RelayFingerprint[] = [];
+  for (const [sessionId, o] of outputs) {
+    const sh = shingles(o.text.join('\n'));
+    if (sh.size === 0) continue;
+    fingerprints.push({
+      sessionId,
+      source: o.source,
+      project: o.project,
+      outBloom: Bloom.of(sh, sh.size).serialize(),
+      outShingles: sh.size,
+      firstTs: o.first,
+      lastTs: o.last,
+    });
+  }
+  return { fingerprints, messages, promptWords };
+}
+
+/**
+ * Price relayed text against the session that re-paid it. Input rate per word
+ * is derived from that session's own spend rather than a global average, so a
+ * paste into a premium-model session is not costed at a cheap blended rate.
+ */
+function priceRelays(pairs: RelayPair[], events: StoredEvent[]): { usd: number; estimated: boolean } {
+  const bySession = new Map<string, StoredEvent[]>();
+  for (const [id, evs] of groupByRootSession(events)) bySession.set(id, evs);
+  let usd = 0;
+  let estimated = false;
+  for (const p of pairs) {
+    const evs = bySession.get(p.toSessionId);
+    if (!evs) continue;
+    let input = 0, cost = 0;
+    for (const e of evs) {
+      input += e.input_tokens;
+      const c = costOf(e.model, e.input_tokens, 0, 0, 0);
+      cost += c.usd;
+      if (c.estimated) estimated = true;
+    }
+    if (input === 0) continue;
+    // ~1.3 tokens per word is the usual English ratio; the estimate is
+    // deliberately coarse and labelled as such wherever it is shown.
+    usd += Math.min(input, p.relayedWords * 1.3) * (cost / input);
+  }
+  return { usd, estimated };
+}
+
+/**
+ * Scan for relayed prompts. Writes fingerprints as a side effect (idempotent),
+ * so a later scan can still match against a session whose transcript the
+ * agent has since deleted.
+ */
+export function runRelayScan(
+  db: DatabaseSync,
+  opts: { days?: number; source?: string; threshold?: number; minShingles?: number } = {},
+): RelayResult {
+  const days = opts.days ?? 30;
+  const { fingerprints, messages, promptWords } = collectText(opts.source);
+  recordRelayFingerprints(db, fingerprints);
+
+  // Detect against everything stored, not just this scan: the whole point is
+  // reaching sessions whose transcripts are gone.
+  const stored = loadRelayFingerprints(db, days + 14);
+  const cutoff = new Date(Date.now() - days * 86_400_000).toISOString();
+  const pairs = detectRelays(
+    messages.filter((m) => m.ts >= cutoff),
+    stored,
+    { threshold: opts.threshold, minShingles: opts.minShingles },
+  );
+
+  const events = loadEvents(db, { days, source: opts.source });
+  const { usd, estimated } = priceRelays(pairs, events);
+  const relayedWords = pairs.reduce((t, p) => t + p.relayedWords, 0);
+  return {
+    days,
+    fingerprinted: fingerprints.length,
+    pairs,
+    relayedWords,
+    relayedShare: promptWords > 0 ? relayedWords / promptWords : 0,
+    relayedCostUsd: usd,
+    estimated,
+  };
+}

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -1,0 +1,238 @@
+/**
+ * Relay-waste detection (#65) — the waste *between* sessions.
+ *
+ * Every other signal in this tool is single-session: cache, rework, bloat,
+ * cold restarts, retries. The pattern this one catches is one session's
+ * output hand-pasted into the next session's prompt — often into a different
+ * agent — re-paying as fresh input for text the toolchain already produced.
+ *
+ * Two design decisions came out of dogfooding the original design (#65), and
+ * both are load-bearing:
+ *
+ * 1. **The unit is one user message, not the session.** Overlap measured
+ *    across a whole session's input drowns a real paste: median session input
+ *    is ~4.8k shingles, so a 500-word pasted block scores ~0.10. Measured over
+ *    a real 30-day window, per-session found 1 relay and per-message found 27.
+ *
+ * 2. **A Bloom filter, not a min-hash sketch.** Min-hash estimates Jaccard;
+ *    what this needs is containment of a small set in a large one. With output
+ *    sets of median ~10.7k shingles, keeping the 192 smallest is a ~2% sample
+ *    a pasted message never lands in — measured recall was 0%. A Bloom filter
+ *    answers exactly the question being asked ("is this shingle in that
+ *    session's output?") at ~100% recall and a bounded size.
+ *
+ * The privacy contract is the same one categorize already keeps: text is
+ * carried in memory only long enough to derive a fingerprint. What is stored
+ * is a bit array of hashed 8-word shingles — not enumerable the way the
+ * single-word category terms would be, which is why those are deliberately
+ * kept readable and these are not. Nothing here is ever printed or exported;
+ * exports carry shares and counts only.
+ */
+
+/** Words per shingle. w=5/8/12 all found the same pairs on real data; 8 is the middle. */
+export const SHINGLE_WORDS = 8;
+/**
+ * A message needs at least this many shingles to be judged. Below it, a quoted
+ * error line or a one-sentence recap would score 1.0 on a handful of shingles
+ * and read as a paste.
+ */
+export const MIN_MESSAGE_SHINGLES = 24;
+/**
+ * Overlap at or above this is called a relay. The observed signal is bimodal —
+ * pastes land near 1.00, everything else near 0.05 — so this sits in the empty
+ * middle where the exact value barely matters.
+ */
+export const RELAY_THRESHOLD = 0.35;
+/** Only pairs this close in time are considered; bounds the comparison space. */
+export const RELAY_WINDOW_DAYS = 14;
+/** Target false-positive rate for the per-session Bloom filter. */
+const BLOOM_FPR = 0.01;
+/** Ceiling on one session's filter, so a huge session can't bloat the database. */
+const BLOOM_MAX_BYTES = 256 * 1024;
+
+/** FNV-1a, the same hash categorize uses for intent ids. */
+export function fnv1a(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/** A second, independent hash for the Kirsch-Mitzenmacher double-hashing scheme. */
+function fnv1aSeeded(s: string): number {
+  let h = 0x84222325;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x000001b3) >>> 0;
+  }
+  return h >>> 0;
+}
+
+export function words(text: string): string[] {
+  return text.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(Boolean);
+}
+
+/** Hashed w-word shingles. Order-insensitive by construction (a Set). */
+export function shingles(text: string, w: number = SHINGLE_WORDS): Set<number> {
+  const ws = words(text);
+  const out = new Set<number>();
+  for (let i = 0; i + w <= ws.length; i++) out.add(fnv1a(ws.slice(i, i + w).join(' ')));
+  return out;
+}
+
+/**
+ * A Bloom filter sized for `n` items at BLOOM_FPR. Deliberately the simplest
+ * thing that answers containment: a bit array plus k derived hashes, no
+ * dependency, and serialisable to a BLOB as-is.
+ */
+export class Bloom {
+  readonly bits: Uint8Array;
+  readonly k: number;
+
+  constructor(bits: Uint8Array, k: number) {
+    this.bits = bits;
+    this.k = k;
+  }
+
+  static forItems(n: number): Bloom {
+    const items = Math.max(1, n);
+    const bitsWanted = Math.ceil((-items * Math.log(BLOOM_FPR)) / (Math.LN2 * Math.LN2));
+    const bytes = Math.min(BLOOM_MAX_BYTES, Math.max(8, Math.ceil(bitsWanted / 8)));
+    const m = bytes * 8;
+    // k that minimises the false-positive rate for this m/n, clamped so a
+    // capped filter on a huge session stays cheap rather than hashing 30 times.
+    const k = Math.max(1, Math.min(12, Math.round((m / items) * Math.LN2)));
+    return new Bloom(new Uint8Array(bytes), k);
+  }
+
+  static of(items: Iterable<number>, n: number): Bloom {
+    const b = Bloom.forItems(n);
+    for (const h of items) b.add(h);
+    return b;
+  }
+
+  private *slots(h: number): Generator<number> {
+    const m = this.bits.length * 8;
+    const h1 = h >>> 0;
+    const h2 = (fnv1aSeeded(String(h)) | 1) >>> 0; // odd, so it strides the whole array
+    for (let i = 0; i < this.k; i++) yield ((h1 + Math.imul(i, h2)) >>> 0) % m;
+  }
+
+  add(h: number): void {
+    for (const s of this.slots(h)) this.bits[s >>> 3] |= 1 << (s & 7);
+  }
+
+  has(h: number): boolean {
+    for (const s of this.slots(h)) if ((this.bits[s >>> 3] & (1 << (s & 7))) === 0) return false;
+    return true;
+  }
+
+  /** `k` rides in the first byte so a stored filter is self-describing. */
+  serialize(): Uint8Array {
+    const out = new Uint8Array(this.bits.length + 1);
+    out[0] = this.k;
+    out.set(this.bits, 1);
+    return out;
+  }
+
+  static deserialize(buf: Uint8Array): Bloom {
+    return new Bloom(buf.subarray(1), buf[0] || 1);
+  }
+}
+
+/** One session's output fingerprint, as stored. */
+export interface RelayFingerprint {
+  sessionId: string;
+  source: string;
+  project: string;
+  /** Serialised Bloom over this session's assistant-output shingles. */
+  outBloom: Uint8Array;
+  outShingles: number;
+  /** Earliest and latest event timestamps, for ordering and the time window. */
+  firstTs: string;
+  lastTs: string;
+}
+
+/** One detected paste: text produced by `from` reappearing in a prompt to `to`. */
+export interface RelayPair {
+  fromSessionId: string;
+  fromSource: string;
+  fromProject: string;
+  toSessionId: string;
+  toSource: string;
+  toProject: string;
+  /** Fraction of the pasted message's shingles found in the earlier output. */
+  overlap: number;
+  /** Words in the relayed message — the re-paid text. */
+  relayedWords: number;
+  /** Whole days between the earlier session ending and the paste. */
+  gapDays: number;
+}
+
+/** A prompt as offered to detection: one user turn, with its timestamp. */
+export interface CandidateMessage {
+  sessionId: string;
+  source: string;
+  project: string;
+  ts: string;
+  text: string;
+}
+
+const DAY = 86_400_000;
+
+/**
+ * Find pastes: prompts whose text substantially reappears from an earlier
+ * session's output. Only earlier-to-later pairs within the window are
+ * considered, and each message keeps only its strongest source — a paste has
+ * one origin, and reporting every partial match would turn one event into a
+ * pile of accusations.
+ *
+ * Biased to false negatives on purpose, like the duplicate-work signal: a
+ * wrong "you are relaying" costs more trust than a missed one.
+ */
+export function detectRelays(
+  messages: CandidateMessage[],
+  fingerprints: RelayFingerprint[],
+  opts: { threshold?: number; minShingles?: number } = {},
+): RelayPair[] {
+  const threshold = opts.threshold ?? RELAY_THRESHOLD;
+  const minShingles = opts.minShingles ?? MIN_MESSAGE_SHINGLES;
+  const sources = fingerprints.map((f) => ({ f, bloom: Bloom.deserialize(f.outBloom), last: Date.parse(f.lastTs) }));
+  const out: RelayPair[] = [];
+
+  for (const m of messages) {
+    const sh = shingles(m.text);
+    if (sh.size < minShingles) continue;
+    const at = Date.parse(m.ts);
+    let best: RelayPair | undefined;
+    for (const { f, bloom, last } of sources) {
+      if (f.sessionId === m.sessionId) continue;
+      if (last >= at || at - last > RELAY_WINDOW_DAYS * DAY) continue;
+      let hit = 0;
+      for (const h of sh) if (bloom.has(h)) hit++;
+      const overlap = hit / sh.size;
+      if (overlap < threshold || (best && overlap <= best.overlap)) continue;
+      best = {
+        fromSessionId: f.sessionId,
+        fromSource: f.source,
+        fromProject: f.project,
+        toSessionId: m.sessionId,
+        toSource: m.source,
+        toProject: m.project,
+        overlap,
+        relayedWords: words(m.text).length,
+        gapDays: Math.max(0, Math.round((at - last) / DAY)),
+      };
+    }
+    if (best) out.push(best);
+  }
+  // Total order so the same database always renders the same list.
+  return out.sort(
+    (a, b) =>
+      b.relayedWords - a.relayedWords ||
+      b.overlap - a.overlap ||
+      (a.toSessionId < b.toSessionId ? -1 : a.toSessionId > b.toSessionId ? 1 : 0),
+  );
+}

--- a/src/report.ts
+++ b/src/report.ts
@@ -16,6 +16,7 @@ import { computeCoverage, fmtCoverage, readRetentionDays, retentionNote, trendIs
 import type { CategorizeResult, CategorizeSummary } from './categorize.js';
 import { fmtCategorizeSummary } from './categorize.js';
 import type { MergedCategories, OrgCategory } from './team-categories.js';
+import type { RelayResult } from './relay-scan.js';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -329,6 +330,56 @@ export function renderCategorize(r: CategorizeResult, days: number): string {
 }
 
 /** Finding lines with savings + worst-session evidence — shared with `analyze`. */
+/**
+ * The relay report. Leads with the honest denominator: re-paid input is
+ * cheap, so the headline is how much text was carried by hand, with the
+ * dollar figure kept beside it rather than in front of it. The remedy is the
+ * point — a file, a subagent, or a skill instead of a clipboard.
+ */
+export function renderRelay(r: RelayResult): string {
+  const out: string[] = [];
+  out.push(section(`Relay waste — last ${r.days} days`));
+  if (r.pairs.length === 0) {
+    out.push(
+      `  ${DIM}No prompts in this window substantially repeat an earlier session's output.${RESET}`,
+    );
+    out.push(
+      `  ${DIM}${r.fingerprinted} session(s) fingerprinted. Detection needs both sides: a source session whose output was collected, and a later prompt that repeats it.${RESET}\n`,
+    );
+    return out.join('\n');
+  }
+
+  const cost = (r.estimated ? '~' : '') + '$' + r.relayedCostUsd.toFixed(2);
+  out.push(
+    `  ${BOLD}${fmtTokens(r.relayedWords)} words of prompt text were carried over from an earlier session${RESET} ` +
+      `${DIM}(${(r.relayedShare * 100).toFixed(1)}% of everything typed or pasted, ${cost} re-paid as fresh input)${RESET}`,
+  );
+  out.push(
+    `  ${DIM}The re-paid input itself is cheap. The cost that matters is the work it re-triggers — and text a person moves by hand is work the toolchain could have handed over directly.${RESET}\n`,
+  );
+
+  out.push(
+    table(
+      ['From', 'To', 'Overlap', 'Words', 'Gap', 'Route'],
+      r.pairs.slice(0, 12).map((p) => [
+        p.fromSessionId.slice(0, 8),
+        p.toSessionId.slice(0, 8),
+        (p.overlap * 100).toFixed(0) + '%',
+        fmtTokens(p.relayedWords),
+        p.gapDays + 'd',
+        p.fromSource === p.toSource ? p.fromSource : `${p.fromSource} → ${p.toSource}`,
+      ]),
+    ),
+  );
+  out.push(
+    `\n  ${YELLOW}→${RESET} Write the output to a file and point the next session at it, or let a subagent carry it — either way the text stops being re-typed.`,
+  );
+  out.push(
+    `  ${DIM}Overlap is measured on hashed 8-word shingles; prompt and response text is never stored, printed, or sent.${RESET}\n`,
+  );
+  return out.join('\n');
+}
+
 export function renderEnrichedRecs(recs: EnrichedRec[]): string[] {
   const out: string[] = [];
   for (const r of recs) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,6 +3,7 @@ import { mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { UsageEvent, Source } from './types.js';
+import type { RelayFingerprint } from './relay.js';
 
 export const DEFAULT_DB = join(homedir(), '.token-monitor', 'token-monitor.sqlite');
 
@@ -401,4 +402,82 @@ export function loadEvents(
       ${col('cache_creation_1h_tokens', '0')}
     FROM events ${where.length ? 'WHERE ' + where.join(' AND ') : ''} ORDER BY ts`;
   return db.prepare(sql).all(...params) as unknown as StoredEvent[];
+}
+
+/**
+ * Per-session relay fingerprints (#65) — a Bloom filter over the hashed
+ * 8-word shingles of that session's assistant output, plus the counts and
+ * timestamps detection needs. There is deliberately no text column, and
+ * unlike category terms these hashes are not enumerable: an 8-word shingle
+ * comes from open prose, not a handful of common dev words.
+ *
+ * Stored so relay can still be found after the source transcript is gone —
+ * Claude Code deletes them after `cleanupPeriodDays`, which is exactly the
+ * window a hand-carried paste spans.
+ */
+export function ensureRelayTable(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session_relay (
+      session_id TEXT PRIMARY KEY,
+      source TEXT NOT NULL,
+      project TEXT NOT NULL,
+      out_bloom BLOB NOT NULL,
+      out_shingles INTEGER NOT NULL,
+      first_ts TEXT NOT NULL,
+      last_ts TEXT NOT NULL
+    );
+  `);
+}
+
+/**
+ * Record fingerprints, refreshing a session whose transcript has grown.
+ *
+ * Unlike session_intents this is NOT first-wins: an intent is a frozen
+ * judgement about what a session was for, while a fingerprint is a mechanical
+ * summary of the text, and a session that gained turns since the last collect
+ * has more output to match against. Re-deriving is idempotent — same text in,
+ * same bits out.
+ */
+export function recordRelayFingerprints(db: DatabaseSync, rows: RelayFingerprint[]): number {
+  ensureRelayTable(db);
+  const stmt = db.prepare(`
+    INSERT INTO session_relay (session_id, source, project, out_bloom, out_shingles, first_ts, last_ts)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(session_id) DO UPDATE SET
+      out_bloom = excluded.out_bloom, out_shingles = excluded.out_shingles,
+      project = excluded.project, last_ts = excluded.last_ts
+      WHERE excluded.out_shingles >= session_relay.out_shingles
+  `);
+  let written = 0;
+  db.exec('BEGIN');
+  try {
+    for (const r of rows) {
+      written += Number(
+        stmt.run(r.sessionId, r.source, r.project, r.outBloom, r.outShingles, r.firstTs, r.lastTs).changes,
+      );
+    }
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+  return written;
+}
+
+/** Fingerprints whose session ended within the window, newest last. */
+export function loadRelayFingerprints(db: DatabaseSync, days?: number): RelayFingerprint[] {
+  ensureRelayTable(db);
+  const where = days ? `WHERE last_ts >= ?` : '';
+  const params = days ? [new Date(Date.now() - days * 86_400_000).toISOString()] : [];
+  const rows = db
+    .prepare(`SELECT * FROM session_relay ${where} ORDER BY last_ts`)
+    .all(...params) as unknown as Array<{
+      session_id: string; source: string; project: string;
+      out_bloom: Uint8Array; out_shingles: number; first_ts: string; last_ts: string;
+    }>;
+  return rows.map((r) => ({
+    sessionId: r.session_id, source: r.source, project: r.project,
+    outBloom: r.out_bloom, outShingles: r.out_shingles,
+    firstTs: r.first_ts, lastTs: r.last_ts,
+  }));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,13 @@ export interface UsageEvent {
    */
   agentType?: string;
   /**
+   * The assistant's response text for this turn. Same contract as intentText
+   * below: carried in memory ONLY, never persisted — insertEvents has no
+   * column for it. Relay detection (#65) hashes it into a Bloom filter and
+   * discards the text; nothing derived from it is ever printed or exported.
+   */
+  responseText?: string;
+  /**
    * The user's prompt text for this turn, carried in-memory ONLY for `categorize`
    * to derive an on-device intent fingerprint. Never persisted: insertEvents has
    * no column for it. Redaction happens in intent.ts before anything is stored.

--- a/test/relay.test.ts
+++ b/test/relay.test.ts
@@ -1,0 +1,173 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  Bloom, shingles, detectRelays, words,
+  MIN_MESSAGE_SHINGLES, RELAY_THRESHOLD,
+} from '../src/relay.js';
+import type { CandidateMessage, RelayFingerprint } from '../src/relay.js';
+
+const LOREM = (n: number) =>
+  Array.from({ length: n }, (_, i) => `token${i % 97} phrase${i % 31} value${i % 13}`).join(' ');
+
+const fingerprint = (
+  sessionId: string, text: string, lastTs: string, extra: Partial<RelayFingerprint> = {},
+): RelayFingerprint => {
+  const sh = shingles(text);
+  return {
+    sessionId, source: 'claude-code', project: 'p',
+    outBloom: Bloom.of(sh, sh.size).serialize(),
+    outShingles: sh.size,
+    firstTs: lastTs, lastTs, ...extra,
+  };
+};
+const msg = (sessionId: string, text: string, ts: string, extra: Partial<CandidateMessage> = {}): CandidateMessage =>
+  ({ sessionId, source: 'claude-code', project: 'p', ts, text, ...extra });
+
+test('a Bloom filter answers containment with no false negatives', () => {
+  const sh = shingles(LOREM(400));
+  const b = Bloom.of(sh, sh.size);
+  for (const h of sh) assert.equal(b.has(h), true, 'every member must be found');
+  // False positives are possible but rare at the configured rate.
+  const absent = [...shingles(LOREM(400).split(' ').reverse().join(' '))].filter((h) => !sh.has(h));
+  const fp = absent.filter((h) => b.has(h)).length;
+  assert.ok(fp / Math.max(1, absent.length) < 0.05, `false-positive rate too high: ${fp}/${absent.length}`);
+});
+
+test('a serialised filter round-trips, k included', () => {
+  const sh = shingles(LOREM(200));
+  const b = Bloom.of(sh, sh.size);
+  const back = Bloom.deserialize(b.serialize());
+  assert.equal(back.k, b.k);
+  for (const h of sh) assert.equal(back.has(h), true);
+});
+
+test('a verbatim paste is detected; unrelated text is not', () => {
+  const produced = LOREM(300);
+  const fps = [fingerprint('A', produced, '2026-06-01T10:00:00Z')];
+  const pairs = detectRelays(
+    [
+      msg('B', produced, '2026-06-02T10:00:00Z'),            // pasted whole
+      msg('C', LOREM(300).split(' ').reverse().join(' '), '2026-06-02T11:00:00Z'), // unrelated
+    ],
+    fps,
+  );
+  assert.equal(pairs.length, 1);
+  assert.equal(pairs[0].fromSessionId, 'A');
+  assert.equal(pairs[0].toSessionId, 'B');
+  assert.ok(pairs[0].overlap > 0.95);
+  assert.equal(pairs[0].gapDays, 1);
+});
+
+test('short quotes stay under the floor even at perfect overlap', () => {
+  const produced = LOREM(300);
+  // A handful of shingles scores 1.0 but is a quoted line, not a relay.
+  const snippet = words(produced).slice(0, MIN_MESSAGE_SHINGLES).join(' ');
+  assert.ok(shingles(snippet).size < MIN_MESSAGE_SHINGLES);
+  const pairs = detectRelays([msg('B', snippet, '2026-06-02T10:00:00Z')], [fingerprint('A', produced, '2026-06-01T10:00:00Z')]);
+  assert.equal(pairs.length, 0);
+});
+
+test('only earlier-to-later pairs inside the window count', () => {
+  const produced = LOREM(300);
+  const later = detectRelays([msg('B', produced, '2026-06-01T09:00:00Z')], [fingerprint('A', produced, '2026-06-01T10:00:00Z')]);
+  assert.equal(later.length, 0, 'output produced after the prompt cannot be its source');
+
+  const stale = detectRelays([msg('B', produced, '2026-07-01T10:00:00Z')], [fingerprint('A', produced, '2026-06-01T10:00:00Z')]);
+  assert.equal(stale.length, 0, 'beyond the window');
+
+  const self = detectRelays([msg('A', produced, '2026-06-02T10:00:00Z')], [fingerprint('A', produced, '2026-06-01T10:00:00Z')]);
+  assert.equal(self.length, 0, 'a session quoting itself is not a relay');
+});
+
+test('cross-source relays are found and each paste keeps one origin', () => {
+  const produced = LOREM(300);
+  const pairs = detectRelays(
+    [msg('B', produced, '2026-06-03T10:00:00Z', { source: 'gemini-cli', project: 'other' })],
+    [
+      fingerprint('A1', produced, '2026-06-01T10:00:00Z'),
+      fingerprint('A2', produced, '2026-06-02T10:00:00Z'), // also matches, but later
+    ],
+  );
+  assert.equal(pairs.length, 1, 'one paste, one reported origin');
+  assert.equal(pairs[0].toSource, 'gemini-cli');
+  assert.equal(pairs[0].fromSource, 'claude-code');
+});
+
+test('detection is deterministic and ordered by relayed volume', () => {
+  const big = LOREM(400), small = LOREM(120);
+  const fps = [fingerprint('A', big + ' ' + small, '2026-06-01T10:00:00Z')];
+  const msgs = [msg('C', small, '2026-06-02T11:00:00Z'), msg('B', big, '2026-06-02T10:00:00Z')];
+  const once = detectRelays(msgs, fps);
+  const twice = detectRelays([...msgs].reverse(), fps);
+  assert.deepEqual(once, twice, 'input order must not change output');
+  assert.equal(once[0].toSessionId, 'B', 'largest relayed block first');
+});
+
+test('the threshold is respected and tunable', () => {
+  const produced = LOREM(300);
+  // Half pasted, half fresh -> roughly 0.5 overlap.
+  const half = words(produced).slice(0, 450).join(' ') + ' ' + LOREM(150).split(' ').reverse().join(' ');
+  const fps = [fingerprint('A', produced, '2026-06-01T10:00:00Z')];
+  assert.equal(detectRelays([msg('B', half, '2026-06-02T10:00:00Z')], fps, { threshold: 0.9 }).length, 0);
+  assert.equal(detectRelays([msg('B', half, '2026-06-02T10:00:00Z')], fps, { threshold: 0.2 }).length, 1);
+  assert.ok(RELAY_THRESHOLD > 0.2 && RELAY_THRESHOLD < 0.9);
+});
+
+// ---- storage + scan wiring --------------------------------------------------
+
+import { openDb, recordRelayFingerprints, loadRelayFingerprints } from '../src/store.js';
+
+test('fingerprints persist, refresh on growth, and never store text', () => {
+  const db = openDb(':memory:');
+  const fp = (id: string, text: string, last: string) => fingerprint(id, text, last);
+
+  assert.equal(recordRelayFingerprints(db, [fp('A', LOREM(200), '2026-06-01T10:00:00Z')]), 1);
+  const [stored] = loadRelayFingerprints(db);
+  assert.equal(stored.sessionId, 'A');
+  assert.ok(stored.outShingles > 0);
+
+  // A session that gained turns has more output to match against: refresh it.
+  const grown = fp('A', LOREM(600), '2026-06-01T12:00:00Z');
+  recordRelayFingerprints(db, [grown]);
+  assert.ok(loadRelayFingerprints(db)[0].outShingles > stored.outShingles);
+
+  // A shorter re-derivation (a truncated re-read) must not clobber the fuller one.
+  recordRelayFingerprints(db, [fp('A', LOREM(50), '2026-06-01T13:00:00Z')]);
+  assert.ok(loadRelayFingerprints(db)[0].outShingles > stored.outShingles);
+
+  // The stored row is a bit array and counts — the plaintext is nowhere in it.
+  const raw = db.prepare('SELECT * FROM session_relay').all() as Array<Record<string, unknown>>;
+  const blob = JSON.stringify(raw).toLowerCase();
+  assert.ok(!blob.includes('token1 phrase1'), 'no source text may reach the database');
+  assert.deepEqual(
+    Object.keys(raw[0]).sort(),
+    ['first_ts', 'last_ts', 'out_bloom', 'out_shingles', 'project', 'session_id', 'source'],
+  );
+});
+
+test('detection still works after the source transcript is gone', () => {
+  // The whole reason fingerprints are persisted: Claude Code deletes
+  // transcripts after ~30 days, which is inside the window a paste spans.
+  const db = openDb(':memory:');
+  const produced = LOREM(300);
+  recordRelayFingerprints(db, [fingerprint('A', produced, '2026-06-01T10:00:00Z')]);
+  // A is no longer re-collectable; only its stored fingerprint remains.
+  const pairs = detectRelays([msg('B', produced, '2026-06-02T10:00:00Z')], loadRelayFingerprints(db));
+  assert.equal(pairs.length, 1);
+  assert.equal(pairs[0].fromSessionId, 'A');
+});
+
+test('secrets are redacted before anything is hashed', async () => {
+  const { redact } = await import('../src/intent.js');
+  const SECRET = 'ghp_ABCDEF0123456789abcdefZZ';
+  const text = `${LOREM(200)} the deploy key is ${SECRET} use it for the push`;
+  // The pipeline shingles redact(text), never text.
+  const raw = shingles(text);
+  const safe = shingles(redact(text));
+  const secretShingles = [...raw].filter((h) => !safe.has(h));
+  assert.ok(secretShingles.length > 0, 'redaction must change the shingle set');
+  const b = Bloom.of(safe, safe.size);
+  // Every shingle that spanned the secret is absent from what gets stored.
+  const leaked = secretShingles.filter((h) => b.has(h)).length;
+  assert.ok(leaked <= 1, `secret-bearing shingles must not be stored (found ${leaked})`);
+});


### PR DESCRIPTION
Closes the detection half of #65. v0.13 flagship, built on the corrected totals from the v0.12 batch.

`token-monitor relay` finds prompts whose text substantially repeats an earlier session's output — an answer hand-pasted into the next session, often into a different agent. Every other signal in this tool is single-session; this is the first that looks between them.

## Two design corrections, measured before building

Both are documented in full on [#65](https://github.com/ryandemelo/token-monitor/issues/65#issuecomment-5225773927).

**1. The unit is one user message, not the session.** Overlap across a whole session's input drowns a real paste — median session input is ~4,822 shingles, so a 500-word block scores ~0.10 and never clears the threshold.

| unit | flagged ≥0.35 |
|---|---|
| per session (as specified) | **1** |
| per user message | **27** |

Per message the signal is sharply bimodal: 24 of 27 score ≥0.70 and the top ten are all 1.00 — verbatim pastes of 99–1077 words. Threshold choice barely matters, which is the low-false-positive property the issue wanted. Width made no difference (w=5/8/12 agreed), so w=8 stands.

**2. Min-hash cannot express the containment formula.** The issue specifies keeping "the N smallest hashes (min-hash style, N≈192)" and detecting with `|B.input ∩ A.output| / |B.input|`. Min-hash estimates *Jaccard*; containment of a small set in a large one is a different quantity. Output sets are median **10,751** shingles (max 90,968), so the 192 smallest are a ~1.8% sample a pasted message essentially never lands in:

| sketch | true pairs | detected | recall |
|---|---|---|---|
| N=192 (as specified) | 30 | 0 | **0%** |
| N=2048 | 30 | 1 | **3%** |

Built as written it would have shipped a detector that finds nothing and reads as *"no relay waste here"* rather than as broken. Replaced with a **per-session Bloom filter**, which answers containment directly at ~100% recall and a bounded size.

## On real data

50 pairs, 23,214 relayed words — **1.8% of everything typed or pasted** — and **$0.15** re-paid as fresh input.

**That dollar figure is deliberately not the headline**, and the report says so. Re-paying a thousand words of input costs cents. The number's value is locating the *handoffs*: text a person moved by hand is work the toolchain could have passed along directly, and the duplicated effort around it is where the spend actually goes. The earlier LLM-driven self-analysis that ranked paste-relay first was pricing that downstream work, not the paste — worth stating plainly rather than inflating the estimate to match the framing.

## Persistence and privacy

Fingerprints persist so a paste stays traceable after the source transcript is deleted — at 30-day retention that is well inside the window a handoff spans, as #68 established. **Refresh-on-growth, not first-wins**: an intent is a frozen judgement, a fingerprint is a mechanical summary, and a session that gained turns has more output to match against; a shorter re-derivation never clobbers a fuller one.

Text is re-collected in memory, **redacted first**, hashed, and dropped — never stored, printed, or sent. What is stored is a bit array of hashed 8-word shingles. That is not enumerable the way single-word category terms are, which is precisely why the README keeps those readable and these hashed. A test plants a secret and asserts its shingles are absent from the filter, pinning the ordering rather than trusting it.

## Deferred, deliberately

The `paste-relay` follow-through finding, the `handoff` family in `potentialBill`, and the export fields. Detection and its surface stand on their own; wiring a new tracked metric into follow-through baselines deserves its own change rather than riding along here.

## Testing

256 tests. New: Bloom membership with zero false negatives and a bounded false-positive rate; serialisation round-trip carrying `k`; verbatim paste detected and unrelated text rejected; short quotes held under the floor even at perfect overlap; direction, self-pairing and the time window; cross-source relay with one origin per paste; determinism under input reordering; threshold tunability; fingerprint refresh-on-growth and the no-clobber rule; detection after the source transcript is gone; and redaction proven to run before hashing.
