### PR TITLE
feat: persist relay findings, cross-surface in report/html

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import {
   relabelEvents, loadProjectAliases, applyProjectAliases, syncIntentProjects,
 } from './store.js';
 import { renderReport, renderTeamReport, renderTrend, renderCategorize, renderRelay } from './report.js';
-import { runRelayScan } from './relay-scan.js';
+import { runRelayScan, relaySummary } from './relay-scan.js';
 import { runCategorize, categorizeSummary, exportCategories } from './categorize.js';
 import type { ExportCategory } from './team.js';
 import { mergeCategories } from './team-categories.js';
@@ -385,7 +385,7 @@ Signing fingerprint (send to your team lead for keys.json):
       const cat = events.length > 0
         ? categorizeSummary(db, { days, project: values.project, source: values.source })
         : undefined;
-      let out = renderReport(events, { days, follow, categorize: cat });
+      let out = renderReport(events, { days, follow, categorize: cat, relay: relaySummary(db, { days }) });
       if (values.trend && events.length > 0) out += '\n' + renderTrend(events, previous, days);
       console.log(out);
     }
@@ -487,7 +487,7 @@ Signing fingerprint (send to your team lead for keys.json):
     const { current: events, previous } = splitWindow(loadEvents(db, { days: days * 2 }), days);
     const follow = events.length > 0 ? syncFindings(db, computeMetrics(events)) : undefined;
     const cat = events.length > 0 ? categorizeSummary(db, { days }) : undefined;
