### PR TITLE
refactor: findings become a rule pack, one file per rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,5 +28,6 @@ If the user works in a VS Code-family IDE (VS Code, Cursor, Windsurf, Antigravit
 - **Zero runtime dependencies is a hard constraint** — only Node built-ins (`node:sqlite`, `node:util` parseArgs). Do not add packages.
 - Privacy is a hard constraint: adapters store aggregate numbers, tool names, timestamps, and project basenames — never prompt or code content. Fixtures must be synthetic; sample output in docs must use fictional project names and costs.
 - New adapters: follow CONTRIBUTING.md — `src/adapters/<name>.ts` with the log root as a parameter, fixtures under `test/fixtures/<name>/`, registered in `src/adapters/index.ts`.
+- New findings ("waste rules"): one file in `src/rules/` exporting a default `Rule` (contract in `src/rules/types.ts`), listed in `src/rules/index.ts`, with a test. `fires()` gets metrics only — it is called on merged team metrics too. `token-monitor rules` prints the catalogue.
 - Workflow: feature branches (`feat/...`, `fix/...`, `chore/...`) → PR → merge to `main`. Releases are tagged `vX.Y.Z`.
 - Never commit user-specific agent context (`.claude/`, `CLAUDE.md`, `.gemini/`) or generated reports/exports (`report.html`, `exports/`) — these are gitignored; keep them that way.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,11 @@
 # Contributing
 
-Thanks for helping make AI token spend measurable. The highest-value contribution is an **adapter for another agent CLI** — but bug fixes, persona-threshold tuning, and price-table updates are all welcome.
+Thanks for helping make AI token spend measurable. Two contribution paths are open by design:
+
+- **A waste rule** — one file, one fixture, one test. The smallest useful change, and the part of the tool where your own habits are better evidence than the maintainer's. Start here; see [Writing a waste rule](#writing-a-waste-rule).
+- **An adapter for another agent CLI** — bigger, and the highest-value change when a tool nobody has covered writes logs somewhere.
+
+Bug fixes, persona-threshold tuning, and price-table updates are all welcome too.
 
 ## Dev setup
 
@@ -13,6 +18,46 @@ npm test          # build + node:test suite
 Node ≥ 24, zero runtime dependencies (built-in `node:sqlite`, `node:util` parseArgs). Please keep it that way — the no-install-friction property is the point of the project.
 
 The suite has two layers: unit/integration tests per module, and `test/e2e.test.ts`, which spawns the built CLI as a subprocess against a synthetic `$HOME` seeded with the fixture logs and runs the full `collect → report → export → verify → merge → html → analyze` pipeline. If you add a command or flag, add an e2e case — unit tests alone don't cover the CLI wiring.
+
+## Writing a waste rule
+
+A **rule** is one heuristic that turns metrics into a finding: a firing condition, a message, and — when the waste is quantifiable — the arithmetic that prices it. Every recommendation the tool prints comes from one.
+
+Run `token-monitor rules` to see the catalogue and which fire on your own data, and `token-monitor rules <key>` for what one measures. Several are pre-specced as `good first issue` in the tracker, each with its failure modes written down.
+
+One file in `src/rules/`, listed once in `src/rules/index.ts`:
+
+```ts
+// src/rules/tool-retry-loops.ts
+import type { Rule } from './types.js';
+import { fmtTokens } from '../fmt.js';
+
+const rule: Rule = {
+  key: 'tool-retry-loops',        // stable id — follow-through baselines key on it
+  metric: 'retryShare',           // the tracked metric this rule wants to move
+  direction: 'down',
+  family: 'rework',               // savings de-overlap group; omit for advice-only rules
+  title: 'Paying to retry a tool that just failed',
+  docs: `What it measures, why it costs money, what to change. Printed by \`rules <key>\`.`,
+  fires: (m) => (m.retryShare >= 0.05 ? `${(m.retryShare * 100).toFixed(0)}% of spend goes to retries...` : undefined),
+  score: (s) => ({ score: s.m.retryTokens, label: `${fmtTokens(s.m.retryTokens)} retry tok` }),
+  savings: ({ m, rates }) => m.retryTokens * rates.spend,
+};
+export default rule;
+```
+
+Only `key`, `metric`, `direction`, `title`, `docs` and `fires` are required. `score` supplies the "worst sessions" evidence; `savings` prices the finding; `target`/`personalTarget` say what it is priced against; `clause` appends a sentence that needs the raw events. See `src/rules/types.ts` for the full contract and `src/rules/low-think-code.ts` for a rule that deliberately prices nothing.
+
+Four rules to write by:
+
+1. **`fires` gets metrics, never events.** It is also called on merged team metrics, where no events exist. Anything needing turns belongs in `score`, `savings` or `clause`.
+2. **Bias to false negatives.** Every finding is an accusation about how someone works. A missed one costs a little money; a wrong one costs the trust that makes the rest of the tool worth reading. Gate on volume, and say "no measurable X" rather than "X is waste".
+3. **Ship the caveat with the rule.** If your signal is a proxy (tool arguments aren't stored; a source doesn't report thinking tokens), the message says so. Sources that can't measure something report *nothing*, not zero.
+4. **Justify thresholds against real data in the PR.** Persona and cluster thresholds set the precedent: a number you picked because it looked round is a number nobody can defend later.
+
+Then a test in `test/rules.test.ts` (or its own file) with a synthetic window from `makeStored`: one case where it fires, one where it must stay silent, and — if it prices savings — one asserting the arithmetic. `npm test` must pass.
+
+If your new rule needs a metric that doesn't exist yet, add it to `Metrics` in `src/metrics.ts` and to the `MetricKey` union in `src/followthrough.ts` so follow-through can track whether the advice worked.
 
 ## Writing an adapter
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,17 @@ Every threshold-fired recommendation answers "why should I believe this and what
 
 These show up in `report`, `analyze`, the HTML dashboard, and ride along in signed exports (`recommendationDetails`).
 
+Each one comes from a **rule** — a single file under `src/rules/` holding its firing condition, its message, and the arithmetic that prices it. `token-monitor rules` lists the catalogue and marks which fire on your window; `token-monitor rules <key>` explains one:
+
+```
+  Rule                   Metric             Goal     Family   Savings
+  ────────────────────   ────────────────   ──────   ───────  ───────────
+⚠ low-cache-hit          cacheHitRatio      ↑ raise  caching  priced
+· low-think-code         thinkToCodeRatio   ↑ raise  —        advice only
+```
+
+Adding a rule is one file, one fixture and one test — the smallest useful contribution, and the fastest way to encode a waste pattern you keep hitting. See [CONTRIBUTING.md](CONTRIBUTING.md#writing-a-waste-rule).
+
 Three more pieces of intelligence:
 
 - **Personalized targets** — with enough sessions, targets come from *your own* top-quartile sessions ("your best sessions already hit 92% cache") instead of static heuristics; thin data falls back to the static targets.
@@ -312,6 +323,7 @@ token-monitor collect [--source claude-code|gemini-cli|codex|cursor|antigravity|
 token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>] [--json] [--no-categories] [--db <path>]
 token-monitor categorize [--days 30] [--threshold 0.4] [--min-cluster 2] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
+token-monitor rules   [<rule-key>] [--days 30] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
 token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline] [--verify] [--keys keys.json] [--threshold 0.4] [--min-cluster 2] [--json] [--html team.html]
 token-monitor reconcile [--provider anthropic|openai] [--days 30] [--db <path>]
@@ -319,7 +331,12 @@ token-monitor reconcile [--provider anthropic|openai] [--days 30] [--db <path>]
 
 ## Contributing
 
-The most valuable contribution: an adapter for another agent CLI (Aider, OpenCode, Cursor…). See [CONTRIBUTING.md](CONTRIBUTING.md) for the adapter guide, fixtures, and conventions. `npm test` runs the suite; CI covers Node 24/25 on Linux + macOS.
+Two ways in, both documented in [CONTRIBUTING.md](CONTRIBUTING.md):
+
+- **A waste rule** — one file in `src/rules/`, one fixture, one test. Several are pre-specced as `good first issue`.
+- **An adapter for another agent CLI** (Aider, OpenCode, Windsurf…) — bigger, and the highest-value change when a tool nobody has covered writes logs somewhere.
+
+`npm test` runs the suite; CI covers Node 24/25 on Linux + macOS.
 
 ## Roadmap
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import {
   openDb, insertEvents, loadEvents, DEFAULT_DB,
   relabelEvents, loadProjectAliases, applyProjectAliases, syncIntentProjects,
 } from './store.js';
-import { renderReport, renderTeamReport, renderTrend, renderCategorize, renderRelay } from './report.js';
+import { renderReport, renderTeamReport, renderTrend, renderCategorize, renderRelay, renderRules, renderRule, lookupRule } from './report.js';
 import { runRelayScan, relaySummary } from './relay-scan.js';
 import { runCategorize, categorizeSummary, exportCategories } from './categorize.js';
 import type { ExportCategory } from './team.js';
@@ -15,6 +15,7 @@ import { splitWindow } from './trends.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import { buildExport, parseTeamConfig, mergeMetrics, dedupeExports, rollupExports, displayName, identityOf } from './team.js';
 import { syncFindings, recordLlmFindings } from './followthrough.js';
+import { RULES } from './rules/index.js';
 import { enrichFindings } from './recommendations.js';
 import { reconcile, renderReconcile, PROVIDERS } from './reconcile.js';
 import { computeMetrics } from './metrics.js';
@@ -34,6 +35,7 @@ Usage:
   token-monitor categorize [--days <n>] [--threshold <0-1>] [--min-cluster <n>] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
   token-monitor analyze [--days <n>] [--llm] [--track] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor relay   [--days <n>] [--threshold <0-1>] [--source <name>] [--json] [--db <path>]
+  token-monitor rules   [<rule-key>] [--days <n>] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline]
                         [--verify] [--keys keys.json] [--threshold <0-1>]
@@ -59,6 +61,10 @@ Commands:
             hand-carried between sessions instead of handed over. Offline and
             on-device: comparison runs on hashed 8-word shingles, and prompt
             and response text is never stored, printed, or sent
+  rules     List the waste rules that produce findings — what each measures,
+            which fire on your current window, and where its file lives. With a
+            rule key, print that rule's documentation. Each rule is one file in
+            src/rules/; adding one is the smallest useful contribution.
   html      Self-contained HTML dashboard (no server, no external assets)
   merge     Combine member exports (report --json > me.json) into a team
             report; clusters member task categories to flag the same task done
@@ -482,6 +488,35 @@ Signing fingerprint (send to your team lead for keys.json):
     const { rows, breach } = await reconcile(provider, events, days);
     console.log(renderReconcile(provider, rows, days));
     if (breach) process.exit(1);
+  } else if (cmd === 'rules') {
+    const days = Number(values.days) || 30;
+    // Firing state is a convenience, not a requirement: the catalogue must
+    // still print on a machine that has never run `collect`.
+    const events = loadEvents(db, { days });
+    const m = events.length > 0 ? computeMetrics(events) : undefined;
+    const key = positionals[1];
+    if (values.json) {
+      console.log(JSON.stringify(
+        RULES.map((r) => ({
+          key: r.key, title: r.title, metric: r.metric, direction: r.direction,
+          family: r.family ?? null, priced: Boolean(r.savings),
+          firing: m ? Boolean(r.fires(m)) : null,
+          docs: r.docs,
+        })).filter((r) => !key || r.key === key),
+        null, 2,
+      ));
+      return;
+    }
+    if (key) {
+      const rule = lookupRule(key);
+      if (!rule) {
+        console.error(`Unknown rule "${key}". Run \`token-monitor rules\` for the list.`);
+        process.exit(1);
+      }
+      console.log(renderRule(rule, m));
+    } else {
+      console.log(renderRules(m));
+    }
   } else if (cmd === 'html') {
     const days = Number(values.days) || 30;
     const { current: events, previous } = splitWindow(loadEvents(db, { days: days * 2 }), days);

--- a/src/fmt.ts
+++ b/src/fmt.ts
@@ -1,0 +1,13 @@
+/**
+ * Formatting helpers with no dependencies of their own.
+ *
+ * `fmtTokens` used to live in report.ts, which imports the whole rendering
+ * and recommendation stack. Rules build their own evidence labels, so keeping
+ * the formatter here is what lets `src/rules/*` stay leaf modules instead of
+ * importing the renderer that renders them.
+ */
+export function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
+  return String(n);
+}

--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from 'node:sqlite';
 import type { Metrics } from './metrics.js';
-import { PREMIUM_MODEL_RE } from './pricing.js';
+import { premiumShare } from './metrics.js';
+import { RULES } from './rules/index.js';
 
 /**
  * Follow-through: a recommendation is only useful if you can see whether it
@@ -26,11 +27,7 @@ export type MetricKey =
   | 'premiumWasteShare'
   | 'retryShare';
 
-export function premiumShare(m: Metrics): number {
-  const premium = Object.entries(m.byModel).filter(([name]) => PREMIUM_MODEL_RE.test(name));
-  if (!premium.length) return 0;
-  return premium.reduce((s, [, v]) => s + v.tokens, 0) / (m.spendTokens || 1);
-}
+export { premiumShare };
 
 export function metricValue(m: Metrics, key: MetricKey): number {
   if (key === 'premiumShare') return premiumShare(m);
@@ -53,75 +50,19 @@ export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
   retryShare: 'down',
 };
 
+/**
+ * Every rule in the registry, asked whether it fires on these metrics. Rules
+ * live one-per-file under src/rules/ — adding a finding is a new file plus one
+ * line in rules/index.ts, and nothing else in the pipeline changes.
+ *
+ * Called with MERGED TEAM metrics as well as a single user's, so a rule may
+ * only look at the Metrics object it is handed — never at events.
+ */
 export function structuredFindings(m: Metrics): Finding[] {
   const out: Finding[] = [];
-  if (m.cacheHitRatio < 0.5 && m.spendTokens > 100_000) {
-    out.push({
-      key: 'low-cache-hit',
-      metric: 'cacheHitRatio',
-      direction: 'up',
-      message: `Cache hit ratio ${(m.cacheHitRatio * 100).toFixed(0)}% — low. Cache reads cost ~10% of fresh input; long-lived sessions and stable system context raise this. Biggest single cost lever.`,
-    });
-  }
-  if (m.reworkRatio > 0.2) {
-    out.push({
-      key: 'high-rework',
-      metric: 'reworkRatio',
-      direction: 'down',
-      message: `${(m.reworkRatio * 100).toFixed(0)}% of spend happens after test failures. Plan-first workflows and tighter task specs cut this.`,
-    });
-  }
-  if (m.thinkToCodeRatio < 0.15 && m.byActivity.coding.tokens > 50_000) {
-    out.push({
-      key: 'low-think-code',
-      metric: 'thinkToCodeRatio',
-      direction: 'up',
-      message: 'Very low think:code ratio. Teams that spend 15-30% of tokens on planning/exploration ship with less rework.',
-    });
-  }
-  const share = premiumShare(m);
-  if (share > 0.9 && Object.keys(m.byModel).length > 1) {
-    out.push({
-      key: 'premium-model-overuse',
-      metric: 'premiumShare',
-      direction: 'down',
-      message: `${(share * 100).toFixed(0)}% of tokens on premium models. Route exploration and boilerplate turns to a cheaper tier.`,
-    });
-  }
-  if (m.contextBloatShare >= 0.3 && m.trendSessions >= 3) {
-    out.push({
-      key: 'context-bloat',
-      metric: 'contextBloatShare',
-      direction: 'down',
-      message: `${m.bloatedSessions} of ${m.trendSessions} long sessions grow their context ≥2× without cache reads keeping pace — start a fresh session or compact at task boundaries before the context balloons.`,
-    });
-  }
-  // Volume gate on MAIN-LOOP spend: the ratio is measured over main-loop
-  // fresh input, so a 20k-token conversation must not clear the bar on the
-  // back of 500k spent by its subagents.
-  if (m.coldRestartShare >= 0.2 && m.spendTokens - (m.subagentSpendTokens ?? 0) > 100_000) {
-    out.push({
-      key: 'cold-restarts',
-      metric: 'coldRestartShare',
-      direction: 'down',
-      message: `${(m.coldRestartShare * 100).toFixed(0)}% of main-loop fresh input tokens were re-paid on ${m.coldRestartTurns} turns that resumed after their session's cache TTL${m.extendedCacheSessions ? ' (1 h where the session wrote to the extended cache, ~5 min otherwise)' : ' (~5 min)'}. Batch prompts within the cache window, or split long-idle work into new sessions.`,
-    });
-  }
-  if (m.premiumWasteShare >= 0.3 && m.spendTokens > 100_000) {
-    out.push({
-      key: 'premium-misroute',
-      metric: 'premiumWasteShare',
-      direction: 'down',
-      message: `${(m.premiumWasteShare * 100).toFixed(0)}% of spend is premium-model tokens on exploration/conversation turns. Route reads and chat to a cheaper tier; keep the premium model for code-writing turns.`,
-    });
-  }
-  if (m.retryShare >= 0.05) {
-    out.push({
-      key: 'tool-retry-loops',
-      metric: 'retryShare',
-      direction: 'down',
-      message: `${(m.retryShare * 100).toFixed(0)}% of spend goes to turns re-running a tool right after it errored. \`analyze\` shows which tools — fix the recurring cause (flaky command, bad path, missing permission) instead of paying for retries.`,
-    });
+  for (const rule of RULES) {
+    const message = rule.fires(m);
+    if (message) out.push({ key: rule.key, metric: rule.metric, direction: rule.direction, message });
   }
   return out;
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -114,6 +114,17 @@ export interface Metrics {
   subagentShare: number;
 }
 
+/**
+ * Premium-model share of spend. Lives here rather than in followthrough.ts so
+ * a rule can use it without importing the module that imports the rules.
+ * Re-exported from followthrough.js for the existing call sites.
+ */
+export function premiumShare(m: Metrics): number {
+  const premium = Object.entries(m.byModel).filter(([name]) => PREMIUM_MODEL_RE.test(name));
+  if (!premium.length) return 0;
+  return premium.reduce((s, [, v]) => s + v.tokens, 0) / (m.spendTokens || 1);
+}
+
 export function computeMetrics(events: StoredEvent[]): Metrics {
   const byActivity = Object.fromEntries(
     ACTIVITIES.map((a) => [a, { tokens: 0, share: 0, events: 0 }]),

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -1,12 +1,17 @@
 import type { Metrics } from './metrics.js';
-import { computeMetrics, groupBy, contextGrowthOf, extendedCacheOpportunity, BLOAT_MIN_TURNS } from './metrics.js';
+import { computeMetrics, groupBy } from './metrics.js';
 import type { StoredEvent } from './store.js';
 import type { Finding, FollowRow, MetricKey } from './followthrough.js';
-import { structuredFindings, premiumShare, fmtMetric } from './followthrough.js';
+import { structuredFindings, fmtMetric } from './followthrough.js';
 import { PRICES, PREMIUM_MODEL_RE } from './pricing.js';
-import { fmtTokens } from './report.js';
+import type { BlendedRates, RuleFamily, SessionInfo, Target } from './rules/types.js';
+import { RULE_BY_KEY, RULES } from './rules/index.js';
 import type { CauseBreakdown } from './causes.js';
 import { decomposeCause } from './causes.js';
+
+// The shapes rules are written against live with the rule contract; these
+// re-exports keep the existing `from './recommendations.js'` call sites working.
+export type { BlendedRates, SessionInfo, Target } from './rules/types.js';
 
 /**
  * Recommendations 2.0: every structured finding answers "why should I believe
@@ -39,34 +44,17 @@ export interface EnrichedRec extends Finding {
   cause?: CauseBreakdown;
 }
 
-/** Static fallback targets for the savings math, per finding key. */
-const TARGETS: Record<string, number> = {
-  'low-cache-hit': 0.8, // cache hit ratio to reach
-  'high-rework': 0.1, // rework ratio to reach
-  'premium-model-overuse': 0.5, // premium share to reach
-  'cold-restarts': 0.05, // cold-restart share to reach
-};
-
 /**
- * Session-skill metrics get personalized targets: with enough qualifying
- * sessions, the target is the top quartile of the user's OWN sessions —
- * "your best sessions prove this is reachable". Model-routing targets stay
- * static (model choice isn't a per-session skill).
+ * Sessions a personalized target is allowed to be computed from.
+ *
+ * "Your own best sessions prove this is reachable" is a claim about the user's
+ * conversations, and a subagent run reports 0 on the main-loop-scoped hygiene
+ * ratios by construction (its denominator is empty), so leaving runs in would
+ * drag every personal target to 0 and tell the user their top quartile already
+ * runs perfectly.
  */
-const PERSONAL_TARGET: Record<string, { metric: (m: Metrics) => number; direction: 'up' | 'down' }> = {
-  'low-cache-hit': { metric: (m) => m.cacheHitRatio, direction: 'up' },
-  'high-rework': { metric: (m) => m.reworkRatio, direction: 'down' },
-  'cold-restarts': { metric: (m) => m.coldRestartShare, direction: 'down' },
-};
-
 const PERSONAL_MIN_SESSIONS = 8;
 const PERSONAL_MIN_SPEND = 10_000; // ignore trivial sessions when benchmarking
-
-export interface Target {
-  value: number;
-  /** True when derived from the user's own top-quartile sessions. */
-  personal: boolean;
-}
 
 function quantile(sorted: number[], q: number): number {
   const pos = (sorted.length - 1) * q;
@@ -75,15 +63,17 @@ function quantile(sorted: number[], q: number): number {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo);
 }
 
+/**
+ * The improvement target a rule's savings are priced against: the user's own
+ * top-quartile sessions when the rule declares a personalized target and there
+ * is enough data, otherwise the rule's static target.
+ */
 export function targetFor(key: string, sessions: SessionInfo[]): Target | undefined {
-  const spec = PERSONAL_TARGET[key];
+  const rule = RULE_BY_KEY.get(key);
+  if (!rule) return undefined;
+  const spec = rule.personalTarget;
   if (spec) {
     const values = sessions
-      // "Your own best sessions prove this is reachable" is a claim about the
-      // user's conversations. A subagent run reports 0 on the main-loop-scoped
-      // hygiene ratios by construction (its denominator is empty), so leaving
-      // runs in would drag every personal target to 0 and tell the user their
-      // top quartile already runs perfectly.
       .filter((s) => !s.isSidechain && s.m.spendTokens >= PERSONAL_MIN_SPEND)
       .map((s) => spec.metric(s.m))
       .sort((a, b) => a - b);
@@ -92,44 +82,7 @@ export function targetFor(key: string, sessions: SessionInfo[]): Target | undefi
       return { value: quantile(values, spec.direction === 'up' ? 0.75 : 0.25), personal: true };
     }
   }
-  return key in TARGETS ? { value: TARGETS[key], personal: false } : undefined;
-}
-
-interface SessionInfo {
-  sessionId: string;
-  project: string;
-  date: string;
-  m: Metrics;
-  events: StoredEvent[];
-  /**
-   * One subagent run rather than a conversation. Context-bloat pricing and
-   * evidence skip these, because `contextBloatShare` — the metric that gates
-   * the finding — excludes them: scoring a fan-out here would bill the user
-   * for sessions the gate never counted and cite runs nobody can compact.
-   */
-  isSidechain: boolean;
-}
-
-/** $/token rates blended over the user's actual model mix in the window. */
-export interface BlendedRates {
-  input: number;
-  cacheRead: number;
-  /** Average realized $/spend-token across all priced usage. */
-  spend: number;
-  /** Realized $/spend-token on premium models only. */
-  premium: number;
-  /** Cheapest priced non-premium model the user already runs; tier-assumed when absent. */
-  cheap: number;
-  /**
-   * Blended $/token surcharge for writing to the 1-hour cache instead of the
-   * 5-minute one. Averaged over ONLY the models that publish both rates, so
-   * the two halves of the subtraction always describe the same population —
-   * blending the 5m rate over every model would let a vendor that doesn't
-   * bill cache writes at all drag it toward zero and inflate the premium.
-   * 0 when no model in the mix publishes an extended-tier price.
-   */
-  extendedWritePremium: number;
-  estimated: boolean;
+  return rule.target !== undefined ? { value: rule.target, personal: false } : undefined;
 }
 
 export function blendedRates(m: Metrics): BlendedRates {
@@ -179,128 +132,6 @@ export function blendedRates(m: Metrics): BlendedRates {
   };
 }
 
-/** Fresh tokens the late half of a bloated session paid beyond the early-half rate. */
-function bloatAvoidableTokens(events: StoredEvent[]): number {
-  if (events.length < BLOAT_MIN_TURNS) return 0;
-  const half = Math.floor(events.length / 2);
-  const fresh = (e: StoredEvent) => e.input_tokens + e.cache_creation_tokens;
-  const earlyFresh = events.slice(0, half).reduce((s, e) => s + fresh(e), 0);
-  const lateFresh = events.slice(events.length - half).reduce((s, e) => s + fresh(e), 0);
-  return Math.max(0, lateFresh - earlyFresh);
-}
-
-function premiumTokensOf(m: Metrics): number {
-  return Object.entries(m.byModel)
-    .filter(([name]) => PREMIUM_MODEL_RE.test(name))
-    .reduce((s, [, v]) => s + v.tokens, 0);
-}
-
-/** Per finding key: how bad is this session (higher = worse) and its evidence label. */
-const SCORERS: Record<string, (s: SessionInfo) => { score: number; label: string }> = {
-  'low-cache-hit': (s) => ({
-    score: s.m.inputTokens,
-    label: `cache ${(s.m.cacheHitRatio * 100).toFixed(0)}% · ${fmtTokens(s.m.inputTokens)} fresh input`,
-  }),
-  'high-rework': (s) => ({
-    score: s.m.reworkTokens,
-    label: `${fmtTokens(s.m.reworkTokens)} rework tok`,
-  }),
-  'low-think-code': (s) => ({
-    score: s.m.thinkToCodeRatio < 0.15 ? s.m.byActivity.coding.tokens : 0,
-    label: `think:code ${s.m.thinkToCodeRatio.toFixed(2)} · ${fmtTokens(s.m.byActivity.coding.tokens)} coding tok`,
-  }),
-  'premium-model-overuse': (s) => ({
-    score: premiumTokensOf(s.m),
-    label: `${fmtTokens(premiumTokensOf(s.m))} premium tok`,
-  }),
-  'context-bloat': (s) => {
-    const growth = contextGrowthOf(s.events);
-    return {
-      score: growth && growth.ratio >= 2 ? bloatAvoidableTokens(s.events) : 0,
-      label: `ctx ×${growth ? growth.ratio.toFixed(1) : '?'} · ${fmtTokens(bloatAvoidableTokens(s.events))} avoidable`,
-    };
-  },
-  'cold-restarts': (s) => ({
-    score: s.m.coldRestartTokens,
-    label: `${fmtTokens(s.m.coldRestartTokens)} re-paid after gaps`,
-  }),
-  'premium-misroute': (s) => ({
-    score: s.m.premiumWasteTokens,
-    label: `${fmtTokens(s.m.premiumWasteTokens)} premium on exploration/chat`,
-  }),
-  'tool-retry-loops': (s) => ({
-    score: s.m.retryTokens,
-    label: `${fmtTokens(s.m.retryTokens)} retry tok`,
-  }),
-};
-
-/** Estimated $ saved over the report window if the finding's metric hit its target. */
-function savingsUsd(
-  key: string,
-  m: Metrics,
-  rates: BlendedRates,
-  sessions: SessionInfo[],
-  target?: Target,
-): number | undefined {
-  const inputSide = m.cacheReadTokens + m.inputTokens + m.cacheCreationTokens;
-  switch (key) {
-    case 'low-cache-hit': {
-      // Tokens that would shift from fresh input to cache reads.
-      const moved = Math.max(0, (target?.value ?? 0) - m.cacheHitRatio) * inputSide;
-      return moved * (rates.input - rates.cacheRead);
-    }
-    case 'high-rework':
-      return Math.max(0, m.reworkRatio - (target?.value ?? 0)) * m.spendTokens * rates.spend;
-    case 'premium-model-overuse': {
-      const moved = Math.max(0, premiumShare(m) - (target?.value ?? 0)) * m.spendTokens;
-      return moved * Math.max(0, rates.premium - rates.cheap);
-    }
-    case 'premium-misroute':
-      return m.premiumWasteTokens * Math.max(0, rates.premium - rates.cheap);
-    case 'cold-restarts': {
-      // Price against the SAME population the ratio is measured over
-      // (main-loop fresh-paid input), or the number is inflated by the whole
-      // fan-out. Pre-0.13 exports have no base and no subagent rows either,
-      // so their own fresh-paid input is the right one.
-      const base = m.coldRestartBaseTokens ?? m.inputTokens + m.cacheCreationTokens;
-      const saved = Math.max(0, m.coldRestartShare - (target?.value ?? 0)) * base;
-      return saved * (rates.input - rates.cacheRead);
-    }
-    case 'context-bloat': {
-      const avoidable = sessions.reduce((s, info) => {
-        const g = info.isSidechain ? undefined : contextGrowthOf(info.events);
-        return g && g.ratio >= 2 ? s + bloatAvoidableTokens(info.events) : s;
-      }, 0);
-      // Conservative: avoided fresh context would have been cache reads at best.
-      return avoidable * (rates.input - rates.cacheRead);
-    }
-    case 'tool-retry-loops':
-      return m.retryTokens * rates.spend;
-    default:
-      return undefined; // e.g. low-think-code: an invest-more rec, not a savings one
-  }
-}
-
-/**
- * The other way to stop re-paying context: turn the 1-hour cache on. Priced
- * as a net — what the covered gaps would stop costing, minus the higher write
- * premium those sessions would start paying — and stated only when the net is
- * positive and material. Deliberately NOT folded into the finding's
- * `savingsUsdPerMonth`, which stays the "reach the target" number: two
- * different remedies with two different price tags, not one blended figure
- * nobody can reproduce.
- */
-function extendedCacheClause(events: StoredEvent[], rates: BlendedRates, monthly: number): string {
-  if (!rates.extendedWritePremium) return ''; // no model in the mix publishes an extended price
-  const { recoverableTokens, writeTokens, sessions } = extendedCacheOpportunity(events);
-  if (sessions === 0) return '';
-  const saved = recoverableTokens * (rates.input - rates.cacheRead);
-  const premium = writeTokens * rates.extendedWritePremium;
-  const net = (saved - premium) * monthly;
-  if (net < 1) return '';
-  return ` ${sessions} of these session(s) run on the 5-minute cache with gaps the 1-hour cache would have covered — enabling it nets about ${fmtUsdShort(net)}/mo after its higher write premium.`;
-}
-
 export function enrichFindings(events: StoredEvent[], m: Metrics, days: number): EnrichedRec[] {
   const findings = structuredFindings(m);
   if (findings.length === 0) return [];
@@ -317,24 +148,24 @@ export function enrichFindings(events: StoredEvent[], m: Metrics, days: number):
 
   return findings
     .map((f) => {
-      const scorer = SCORERS[f.key];
+      const rule = RULE_BY_KEY.get(f.key);
       // Evidence names sessions the user can go and change, so it ranks
       // conversations only. Subagent runs outnumber them ~14:1 and each turn
       // carries more absolute context, so leaving them in fills every "worst
       // 3 sessions" line with anonymous runs nobody can act on — their spend
       // is accounted for in the metric itself and in analyze's fan-out table.
-      const evidence = scorer
+      const evidence = rule?.score
         ? sessions
             .filter((s) => !s.isSidechain)
-            .map((s) => ({ s, ...scorer(s) }))
+            .map((s) => ({ s, ...rule.score!(s) }))
             .filter((x) => x.score > 0)
             .sort((a, b) => b.score - a.score)
             .slice(0, 3)
             .map(({ s, label }) => ({ sessionId: s.sessionId, project: s.project, date: s.date, label }))
         : [];
       const target = targetFor(f.key, sessions);
-      const extended = f.key === 'cold-restarts' ? extendedCacheClause(events, rates, monthly) : '';
-      const usd = savingsUsd(f.key, m, rates, sessions, target);
+      const extended = rule?.clause?.({ events, rates, monthly }) ?? '';
+      const usd = rule?.savings?.({ m, rates, sessions, target });
       const message =
         (target?.personal
           ? `${f.message} Your own top-quartile sessions already run at ${fmtMetric(f.metric, target.value)} — the target below assumes only that.`
@@ -355,14 +186,20 @@ export function enrichFindings(events: StoredEvent[], m: Metrics, days: number):
 
 /**
  * Per-rec savings overlap (misroute tokens are a subset of overuse tokens;
- * cold-restart tokens overlap the cache-hit gap). Group levers into families,
- * take the max within each, sum across — an honest combined number.
+ * cold-restart tokens overlap the cache-hit gap). Rules declare a `family`;
+ * within one we take the max and sum across families — an honest combined
+ * number. A rule with no family never contributes to the headline.
  */
-const FAMILIES: Array<{ family: string; keys: string[] }> = [
-  { family: 'caching', keys: ['low-cache-hit', 'cold-restarts', 'context-bloat'] },
-  { family: 'routing', keys: ['premium-model-overuse', 'premium-misroute'] },
-  { family: 'rework', keys: ['high-rework', 'tool-retry-loops'] },
-];
+function ruleFamilies(): Array<{ family: RuleFamily; keys: string[] }> {
+  const out = new Map<RuleFamily, string[]>();
+  for (const r of RULES) {
+    if (!r.family) continue;
+    const keys = out.get(r.family) ?? [];
+    keys.push(r.key);
+    out.set(r.family, keys);
+  }
+  return [...out].map(([family, keys]) => ({ family, keys }));
+}
 
 export interface PotentialBill {
   currentUsdPerMonth: number;
@@ -372,7 +209,7 @@ export interface PotentialBill {
 }
 
 export function potentialBill(recs: EnrichedRec[], m: Metrics, days: number): PotentialBill | undefined {
-  const families = FAMILIES.map(({ family, keys }) => ({
+  const families = ruleFamilies().map(({ family, keys }) => ({
     family,
     usdPerMonth: Math.max(
       0,

--- a/src/report.ts
+++ b/src/report.ts
@@ -17,6 +17,9 @@ import type { CategorizeResult, CategorizeSummary } from './categorize.js';
 import { fmtCategorizeSummary } from './categorize.js';
 import type { MergedCategories, OrgCategory } from './team-categories.js';
 import type { RelayResult, RelaySummary } from './relay-scan.js';
+import { fmtTokens } from './fmt.js';
+import type { Rule } from './rules/index.js';
+import { RULES, RULE_BY_KEY } from './rules/index.js';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -26,11 +29,10 @@ const YELLOW = '\x1b[33m';
 const GREEN = '\x1b[32m';
 const RED = '\x1b[31m';
 
-export function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
-  return String(n);
-}
+// Re-exported so the many `import { fmtTokens } from './report.js'` call
+// sites keep working; the implementation lives in fmt.ts so rules can use it
+// without importing the renderer.
+export { fmtTokens };
 
 function fmtCost(m: Metrics): string {
   const prefix = m.costEstimated ? '~' : '';
@@ -389,6 +391,66 @@ export function renderRelay(r: RelayResult): string {
     `  ${DIM}Overlap is measured on hashed 8-word shingles; prompt and response text is never stored, printed, or sent.${RESET}\n`,
   );
   return out.join('\n');
+}
+
+/**
+ * The rule catalogue — every waste heuristic the tool knows, whether it fires
+ * on the current window, and where its file lives. It doubles as the
+ * contributor's index: the list IS the extension point.
+ */
+export function renderRules(m?: Metrics): string {
+  const out: string[] = [];
+  out.push(section(`Waste rules (${RULES.length})`));
+  const firing = new Set(m ? RULES.filter((r) => r.fires(m)).map((r) => r.key) : []);
+  out.push(
+    table(
+      ['', 'Rule', 'Metric', 'Goal', 'Family', 'Savings'],
+      RULES.map((r) => [
+        m ? (firing.has(r.key) ? `${YELLOW}⚠${RESET}` : `${DIM}·${RESET}`) : ' ',
+        r.key,
+        r.metric,
+        r.direction === 'up' ? '↑ raise' : '↓ lower',
+        r.family ?? `${DIM}—${RESET}`,
+        r.savings ? 'priced' : `${DIM}advice only${RESET}`,
+      ]),
+    ),
+  );
+  if (m) {
+    const n = firing.size;
+    out.push(`\n  ${DIM}${n === 0 ? 'none firing' : `${n} firing`} on the current window (⚠). Run \`token-monitor rules <key>\` for what one measures.${RESET}`);
+  } else {
+    out.push(`\n  ${DIM}Run \`token-monitor rules <key>\` for what one measures, or with a collected database to see which fire.${RESET}`);
+  }
+  out.push(
+    `  ${DIM}Each rule is one file in src/rules/ — see CONTRIBUTING.md to add one.${RESET}\n`,
+  );
+  return out.join('\n');
+}
+
+/** One rule's documentation, for `token-monitor rules <key>`. */
+export function renderRule(rule: Rule, m?: Metrics): string {
+  const out: string[] = [];
+  out.push(section(`${rule.key} — ${rule.title}`));
+  out.push(
+    `  ${DIM}metric${RESET} ${rule.metric}  ${DIM}·${RESET} ${rule.direction === 'up' ? 'higher is better' : 'lower is better'}` +
+      `  ${DIM}·${RESET} family ${rule.family ?? 'none'}  ${DIM}·${RESET} ${rule.savings ? 'savings priced' : 'advice only'}`,
+  );
+  if (m) {
+    const message = rule.fires(m);
+    out.push(
+      message
+        ? `  ${YELLOW}⚠ fires on the current window:${RESET} ${message}`
+        : `  ${GREEN}✓${RESET} ${DIM}does not fire on the current window${RESET}`,
+    );
+  }
+  out.push('');
+  for (const line of rule.docs.split('\n')) out.push(`  ${line}`);
+  out.push(`\n  ${DIM}src/rules/${rule.key}.ts${RESET}\n`);
+  return out.join('\n');
+}
+
+export function lookupRule(key: string): Rule | undefined {
+  return RULE_BY_KEY.get(key);
 }
 
 export function renderEnrichedRecs(recs: EnrichedRec[]): string[] {

--- a/src/rules/cold-restarts.ts
+++ b/src/rules/cold-restarts.ts
@@ -1,0 +1,71 @@
+import type { Rule } from './types.js';
+import { extendedCacheOpportunity } from '../metrics.js';
+import { fmtTokens } from '../fmt.js';
+
+/** "$1.2k" / "$84" / "$3.40" — local copy so the rule stays a leaf module. */
+function usdShort(n: number): string {
+  if (n >= 1_000) return '$' + (n / 1000).toFixed(1) + 'k';
+  if (n >= 100) return '$' + n.toFixed(0);
+  return '$' + n.toFixed(2);
+}
+
+const rule: Rule = {
+  key: 'cold-restarts',
+  metric: 'coldRestartShare',
+  direction: 'down',
+  family: 'caching',
+  title: 'Context re-paid after idle gaps',
+  docs: `Turns that resume after a gap longer than their session's prompt-cache TTL
+re-pay the whole context as fresh input instead of reading it cheaply. The gap is
+measured against the TTL the session actually used: Claude Code reports how each
+cache write split between the 5-minute and 1-hour tiers, and a session whose
+writes are mostly 1-hour is scored against an hour.
+
+Main-loop only on both sides of the ratio. A subagent run is a back-to-back burst
+that never idles, and its remedy — batch prompts, split idle work — cannot be
+applied to something that is spawned and exits.
+
+Fires above 20% of main-loop fresh input, gated on main-loop spend so a small
+conversation cannot clear the bar on the back of its fan-out. Beyond the target
+savings, the rule adds a second, separately-priced remedy: for sessions still on
+the 5-minute cache, what turning on the 1-hour cache would net after its higher
+write premium.`,
+  fires: (m) =>
+    m.coldRestartShare >= 0.2 && m.spendTokens - (m.subagentSpendTokens ?? 0) > 100_000
+      ? `${(m.coldRestartShare * 100).toFixed(0)}% of main-loop fresh input tokens were re-paid on ${m.coldRestartTurns} turns that resumed after their session's cache TTL${m.extendedCacheSessions ? ' (1 h where the session wrote to the extended cache, ~5 min otherwise)' : ' (~5 min)'}. Batch prompts within the cache window, or split long-idle work into new sessions.`
+      : undefined,
+  score: (s) => ({
+    score: s.m.coldRestartTokens,
+    label: `${fmtTokens(s.m.coldRestartTokens)} re-paid after gaps`,
+  }),
+  target: 0.05,
+  personalTarget: { metric: (m) => m.coldRestartShare, direction: 'down' },
+  savings: ({ m, rates, target }) => {
+    // Price against the SAME population the ratio is measured over (main-loop
+    // fresh-paid input), or the number is inflated by the whole fan-out.
+    // Pre-0.13 exports have no base and no subagent rows either, so their own
+    // fresh-paid input is the right one.
+    const base = m.coldRestartBaseTokens ?? m.inputTokens + m.cacheCreationTokens;
+    const saved = Math.max(0, m.coldRestartShare - (target?.value ?? 0)) * base;
+    return saved * (rates.input - rates.cacheRead);
+  },
+  /**
+   * The other way to stop re-paying context: turn the 1-hour cache on. Priced
+   * as a net — what the covered gaps would stop costing, minus the higher write
+   * premium those sessions would start paying — and stated only when the net is
+   * positive and material. Deliberately NOT folded into savings, which stays the
+   * "reach the target" number: two remedies with two price tags, not one blended
+   * figure nobody can reproduce.
+   */
+  clause: ({ events, rates, monthly }) => {
+    if (!rates.extendedWritePremium) return ''; // no model in the mix publishes an extended price
+    const { recoverableTokens, writeTokens, sessions } = extendedCacheOpportunity(events);
+    if (sessions === 0) return '';
+    const saved = recoverableTokens * (rates.input - rates.cacheRead);
+    const premium = writeTokens * rates.extendedWritePremium;
+    const net = (saved - premium) * monthly;
+    if (net < 1) return '';
+    return ` ${sessions} of these session(s) run on the 5-minute cache with gaps the 1-hour cache would have covered — enabling it nets about ${usdShort(net)}/mo after its higher write premium.`;
+  },
+};
+export default rule;

--- a/src/rules/context-bloat.ts
+++ b/src/rules/context-bloat.ts
@@ -1,0 +1,54 @@
+import type { Rule } from './types.js';
+import type { StoredEvent } from '../store.js';
+import { contextGrowthOf, BLOAT_MIN_TURNS } from '../metrics.js';
+import { fmtTokens } from '../fmt.js';
+
+/** Fresh tokens the late half of a bloated session paid beyond the early-half rate. */
+function bloatAvoidableTokens(events: StoredEvent[]): number {
+  if (events.length < BLOAT_MIN_TURNS) return 0;
+  const half = Math.floor(events.length / 2);
+  const fresh = (e: StoredEvent) => e.input_tokens + e.cache_creation_tokens;
+  const earlyFresh = events.slice(0, half).reduce((s, e) => s + fresh(e), 0);
+  const lateFresh = events.slice(events.length - half).reduce((s, e) => s + fresh(e), 0);
+  return Math.max(0, lateFresh - earlyFresh);
+}
+
+const rule: Rule = {
+  key: 'context-bloat',
+  metric: 'contextBloatShare',
+  direction: 'down',
+  family: 'caching',
+  title: 'Sessions that balloon their own context',
+  docs: `Long sessions whose late-half context per turn is at least twice their
+early half, with cache reads failing to keep pace — so the growth is re-paid as
+fresh input rather than read cheaply. The remedy is a task boundary: compact, or
+start a new session.
+
+Measured over main-loop sessions only. A subagent run is spawned fresh, does one
+job and exits, and nobody can compact it; counting runs would bury a real hygiene
+problem in a denominator of things nobody can act on.
+
+Fires when at least 30% of long sessions bloat and there are at least 3 of them.
+Savings price the late-half excess fresh tokens at the fresh-minus-cache-read
+delta — conservatively, since avoided context would have been cache reads at
+best.`,
+  fires: (m) =>
+    m.contextBloatShare >= 0.3 && m.trendSessions >= 3
+      ? `${m.bloatedSessions} of ${m.trendSessions} long sessions grow their context ≥2× without cache reads keeping pace — start a fresh session or compact at task boundaries before the context balloons.`
+      : undefined,
+  score: (s) => {
+    const growth = contextGrowthOf(s.events);
+    return {
+      score: growth && growth.ratio >= 2 ? bloatAvoidableTokens(s.events) : 0,
+      label: `ctx ×${growth ? growth.ratio.toFixed(1) : '?'} · ${fmtTokens(bloatAvoidableTokens(s.events))} avoidable`,
+    };
+  },
+  savings: ({ rates, sessions }) => {
+    const avoidable = sessions.reduce((s, info) => {
+      const g = info.isSidechain ? undefined : contextGrowthOf(info.events);
+      return g && g.ratio >= 2 ? s + bloatAvoidableTokens(info.events) : s;
+    }, 0);
+    return avoidable * (rates.input - rates.cacheRead);
+  },
+};
+export default rule;

--- a/src/rules/high-rework.ts
+++ b/src/rules/high-rework.ts
@@ -1,0 +1,31 @@
+import type { Rule } from './types.js';
+import { fmtTokens } from '../fmt.js';
+
+const rule: Rule = {
+  key: 'high-rework',
+  metric: 'reworkRatio',
+  direction: 'down',
+  family: 'rework',
+  title: 'High rework after failures',
+  docs: `Share of spend on coding/testing turns that happen after the first failed
+turn in a session. High rework is the signature of work that started before it
+was specified: the agent codes, the test fails, and every subsequent turn pays a
+full context to iterate.
+
+Distinct from analyze's fix iterations, which counts testing->coding transitions
+— a session that barely tests can have high rework and no visible loops.
+User-declined permission prompts are not failures and never count.
+
+Fires above 20%. Savings price the excess over the target at the blended spend
+rate.`,
+  fires: (m) =>
+    m.reworkRatio > 0.2
+      ? `${(m.reworkRatio * 100).toFixed(0)}% of spend happens after test failures. Plan-first workflows and tighter task specs cut this.`
+      : undefined,
+  score: (s) => ({ score: s.m.reworkTokens, label: `${fmtTokens(s.m.reworkTokens)} rework tok` }),
+  target: 0.1,
+  personalTarget: { metric: (m) => m.reworkRatio, direction: 'down' },
+  savings: ({ m, rates, target }) =>
+    Math.max(0, m.reworkRatio - (target?.value ?? 0)) * m.spendTokens * rates.spend,
+};
+export default rule;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,0 +1,44 @@
+import type { Rule } from './types.js';
+import lowCacheHit from './low-cache-hit.js';
+import highRework from './high-rework.js';
+import lowThinkCode from './low-think-code.js';
+import premiumModelOveruse from './premium-model-overuse.js';
+import contextBloat from './context-bloat.js';
+import coldRestarts from './cold-restarts.js';
+import premiumMisroute from './premium-misroute.js';
+import toolRetryLoops from './tool-retry-loops.js';
+
+/**
+ * The rule registry.
+ *
+ * Adding a finding: write `src/rules/<key>.ts` exporting a default Rule (see
+ * types.ts for the contract), add it to this list, and add a test with a
+ * fixture. Nothing else in the pipeline changes — the report, the dashboard,
+ * follow-through, savings and the LLM payload all read from here.
+ *
+ * Order is the order findings fire in, which is the order they appear when
+ * savings can't rank them. Keep new rules at the end unless there is a reason.
+ */
+export const RULES: Rule[] = [
+  lowCacheHit,
+  highRework,
+  lowThinkCode,
+  premiumModelOveruse,
+  contextBloat,
+  coldRestarts,
+  premiumMisroute,
+  toolRetryLoops,
+];
+
+export const RULE_BY_KEY: Map<string, Rule> = new Map(RULES.map((r) => [r.key, r]));
+
+// A duplicate key would silently shadow a rule and corrupt follow-through
+// baselines (they are keyed on it). Fail at import instead — the contributor
+// who just copied a rule file sees it on the first `npm test`.
+if (RULE_BY_KEY.size !== RULES.length) {
+  const seen = new Set<string>();
+  const dup = RULES.map((r) => r.key).find((k) => seen.size === seen.add(k).size);
+  throw new Error(`duplicate rule key "${dup}" in src/rules/index.ts`);
+}
+
+export type { Rule } from './types.js';

--- a/src/rules/low-cache-hit.ts
+++ b/src/rules/low-cache-hit.ts
@@ -1,0 +1,37 @@
+import type { Rule } from './types.js';
+import { fmtTokens } from '../fmt.js';
+
+/** Cache reads cost ~10% of fresh input, so this is the biggest single lever. */
+const rule: Rule = {
+  key: 'low-cache-hit',
+  metric: 'cacheHitRatio',
+  direction: 'up',
+  family: 'caching',
+  title: 'Low cache hit ratio',
+  docs: `Cache reads are billed at roughly a tenth of fresh input, so the share of
+input-side tokens served from cache is the single largest cost lever in the data.
+A low ratio usually means sessions are short-lived, the system context keeps
+changing between turns, or work is spread across many cold starts.
+
+Fires below 50% on windows with more than 100k spend tokens. The savings figure
+prices the tokens that would move from the fresh-input rate to the cache-read
+rate if the ratio reached its target — the user's own top-quartile sessions when
+there are enough of them, 80% otherwise.`,
+  fires: (m) =>
+    m.cacheHitRatio < 0.5 && m.spendTokens > 100_000
+      ? `Cache hit ratio ${(m.cacheHitRatio * 100).toFixed(0)}% — low. Cache reads cost ~10% of fresh input; long-lived sessions and stable system context raise this. Biggest single cost lever.`
+      : undefined,
+  score: (s) => ({
+    score: s.m.inputTokens,
+    label: `cache ${(s.m.cacheHitRatio * 100).toFixed(0)}% · ${fmtTokens(s.m.inputTokens)} fresh input`,
+  }),
+  target: 0.8,
+  personalTarget: { metric: (m) => m.cacheHitRatio, direction: 'up' },
+  savings: ({ m, rates, target }) => {
+    const inputSide = m.cacheReadTokens + m.inputTokens + m.cacheCreationTokens;
+    // Tokens that would shift from fresh input to cache reads.
+    const moved = Math.max(0, (target?.value ?? 0) - m.cacheHitRatio) * inputSide;
+    return moved * (rates.input - rates.cacheRead);
+  },
+};
+export default rule;

--- a/src/rules/low-think-code.ts
+++ b/src/rules/low-think-code.ts
@@ -1,0 +1,31 @@
+import type { Rule } from './types.js';
+import { fmtTokens } from '../fmt.js';
+
+/**
+ * An invest-MORE finding: the remedy costs tokens rather than saving them, so
+ * it deliberately has no savings function and no family. Rules are allowed to
+ * be advice without a price tag.
+ */
+const rule: Rule = {
+  key: 'low-think-code',
+  metric: 'thinkToCodeRatio',
+  direction: 'up',
+  title: 'Very low think:code ratio',
+  docs: `Planning and exploration tokens per coding token. Teams that spend 15-30%
+of their tokens understanding the problem before writing code ship with
+measurably less rework; going straight to code trades a small planning cost for a
+larger fix-loop one.
+
+Fires below 0.15 once coding spend passes 50k tokens. There is no savings figure
+on purpose — the advice is to spend more up front, and pricing that as a saving
+would be dishonest. Watch reworkRatio to see whether it worked.`,
+  fires: (m) =>
+    m.thinkToCodeRatio < 0.15 && m.byActivity.coding.tokens > 50_000
+      ? 'Very low think:code ratio. Teams that spend 15-30% of tokens on planning/exploration ship with less rework.'
+      : undefined,
+  score: (s) => ({
+    score: s.m.thinkToCodeRatio < 0.15 ? s.m.byActivity.coding.tokens : 0,
+    label: `think:code ${s.m.thinkToCodeRatio.toFixed(2)} · ${fmtTokens(s.m.byActivity.coding.tokens)} coding tok`,
+  }),
+};
+export default rule;

--- a/src/rules/premium-misroute.ts
+++ b/src/rules/premium-misroute.ts
@@ -1,0 +1,28 @@
+import type { Rule } from './types.js';
+import { fmtTokens } from '../fmt.js';
+
+const rule: Rule = {
+  key: 'premium-misroute',
+  metric: 'premiumWasteShare',
+  direction: 'down',
+  family: 'routing',
+  title: 'Premium tokens on reading and chat',
+  docs: `The sharper half of the routing story: premium-model tokens spent on
+exploration and conversation turns, where a cheaper tier does the same job. Unlike
+premium-model-overuse this makes no claim about coding turns — keep the expensive
+model where it writes code.
+
+Fires above 30% of spend on windows over 100k tokens. Savings price those exact
+tokens at the premium-minus-cheap delta; no target is involved, because the
+number is already the misrouted tokens themselves.`,
+  fires: (m) =>
+    m.premiumWasteShare >= 0.3 && m.spendTokens > 100_000
+      ? `${(m.premiumWasteShare * 100).toFixed(0)}% of spend is premium-model tokens on exploration/conversation turns. Route reads and chat to a cheaper tier; keep the premium model for code-writing turns.`
+      : undefined,
+  score: (s) => ({
+    score: s.m.premiumWasteTokens,
+    label: `${fmtTokens(s.m.premiumWasteTokens)} premium on exploration/chat`,
+  }),
+  savings: ({ m, rates }) => m.premiumWasteTokens * Math.max(0, rates.premium - rates.cheap),
+};
+export default rule;

--- a/src/rules/premium-model-overuse.ts
+++ b/src/rules/premium-model-overuse.ts
@@ -1,0 +1,43 @@
+import type { Rule } from './types.js';
+import type { Metrics } from '../metrics.js';
+import { premiumShare } from '../metrics.js';
+import { PREMIUM_MODEL_RE } from '../pricing.js';
+import { fmtTokens } from '../fmt.js';
+
+function premiumTokensOf(m: Metrics): number {
+  return Object.entries(m.byModel)
+    .filter(([name]) => PREMIUM_MODEL_RE.test(name))
+    .reduce((s, [, v]) => s + v.tokens, 0);
+}
+
+const rule: Rule = {
+  key: 'premium-model-overuse',
+  metric: 'premiumShare',
+  direction: 'down',
+  family: 'routing',
+  title: 'Almost everything on the premium tier',
+  docs: `Share of spend on premium models. Fires above 90% — and only when the mix
+already contains more than one model, because advice to route work to a cheaper
+tier is useless to someone who has never run one.
+
+The target is static (50%), not personalized: model choice is a routing decision,
+not a per-session skill, so "your best sessions" says nothing about it. Savings
+price the moved tokens at the premium-minus-cheap rate delta, where "cheap" is
+the cheapest tier already in the user's own mix.`,
+  fires: (m) => {
+    const share = premiumShare(m);
+    return share > 0.9 && Object.keys(m.byModel).length > 1
+      ? `${(share * 100).toFixed(0)}% of tokens on premium models. Route exploration and boilerplate turns to a cheaper tier.`
+      : undefined;
+  },
+  score: (s) => ({
+    score: premiumTokensOf(s.m),
+    label: `${fmtTokens(premiumTokensOf(s.m))} premium tok`,
+  }),
+  target: 0.5,
+  savings: ({ m, rates, target }) => {
+    const moved = Math.max(0, premiumShare(m) - (target?.value ?? 0)) * m.spendTokens;
+    return moved * Math.max(0, rates.premium - rates.cheap);
+  },
+};
+export default rule;

--- a/src/rules/tool-retry-loops.ts
+++ b/src/rules/tool-retry-loops.ts
@@ -1,0 +1,26 @@
+import type { Rule } from './types.js';
+import { fmtTokens } from '../fmt.js';
+
+const rule: Rule = {
+  key: 'tool-retry-loops',
+  metric: 'retryShare',
+  direction: 'down',
+  family: 'rework',
+  title: 'Paying to retry a tool that just failed',
+  docs: `Spend on turns that re-run a tool which errored in the immediately
+previous turn. Each retry re-pays a full context to try the same thing again, and
+the underlying cause is almost always structural: a flaky command, a wrong path, a
+missing permission, a service that is down.
+
+Fires above 5% of spend — a low bar deliberately, because the fix is cheap and
+one-off. \`analyze\` names the offending tools and their error rates.
+
+Savings price the retry tokens at the blended spend rate.`,
+  fires: (m) =>
+    m.retryShare >= 0.05
+      ? `${(m.retryShare * 100).toFixed(0)}% of spend goes to turns re-running a tool right after it errored. \`analyze\` shows which tools — fix the recurring cause (flaky command, bad path, missing permission) instead of paying for retries.`
+      : undefined,
+  score: (s) => ({ score: s.m.retryTokens, label: `${fmtTokens(s.m.retryTokens)} retry tok` }),
+  savings: ({ m, rates }) => m.retryTokens * rates.spend,
+};
+export default rule;

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -1,0 +1,112 @@
+import type { Metrics } from '../metrics.js';
+import type { StoredEvent } from '../store.js';
+import type { MetricKey } from '../followthrough.js';
+
+/**
+ * The contract for a waste rule.
+ *
+ * One rule per file in this directory, listed once in index.ts. Everything a
+ * rule needs is passed in; a rule imports nothing from the report, the CLI, or
+ * the recommendation engine, so it can be written and tested on its own.
+ *
+ * The type import above is erased at runtime, which is what keeps
+ * followthrough.ts -> rules/index.ts -> rules/<key>.ts a straight line rather
+ * than a cycle. Keep runtime imports here pointed at leaf modules
+ * (metrics, pricing, fmt) only.
+ */
+
+/** The improvement goal a savings estimate is priced against. */
+export interface Target {
+  value: number;
+  /** True when derived from the user's own top-quartile sessions. */
+  personal: boolean;
+}
+
+/** $/token rates blended over the user's actual model mix in the window. */
+export interface BlendedRates {
+  input: number;
+  cacheRead: number;
+  /** Average realized $/spend-token across all priced usage. */
+  spend: number;
+  /** Realized $/spend-token on premium models only. */
+  premium: number;
+  /** Cheapest priced non-premium model the user already runs; tier-assumed when absent. */
+  cheap: number;
+  /**
+   * Blended $/token surcharge for writing to the 1-hour cache instead of the
+   * 5-minute one; 0 when no model in the mix publishes an extended-tier price.
+   */
+  extendedWritePremium: number;
+  estimated: boolean;
+}
+
+/** One session (or one subagent run) with its own metrics and turns. */
+export interface SessionInfo {
+  sessionId: string;
+  project: string;
+  date: string;
+  m: Metrics;
+  events: StoredEvent[];
+  /**
+   * This "session" is one subagent run, not a conversation. Evidence and
+   * personalized targets skip these — see the comments at their call sites.
+   */
+  isSidechain: boolean;
+}
+
+export interface SavingsArgs {
+  m: Metrics;
+  rates: BlendedRates;
+  /** Every session in the window, subagent runs included. */
+  sessions: SessionInfo[];
+  /** The target this estimate is priced against, when the rule declares one. */
+  target?: Target;
+}
+
+export interface ClauseArgs {
+  events: StoredEvent[];
+  rates: BlendedRates;
+  /** Multiplier turning a window figure into a monthly one. */
+  monthly: number;
+}
+
+/**
+ * Savings families. Levers inside one family overlap (cold-restart tokens are
+ * part of the cache-hit gap; misroute tokens are a subset of overuse tokens),
+ * so `potentialBill` takes the max within a family and sums across families.
+ * A rule with no family contributes evidence and advice but no headline $.
+ */
+export type RuleFamily = 'caching' | 'routing' | 'rework';
+
+export interface Rule {
+  /** Stable id. Follow-through baselines key on it — never rename a shipped key. */
+  key: string;
+  /** The tracked metric this rule wants to move. */
+  metric: MetricKey;
+  direction: 'up' | 'down';
+  family?: RuleFamily;
+  /** Short human name for `token-monitor rules`. */
+  title: string;
+  /** What it measures, why it costs money, and what to change. Printed by `rules <key>`. */
+  docs: string;
+  /**
+   * The firing condition. Return the finding's message, or undefined to stay
+   * quiet. Gets ONLY the metrics — it is also called on merged team metrics,
+   * where no events exist.
+   */
+  fires(m: Metrics): string | undefined;
+  /** How bad is this session for this rule (higher = worse), and its evidence label. */
+  score?(s: SessionInfo): { score: number; label: string };
+  /** Static improvement target for the savings math. */
+  target?: number;
+  /**
+   * Personalized target: with enough qualifying sessions, the user's own
+   * top-quartile value replaces `target` ("your best sessions prove this is
+   * reachable"). Only for per-session skills — model choice is not one.
+   */
+  personalTarget?: { metric: (m: Metrics) => number; direction: 'up' | 'down' };
+  /** Estimated $ saved over the window if the metric hit its target. */
+  savings?(a: SavingsArgs): number | undefined;
+  /** Extra sentence appended to the message when the rule fires (needs events). */
+  clause?(a: ClauseArgs): string;
+}

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -185,6 +185,26 @@ test('e2e: report --trend renders the trend section (empty previous window)', ()
   assert.ok(stdout.includes('No events in the previous window'));
 });
 
+test('e2e: rules lists the catalogue, explains one rule, and rejects an unknown key', () => {
+  const list = run(['rules', ...DAYS]);
+  assert.equal(list.code, 0);
+  assert.ok(list.stdout.includes('Waste rules'));
+  assert.ok(list.stdout.includes('low-cache-hit'));
+  assert.ok(list.stdout.includes('tool-retry-loops'));
+
+  const one = run(['rules', 'high-rework', ...DAYS]);
+  assert.equal(one.code, 0);
+  assert.ok(one.stdout.includes('src/rules/high-rework.ts'));
+
+  const json = JSON.parse(run(['rules', '--json', ...DAYS]).stdout);
+  assert.equal(json.length, 8);
+  assert.ok(json.every((r: { key: string; docs: string }) => r.key && r.docs.length > 0));
+
+  const bad = run(['rules', 'no-such-rule', ...DAYS]);
+  assert.equal(bad.code, 1);
+  assert.ok(bad.stderr.includes('Unknown rule'));
+});
+
 test('e2e: html writes a self-contained dashboard', () => {
   const out = join(HOME, 'dash.html');
   const { code } = run(['html', '--out', out, ...DAYS]);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RULES, RULE_BY_KEY } from '../src/rules/index.js';
+import { computeMetrics } from '../src/metrics.js';
+import { structuredFindings } from '../src/followthrough.js';
+import { enrichFindings, targetFor } from '../src/recommendations.js';
+import { renderRules, renderRule } from '../src/report.js';
+import { makeStored } from './helpers.js';
+import type { StoredEvent } from '../src/store.js';
+
+test('registry: keys are unique, complete, and every rule keeps the contract', () => {
+  assert.equal(RULE_BY_KEY.size, RULES.length, 'duplicate rule key');
+  for (const r of RULES) {
+    assert.ok(r.key && /^[a-z0-9-]+$/.test(r.key), `bad key: ${r.key}`);
+    assert.ok(r.title.length > 0, `${r.key} has no title`);
+    assert.ok(r.docs.length > 80, `${r.key} needs real docs — they are what \`rules <key>\` prints`);
+    assert.ok(['up', 'down'].includes(r.direction));
+    // A rule that prices savings must declare what it is priced against:
+    // either a target (static or personalized) or tokens it can name directly.
+    assert.equal(typeof r.fires, 'function');
+  }
+});
+
+test('registry: a rule that declares no target still yields no target', () => {
+  assert.equal(targetFor('low-think-code', []), undefined);
+  assert.deepEqual(targetFor('low-cache-hit', []), { value: 0.8, personal: false });
+  assert.equal(targetFor('not-a-rule', []), undefined);
+});
+
+/** The eight rules the tool shipped with, in firing order. Renaming a key breaks
+ *  follow-through baselines in every existing database, so it is asserted here. */
+test('registry: shipped rule keys and their order are stable', () => {
+  assert.deepEqual(RULES.map((r) => r.key), [
+    'low-cache-hit',
+    'high-rework',
+    'low-think-code',
+    'premium-model-overuse',
+    'context-bloat',
+    'cold-restarts',
+    'premium-misroute',
+    'tool-retry-loops',
+  ]);
+});
+
+function wastefulWindow(): StoredEvent[] {
+  const out: StoredEvent[] = [];
+  // 12 turns of premium exploration with no cache reads: low cache hit,
+  // premium overuse + misroute, all on one session.
+  for (let i = 0; i < 12; i++) {
+    out.push(makeStored({
+      session_id: 'burn',
+      ts: `2026-06-0${1 + Math.floor(i / 6)}T0${i % 6}:00:00.000Z`,
+      model: 'claude-opus-4-7',
+      activity: 'exploration',
+      input_tokens: 40_000,
+      output_tokens: 2_000,
+    }));
+  }
+  out.push(makeStored({ session_id: 'cheap', model: 'claude-haiku-4-5', activity: 'coding', input_tokens: 1_000 }));
+  return out;
+}
+
+test('rules fire through the registry and reach enrichFindings with evidence', () => {
+  const events = wastefulWindow();
+  const m = computeMetrics(events);
+  const keys = structuredFindings(m).map((f) => f.key);
+  assert.ok(keys.includes('low-cache-hit'), 'low-cache-hit should fire');
+  assert.ok(keys.includes('premium-misroute'), 'premium-misroute should fire');
+
+  const enriched = enrichFindings(events, m, 30);
+  const cache = enriched.find((r) => r.key === 'low-cache-hit')!;
+  assert.ok(cache.savingsUsdPerMonth! > 0, 'priced rule produces savings');
+  assert.equal(cache.evidence[0].sessionId, 'burn', 'score() picks the worst session');
+  // low-think-code declares no savings function: advice-only rules stay unpriced.
+  const think = enriched.find((r) => r.key === 'low-think-code');
+  if (think) assert.equal(think.savingsUsdPerMonth, undefined);
+});
+
+test('cold-restarts contributes its extended-cache clause through Rule.clause', () => {
+  // Two turns an hour apart on the 5-minute cache: the gap is recoverable by
+  // the 1-hour tier, which is what the clause prices.
+  const events: StoredEvent[] = [];
+  for (let i = 0; i < 6; i++) {
+    events.push(makeStored({
+      session_id: 'gappy',
+      ts: `2026-06-01T0${i}:00:00.000Z`,
+      model: 'claude-opus-4-7',
+      input_tokens: 200_000,
+      cache_creation_tokens: 10_000,
+      output_tokens: 1_000,
+      activity: 'coding',
+    }));
+  }
+  const m = computeMetrics(events);
+  const rec = enrichFindings(events, m, 30).find((r) => r.key === 'cold-restarts');
+  assert.ok(rec, 'cold-restarts should fire on hourly gaps with 5-minute cache writes');
+  assert.match(rec!.message, /1-hour cache would have covered/);
+});
+
+test('renderRules lists every rule; renderRule prints one rule with its firing state', () => {
+  const m = computeMetrics(wastefulWindow());
+  const listed = renderRules(m);
+  for (const r of RULES) assert.ok(listed.includes(r.key), `${r.key} missing from the catalogue`);
+  assert.match(listed, /firing on the current window/);
+
+  const one = renderRule(RULE_BY_KEY.get('low-cache-hit')!, m);
+  assert.match(one, /src\/rules\/low-cache-hit\.ts/);
+  assert.match(one, /fires on the current window/);
+  // With no metrics at all the catalogue still renders (never-collected machine).
+  assert.ok(renderRules().includes('tool-retry-loops'));
+});


### PR DESCRIPTION
Closes #81.

## Why

Adding a finding meant editing five places across two files: `structuredFindings`, `TARGETS`, `PERSONAL_TARGET`, `SCORERS`, the `savingsUsd` switch and `FAMILIES`. That shape is the reason this project has one contributor — the only documented way in is an adapter, which is a high-context PR against an undocumented vendor format, and the three open adapter issues have had no takers since June.

## What

Every finding is now one file under `src/rules/`, holding its firing condition, evidence scorer, target, savings math and its own documentation, listed once in `src/rules/index.ts`.

- `structuredFindings`, `enrichFindings`, `potentialBill` and every finding **key** are unchanged, so follow-through baselines in existing databases keep working. The refactor is invisible in output: the pre-existing suite passes untouched.
- `fires(m)` takes metrics only — it is called on merged team metrics too, where no events exist. Anything needing turns goes in `score` / `savings` / `clause`.
- The cold-restart extended-cache sentence stops being a special case in `enrichFindings` and becomes that rule's own `clause`.
- `fmtTokens` moves to `src/fmt.ts` and `premiumShare` to `src/metrics.ts` so rules stay leaf modules rather than importing the renderer that renders them.

## New command

`token-monitor rules` prints the catalogue and marks which rules fire on the current window; `token-monitor rules <key>` prints one rule's docs and its firing state; `--json` for both.

## Contributor path

CONTRIBUTING gains a "Writing a waste rule" section: the contract, the four rules to write by (metrics-only firing, false-negative bias, ship the caveat with the rule, justify thresholds against real data), and the test shape. Eight rules are pre-specced as `good first issue` (#87–#94), each with its failure modes written down.

## Tests

`test/rules.test.ts` — registry integrity, key/order stability (renaming a key would break every stored baseline), advice-only rules staying unpriced, evidence selection, the cold-restart clause, and both renderers. `test/e2e.test.ts` covers the new command end to end. 265 pass.