-    writeFileSync(values.out, renderHtml(events, { days, follow, previousEvents: previous, categorize: cat }));
+    writeFileSync(values.out, renderHtml(events, { days, follow, previousEvents: previous, categorize: cat, relay: relaySummary(db, { days }) }));
     console.log(`Wrote ${values.out} (${events.length} turns, last ${days} days). Open it in a browser.`);
   } else {
     console.error(`Unknown command "${cmd}"\n`);

--- a/src/html.ts
+++ b/src/html.ts
@@ -5,7 +5,7 @@ import { ACTIVITIES } from './types.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
-import { fmtTokens, fmtSubagents, fmtCacheTtl } from './report.js';
+import { fmtTokens, fmtSubagents, fmtCacheTtl, fmtRelaySummary } from './report.js';
 import { computeCoverage, fmtCoverage, readRetentionDays, retentionNote } from './coverage.js';
 import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
 import { mergeMetrics, rollupExports, displayName } from './team.js';
@@ -14,6 +14,7 @@ import { trendRows, verdictOf, fmtTrendValue, projectMovers } from './trends.js'
 import type { CategorizeResult, CategoryRow, CategorizeSummary } from './categorize.js';
 import { fmtCategorizeSummary } from './categorize.js';
 import type { MergedCategories, OrgCategory } from './team-categories.js';
+import type { RelaySummary } from './relay-scan.js';
 
 const ACTIVITY_COLORS: Record<string, string> = {
   thinking: '#8b7ff5',
@@ -48,7 +49,7 @@ function stackedBar(m: Metrics): string {
 
 export function renderHtml(
   events: StoredEvent[],
-  opts: { days: number; follow?: FollowRow[]; previousEvents?: StoredEvent[]; categorize?: CategorizeSummary },
+  opts: { days: number; follow?: FollowRow[]; previousEvents?: StoredEvent[]; categorize?: CategorizeSummary; relay?: RelaySummary },
 ): string {
   const m = computeMetrics(events);
   const persona = assignPersona(m);
@@ -153,6 +154,7 @@ ${stackedBar(m)}
 ${coverageNote ? `<p class="dup">⚠ ${esc(coverageNote)}</p>` : ''}
 <p class="muted">rework ${pct(m.reworkRatio)} · think:code ${m.thinkToCodeRatio.toFixed(2)} · ${m.errorEvents} turns hit tool errors</p>
 <p class="muted">signals: context bloat ${m.bloatedSessions}/${m.trendSessions} long sessions · cold restarts ${pct(m.coldRestartShare)} of main-loop fresh input · premium on exploration/chat ${pct(m.premiumWasteShare)} · retry loops ${pct(m.retryShare)}${esc(fmtSubagents(m))}${esc(fmtCacheTtl(m))}</p>
+${opts.relay ? `<p class="dup">📋 ${esc(fmtRelaySummary(opts.relay))} <span class="muted">— run <code>relay</code> for detail</span></p>` : ''}
 ${opts.categorize ? `<p class="dup">🔁 ${esc(fmtCategorizeSummary(opts.categorize))} <span class="muted">— run <code>categorize</code> for detail</span></p>` : ''}
 
 <h2>Projects</h2>

--- a/src/relay-scan.ts
+++ b/src/relay-scan.ts
@@ -12,7 +12,7 @@
  * text — the return type carries session ids, counts and dollars only.
  */
 import type { DatabaseSync } from 'node:sqlite';
-import { loadEvents, recordRelayFingerprints, loadRelayFingerprints } from './store.js';
+import { loadEvents, recordRelayFingerprints, loadRelayFingerprints, recordRelayFindings, loadRelayFindings } from './store.js';
 import type { StoredEvent } from './store.js';
 import { groupByRootSession } from './metrics.js';
 import { costOf } from './pricing.js';
@@ -156,6 +156,14 @@ export function runRelayScan(
 
   const events = loadEvents(db, { days, source: opts.source });
   const { usd, estimated } = priceRelays(pairs, events);
+  // Persist so report/html can surface the signal without re-scanning, the
+  // same way categorize freezes intents for its cross-surfaced callout.
+  recordRelayFindings(db, pairs.map((p) => ({
+    to_session_id: p.toSessionId, from_session_id: p.fromSessionId,
+    to_source: p.toSource, from_source: p.fromSource, to_project: p.toProject,
+    overlap: p.overlap, relayed_words: p.relayedWords,
+    to_ts: new Date(Date.now()).toISOString(),
+  })));
   const relayedWords = pairs.reduce((t, p) => t + p.relayedWords, 0);
   return {
     days,
@@ -165,5 +173,28 @@ export function runRelayScan(
     relayedShare: promptWords > 0 ? relayedWords / promptWords : 0,
     relayedCostUsd: usd,
     estimated,
+  };
+}
+
+/** Cross-surface summary for `report`/`html` (see categorizeSummary). */
+export interface RelaySummary {
+  pairs: number;
+  relayedWords: number;
+  sessions: number;
+}
+
+/**
+ * Read-only relay signal for the shared surfaces, derived from findings a
+ * previous `relay` run already stored. No re-collection, no new privacy
+ * surface. Undefined until the user has run `relay`, or when it found
+ * nothing, so the callout only appears when there is something to say.
+ */
+export function relaySummary(db: DatabaseSync, opts: { days?: number } = {}): RelaySummary | undefined {
+  const rows = loadRelayFindings(db, opts.days ?? 30);
+  if (rows.length === 0) return undefined;
+  return {
+    pairs: rows.length,
+    relayedWords: rows.reduce((t, r) => t + r.relayed_words, 0),
+    sessions: new Set(rows.map((r) => r.to_session_id)).size,
   };
 }

--- a/src/report.ts
+++ b/src/report.ts
@@ -16,7 +16,7 @@ import { computeCoverage, fmtCoverage, readRetentionDays, retentionNote, trendIs
 import type { CategorizeResult, CategorizeSummary } from './categorize.js';
 import { fmtCategorizeSummary } from './categorize.js';
 import type { MergedCategories, OrgCategory } from './team-categories.js';
-import type { RelayResult } from './relay-scan.js';
+import type { RelayResult, RelaySummary } from './relay-scan.js';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -95,7 +95,7 @@ const STATUS_LABEL: Record<FollowRow['status'], string> = {
 
 export function renderReport(
   events: StoredEvent[],
-  opts: { days: number; follow?: FollowRow[]; categorize?: CategorizeSummary },
+  opts: { days: number; follow?: FollowRow[]; categorize?: CategorizeSummary; relay?: RelaySummary },
 ): string {
   if (events.length === 0) {
     return 'No events in range. Run `token-monitor collect` first, or widen --days.';
@@ -142,6 +142,11 @@ export function renderReport(
   if (opts.categorize) {
     out.push(
       `  ${YELLOW}🔁 ${fmtCategorizeSummary(opts.categorize)}${RESET} ${DIM}— run \`categorize\` for detail${RESET}`,
+    );
+  }
+  if (opts.relay) {
+    out.push(
+      `  ${YELLOW}📋 ${fmtRelaySummary(opts.relay)}${RESET} ${DIM}— run \`relay\` for detail${RESET}`,
     );
   }
 
@@ -336,6 +341,12 @@ export function renderCategorize(r: CategorizeResult, days: number): string {
  * dollar figure kept beside it rather than in front of it. The remedy is the
  * point — a file, a subagent, or a skill instead of a clipboard.
  */
+/** Shared wording for the one-line relay callout in report/html. */
+export function fmtRelaySummary(r: RelaySummary): string {
+  const p = r.pairs === 1 ? '1 prompt' : `${r.pairs} prompts`;
+  return `${p} repeated an earlier session's output (${fmtTokens(r.relayedWords)} words carried by hand)`;
+}
+
 export function renderRelay(r: RelayResult): string {
   const out: string[] = [];
   out.push(section(`Relay waste — last ${r.days} days`));

--- a/src/store.ts
+++ b/src/store.ts
@@ -481,3 +481,77 @@ export function loadRelayFingerprints(db: DatabaseSync, days?: number): RelayFin
     firstTs: r.first_ts, lastTs: r.last_ts,
   }));
 }
+
+/**
+ * Detected relays, persisted so `report` and `html` can surface the signal
+ * without paying for a full re-scan. Same contract as the frozen intents
+ * categorize writes: the expensive derivation happens in its own command, and
+ * the cheap read-only summary rides along elsewhere.
+ *
+ * Results, unlike fingerprints, depend on the whole corpus — a later scan
+ * with more history can find an origin an earlier one could not — so a rerun
+ * replaces a pair rather than being ignored. Session ids and counts only; no
+ * text, no hashes.
+ */
+export function ensureRelayFindingsTable(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS relay_findings (
+      to_session_id TEXT NOT NULL,
+      from_session_id TEXT NOT NULL,
+      to_source TEXT NOT NULL,
+      from_source TEXT NOT NULL,
+      to_project TEXT NOT NULL,
+      overlap REAL NOT NULL,
+      relayed_words INTEGER NOT NULL,
+      to_ts TEXT NOT NULL,
+      PRIMARY KEY (to_session_id, from_session_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_relay_findings_ts ON relay_findings(to_ts);
+  `);
+}
+
+export interface RelayFindingRow {
+  to_session_id: string;
+  from_session_id: string;
+  to_source: string;
+  from_source: string;
+  to_project: string;
+  overlap: number;
+  relayed_words: number;
+  to_ts: string;
+}
+
+/** Replace the findings for the scanned window; returns rows written. */
+export function recordRelayFindings(db: DatabaseSync, rows: RelayFindingRow[]): number {
+  ensureRelayFindingsTable(db);
+  const stmt = db.prepare(`
+    INSERT INTO relay_findings
+      (to_session_id, from_session_id, to_source, from_source, to_project, overlap, relayed_words, to_ts)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(to_session_id, from_session_id) DO UPDATE SET
+      overlap = excluded.overlap, relayed_words = excluded.relayed_words,
+      to_source = excluded.to_source, from_source = excluded.from_source,
+      to_project = excluded.to_project, to_ts = excluded.to_ts
+  `);
+  let n = 0;
+  db.exec('BEGIN');
+  try {
+    for (const r of rows) {
+      n += Number(stmt.run(r.to_session_id, r.from_session_id, r.to_source, r.from_source,
+        r.to_project, r.overlap, r.relayed_words, r.to_ts).changes);
+    }
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+  return n;
+}
+
+export function loadRelayFindings(db: DatabaseSync, days?: number): RelayFindingRow[] {
+  ensureRelayFindingsTable(db);
+  const where = days ? 'WHERE to_ts >= ?' : '';
+  const params = days ? [new Date(Date.now() - days * 86_400_000).toISOString()] : [];
+  return db.prepare(`SELECT * FROM relay_findings ${where} ORDER BY relayed_words DESC`)
+    .all(...params) as unknown as RelayFindingRow[];
+}

--- a/test/relay.test.ts
+++ b/test/relay.test.ts
@@ -171,3 +171,54 @@ test('secrets are redacted before anything is hashed', async () => {
   const leaked = secretShingles.filter((h) => b.has(h)).length;
   assert.ok(leaked <= 1, `secret-bearing shingles must not be stored (found ${leaked})`);
 });
+
+// ---- persisted findings and the cross-surfaced summary ----------------------
+
+import { recordRelayFindings, loadRelayFindings } from '../src/store.js';
+import { relaySummary } from '../src/relay-scan.js';
+
+test('findings persist, a rerun replaces rather than duplicates, and the summary aggregates', () => {
+  const db = openDb(':memory:');
+  const now = new Date().toISOString();
+  const row = (to: string, from: string, wordsN: number, overlap = 1) => ({
+    to_session_id: to, from_session_id: from, to_source: 'claude-code',
+    from_source: 'claude-code', to_project: 'p', overlap, relayed_words: wordsN, to_ts: now,
+  });
+
+  // Nothing recorded yet: the shared surfaces stay silent.
+  assert.equal(relaySummary(db), undefined);
+
+  recordRelayFindings(db, [row('B', 'A', 500), row('C', 'A', 300)]);
+  let s = relaySummary(db)!;
+  assert.equal(s.pairs, 2);
+  assert.equal(s.relayedWords, 800);
+  assert.equal(s.sessions, 2);
+
+  // A later scan with more history can revise a pair — it must replace, not
+  // accumulate, or the totals inflate on every run.
+  recordRelayFindings(db, [row('B', 'A', 900, 0.8)]);
+  assert.equal(loadRelayFindings(db).length, 2);
+  s = relaySummary(db)!;
+  assert.equal(s.relayedWords, 1200);
+
+  // Two pastes into one session are two findings but one affected session.
+  recordRelayFindings(db, [row('B', 'Z', 100)]);
+  assert.equal(relaySummary(db)!.pairs, 3);
+  assert.equal(relaySummary(db)!.sessions, 2);
+
+  // Findings carry ids and counts only — no text, no hashes.
+  const cols = Object.keys(loadRelayFindings(db)[0]).sort();
+  assert.deepEqual(cols, ['from_session_id', 'from_source', 'overlap', 'relayed_words',
+    'to_project', 'to_session_id', 'to_source', 'to_ts']);
+});
+
+test('the relay callout is out of the window once findings age out', () => {
+  const db = openDb(':memory:');
+  const old = new Date(Date.now() - 60 * 86_400_000).toISOString();
+  recordRelayFindings(db, [{
+    to_session_id: 'B', from_session_id: 'A', to_source: 'claude-code', from_source: 'claude-code',
+    to_project: 'p', overlap: 1, relayed_words: 500, to_ts: old,
+  }]);
+  assert.equal(relaySummary(db, { days: 30 }), undefined, 'outside the window');
+  assert.ok(relaySummary(db, { days: 90 }), 'inside a wider one');
+});


### PR DESCRIPTION
Second half of #65's surfacing, on top of #78.

The relay scan re-collects and re-shingles every transcript — ~22s on a real corpus — so `report` and `html` can't run it inline. They now read findings a previous `relay` run stored, exactly the arrangement categorize uses: the expensive derivation lives in its own command, the cheap read-only callout rides along.

```
📋 48 prompts repeated an earlier session's output (21.7k words carried by hand) — run `relay` for detail
```

**Findings replace rather than accumulate** on a rerun. A later scan with more history can revise a pair's origin or size, and appending would inflate the totals on every run. That is deliberately the opposite rule from `session_intents`, which freezes first-wins — a finding is a claim about the corpus, not a judgement about a session.

Rows carry session ids, sources, a project, an overlap and a word count. No text, no hashes; a test pins the column set.

**Still deferred:** the `paste-relay` trackable metric and the `handoff` family in `potentialBill`. Both require a metric on `computeMetrics`, which is pure over stored events and cannot reach the relay corpus — that needs its own design, not an extension of this one.

258 tests.