### PR TITLE
feat: ship token-monitor as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "token-monitor",
+  "description": "token-monitor — measure what your coding-agent tokens actually buy, locally and with zero setup.",
+  "owner": {
+    "name": "Ryan de Melo",
+    "url": "https://github.com/ryandemelo"
+  },
+  "plugins": [
+    {
+      "name": "token-monitor",
+      "description": "Analyze your local agent session logs: where tokens go, what they cost, and what to change. No API keys, no server, no telemetry.",
+      "source": "./",
+      "category": "productivity",
+      "homepage": "https://github.com/ryandemelo/token-monitor"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "token-monitor",
+  "version": "0.13.0",
+  "description": "Measure how effectively you spend AI coding-agent tokens: activity breakdown, cache/rework/context-surface signals, and priced recommendations — locally, from the session logs your agents already write.",
+  "author": {
+    "name": "Ryan de Melo",
+    "url": "https://github.com/ryandemelo"
+  },
+  "homepage": "https://github.com/ryandemelo/token-monitor",
+  "repository": "https://github.com/ryandemelo/token-monitor",
+  "license": "MIT",
+  "keywords": ["tokens", "cost", "usage", "analytics", "productivity"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ token-monitor collect && token-monitor report
 
 After installing, run `collect` then `report` and walk the user through their activity breakdown, cache hit ratio, rework ratio, and persona. `token-monitor context` adds what the standing surface costs — the session floor, tool-result carry, per-MCP-server spend, and connected servers nothing invokes. Tool and server names in that output are local-only: don't paste them anywhere they'd leave the user's machine.
 
+If the user is in Claude Code, mention the plugin: `/plugin marketplace add ryandemelo/token-monitor` then `/plugin install token-monitor` — it adds `/token-report`, `/token-context`, `/token-rules` and a skill covering the whole workflow.
+
 If the user works in a VS Code-family IDE (VS Code, Cursor, Windsurf, Antigravity), mention the extension: `.vsix` attached to the latest GitHub release, installed via "Extensions: Install from VSIX…" — status-bar token/cost plus the dashboard in a webview.
 
 ## Working on the codebase
@@ -30,4 +32,5 @@ If the user works in a VS Code-family IDE (VS Code, Cursor, Windsurf, Antigravit
 - New adapters: follow CONTRIBUTING.md — `src/adapters/<name>.ts` with the log root as a parameter, fixtures under `test/fixtures/<name>/`, registered in `src/adapters/index.ts`.
 - New findings ("waste rules"): one file in `src/rules/` exporting a default `Rule` (contract in `src/rules/types.ts`), listed in `src/rules/index.ts`, with a test. `fires()` gets metrics only — it is called on merged team metrics too. `token-monitor rules` prints the catalogue.
 - Workflow: feature branches (`feat/...`, `fix/...`, `chore/...`) → PR → merge to `main`. Releases are tagged `vX.Y.Z`.
+- The Claude Code plugin (`.claude-plugin/`, `commands/`, `skills/`, `hooks/`) is markdown + JSON over the CLI: no parsing logic there, and `plugin.json`'s version tracks `package.json` (asserted in `test/plugin.test.ts`).
 - Never commit user-specific agent context (`.claude/`, `CLAUDE.md`, `.gemini/`) or generated reports/exports (`report.html`, `exports/`) — these are gitignored; keep them that way.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ Adapters skip gracefully when a tool isn't installed. The Cursor adapter reads o
 
 **Subagent coverage.** Claude Code writes each Task/Agent run to its own transcript under the session directory, and the main transcript never mentions what those runs spent. token-monitor reads them: on the maintainer's own 30-day window that is 24% of spend across 2,027 runs — invisible to every version before 0.13, and to any tool that reads only the top level. The format is vendor-internal and undocumented, so parsing is fail-soft (a reshaped or unreadable agent file costs its own turns, never the collect). Only Claude Code is known to persist this; the other five sources report no sidechain data, so their subagent share reads as absent rather than zero.
 
+## Claude Code plugin
+
+```
+/plugin marketplace add ryandemelo/token-monitor
+/plugin install token-monitor
+```
+
+Adds `/token-report`, `/token-context` and `/token-rules`, plus a skill that teaches the agent the whole workflow — including the rules that matter: quote the numbers the tool produced, keep the `~` on estimates, treat absent as absent rather than zero, and never move tool or MCP-server names off the machine.
+
+An **opt-in** `SessionStart` hook can name the rules currently firing on your own data. It is silent until you turn it on (`touch ~/.token-monitor/session-hint`), never runs a collect, never touches the network, and fails open. The plugin is a thin wrapper over the CLI — the same contract the IDE extension follows.
+
 ## IDE extension
 
 [`extension/`](extension/) ships a VS Code-family extension (works in VS Code, Cursor, Windsurf, Antigravity): status-bar tokens/cost for the current project and the dashboard in a webview, both powered by the CLI. Install **[Token Monitor](https://marketplace.visualstudio.com/items?itemName=ryan653133.token-monitor)** from the VS Code Marketplace (search "token-monitor"), or grab the `.vsix` from the latest release and use *Extensions: Install from VSIX…*

--- a/commands/token-context.md
+++ b/commands/token-context.md
@@ -1,0 +1,15 @@
+---
+description: Show what the standing context surface costs — floor, tool-result carry, MCP servers
+---
+
+Run `npx -y @ryandemelo/token-monitor context` (after `collect` if the database is empty) and explain what it found.
+
+Cover:
+- **Session floor** — the smallest context each session runs with: system prompt, the tool definitions of every connected MCP server, loaded skills, `CLAUDE.md` and its imports. Frame it as the standing cost re-read every turn, not as waste; the question is whether it is creeping, which `report --trend` answers.
+- **Tool-result carry** — result size × the turns it kept riding in context. Point at the specific tools at the top of the table and suggest concrete bounds: a line limit, a narrower search, a paged MCP call, or handing the payload to a subagent whose context ends with it.
+- **MCP servers** — spend and error rate per server, and any server that is connected but was never invoked in the window. Say clearly that usage is not value: a server called twice may have saved an afternoon. A server called zero times is paying for its tool definitions on every request.
+
+Rules:
+- Everything in this command's output is an estimate (`~`): sizes come from characters at ~4 chars/token, and carry is an upper bound cut at the last measurable context collapse. Say so once, plainly.
+- Tool and MCP server names in this output are **local only**. Do not put them in a file, a commit, an issue, or any message that leaves the user's machine unless they ask for exactly that.
+- Only Claude Code persists tool results today. For other sources carry reads as unmeasured, which is not the same as zero — do not report it as zero.

--- a/commands/token-report.md
+++ b/commands/token-report.md
@@ -1,0 +1,18 @@
+---
+description: Collect local agent logs and walk through where this month's tokens went
+---
+
+Run token-monitor over the user's local agent session logs and explain the result.
+
+1. Run `npx -y @ryandemelo/token-monitor collect` (idempotent; safe to re-run). If `token-monitor` is already on PATH, use that instead — it is faster and pinned.
+2. Run `npx -y @ryandemelo/token-monitor report --trend`.
+3. Summarize for the user, in this order:
+   - the headline: spend, cost, cache hit ratio, and the coverage line (a window with gaps must be stated, not glossed over);
+   - the activity breakdown — what the tokens bought (thinking, exploration, coding, testing, shipping);
+   - the persona and the top two or three recommendations, each with the savings estimate and the evidence sessions the tool cited;
+   - the trend arrows, and say plainly when the tool reports `insufficient data` rather than inventing a direction.
+
+Rules:
+- Report the numbers the tool produced. Do not re-derive, re-estimate, or round them into something more flattering.
+- Figures marked `~` are estimates (placeholder prices, or estimated token counts for sources that do not report them). Keep the mark when you quote them.
+- If Node is older than 24 or the collect finds nothing, say so and stop — do not guess at usage.

--- a/commands/token-rules.md
+++ b/commands/token-rules.md
@@ -1,0 +1,9 @@
+---
+description: List the waste rules, which fire on this window, and explain one
+---
+
+Run `npx -y @ryandemelo/token-monitor rules` and show the user the catalogue: what each rule measures, which fire on their current window (marked ⚠), and which are priced versus advice-only.
+
+If the user asks about a specific finding, run `npx -y @ryandemelo/token-monitor rules <key>` and explain it in their terms, including the caveats the rule's own documentation states.
+
+If the user describes a waste pattern that no rule covers, tell them a rule is one file in `src/rules/`, one fixture and one test — and point them at CONTRIBUTING.md in https://github.com/ryandemelo/token-monitor. Several are pre-specced as `good first issue`.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Opt-in session hint: names the waste rules currently firing on your own data. Silent unless you turn it on.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-hint.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/session-hint.sh
+++ b/hooks/session-hint.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Opt-in SessionStart hint: which waste rules currently fire on your own data.
+#
+# OFF BY DEFAULT. Turn it on with:
+#   touch ~/.token-monitor/session-hint
+# or by exporting TOKEN_MONITOR_SESSION_HINT=1. Turn it off by removing either.
+#
+# Three things this must never do, because a session start is not a report:
+#   - run `collect` (a scan takes seconds; starting a session is not the moment)
+#   - reach the network (no npx: the CLI must already be installed)
+#   - fail loudly (any problem here exits 0 with no output)
+set -u
+
+hint_enabled() {
+  [ "${TOKEN_MONITOR_SESSION_HINT:-0}" = "1" ] && return 0
+  [ -f "${HOME}/.token-monitor/session-hint" ] && return 0
+  return 1
+}
+
+hint_enabled || exit 0
+command -v token-monitor >/dev/null 2>&1 || exit 0
+[ -f "${HOME}/.token-monitor/token-monitor.sqlite" ] || exit 0
+
+firing=$(token-monitor rules --days 7 --json 2>/dev/null |
+  node -e '
+    let s = "";
+    process.stdin.on("data", (d) => (s += d)).on("end", () => {
+      try {
+        const rules = JSON.parse(s).filter((r) => r.firing);
+        if (rules.length) process.stdout.write(rules.map((r) => r.key).join(", "));
+      } catch { /* nothing to say */ }
+    });
+  ' 2>/dev/null)
+
+[ -n "${firing}" ] || exit 0
+echo "token-monitor (last 7 days): ${firing}. Run \`token-monitor report\` for the evidence and the priced fix, or \`token-monitor rules <key>\` for what one measures."
+exit 0

--- a/skills/token-monitor/SKILL.md
+++ b/skills/token-monitor/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: token-monitor
+description: >
+  Measure and explain AI coding-agent token spend from local session logs — activity
+  breakdown, cache/rework/context-surface signals, per-task duplicate work, and priced
+  recommendations. Use when the user asks where their tokens or agent costs are going,
+  why a project is expensive, whether their agent usage is efficient, what an MCP server
+  or a big tool result is costing them, or asks to install / run / interpret token-monitor.
+---
+
+# token-monitor
+
+A local, zero-dependency CLI that parses the session logs Claude Code, Gemini CLI, Codex, Cursor, Antigravity and Copilot Chat already write, and answers *what the tokens bought*. No API keys, no server, no telemetry. Requires Node ≥ 24.
+
+Run it with `npx -y @ryandemelo/token-monitor <command>`, or `token-monitor <command>` when it is installed globally.
+
+## The workflow
+
+| Step | Command | What it answers |
+|---|---|---|
+| 1 | `collect` | Scan local logs into `~/.token-monitor/token-monitor.sqlite`. Idempotent — safe to re-run any time, and required before anything else. |
+| 2 | `report [--trend]` | Where the tokens go, what they cost, the persona, the priced recommendations, and follow-through on earlier advice. |
+| 3 | `context` | What the standing surface costs: session floor, tool-result carry, per-MCP-server spend, connected-but-unused servers. |
+| 4 | `analyze` | Which *sessions and habits* burn the tokens: expensive sessions, fix loops, context bloat, cold restarts, subagent fan-out, tool error rates. |
+| 5 | `categorize` | Cluster sessions by task intent; flag the same task re-derived across projects. |
+| 6 | `relay` | Prompts that repeat an earlier session's output — text hand-carried between sessions instead of handed over. |
+| 7 | `rules [<key>]` | The catalogue of waste rules and which fire on this window. |
+| — | `html --out report.html` | Self-contained dashboard, no server or external assets. |
+| — | `merge <exports>` | Team rollups from signed member exports. |
+
+## Reading the numbers
+
+- **Cache hit ratio** — cache reads cost ~10% of fresh input. The single biggest cost lever.
+- **Rework ratio** — spend on coding/testing turns after the first failure in a session. High rework usually means skipped planning. Declined permission prompts are not failures.
+- **Think:code** — planning + exploration tokens per coding token. Low values correlate with high rework.
+- **Context bloat / cold restarts / session floor / tool-result carry** — four different context problems with four different remedies: compact at task boundaries; batch prompts inside the cache window; trim what is loaded on every session; bound what tools return.
+- **Subagent share** — spend from Task/Agent fan-out. Descriptive, never a verdict: delegating heavily is often exactly right. Read it against what the fan-out produced.
+- **Personas** — architect, surgeon, explorer, sprinter, firefighter, balanced — with recommendations tailored to each.
+
+Recommendations carry evidence (the worst sessions, by id and date) and a priced estimate from the user's own model mix. Once a recommendation fires, follow-through tracks whether its metric actually moved.
+
+## Rules for using this tool
+
+1. **Report what it printed.** Never re-estimate, extrapolate, or smooth a number into a better story. If the coverage line reports gaps, say so before quoting anything.
+2. **Keep the `~`.** It marks placeholder prices and estimated token counts. Quoting an estimate as exact is the fastest way to make the whole report untrustworthy.
+3. **Names stay local.** Tool names, MCP server names and subagent type names are shown on the machine and never leave it. Do not paste them into files, commits, issues, or messages unless the user explicitly asks for exactly that. Project names are basenames and are safe to discuss with the user, but exports carry aggregates only.
+4. **`--llm` sends data off the machine.** `analyze --llm` hands aggregates (counts, ratios, redacted tool names, project basenames — never prompts or code) to whichever agent CLI is installed. Say so before running it; skip it if project names are sensitive.
+5. **Absent is not zero.** Sources that cannot report something (Cursor has no cache split, Copilot has no token counts, only Claude Code persists tool results and subagent transcripts) report *nothing*. Never read that as "zero waste".
+6. **One finding at a time.** The user came with a question, not a dashboard. Lead with the largest priced lever and its evidence.
+
+## When the user wants more
+
+- Team rollups: each member runs `report --json > me.json`, the lead runs `merge exports/*.json --team team.yaml`. Exports are Ed25519-signed and carry aggregates only.
+- A waste pattern the tool does not measure: a rule is one file in `src/rules/`, one fixture and one test — see CONTRIBUTING.md in https://github.com/ryandemelo/token-monitor.

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync, mkdtempSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The Claude Code plugin is markdown and JSON wrapped around the CLI, so the
+ * things that can break it are: a manifest that stops parsing, a version that
+ * drifts from the package, a command that tells an agent to run a subcommand
+ * that no longer exists, and a session hook that says something when it was
+ * never turned on.
+ */
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const CLI = join(ROOT, 'dist', 'src', 'cli.js');
+const read = (...p: string[]) => readFileSync(join(ROOT, ...p), 'utf8');
+const readJson = (...p: string[]) => JSON.parse(read(...p));
+
+test('plugin manifests parse and stay pinned to the package version', () => {
+  const pkg = readJson('package.json');
+  const plugin = readJson('.claude-plugin', 'plugin.json');
+  const marketplace = readJson('.claude-plugin', 'marketplace.json');
+
+  assert.equal(plugin.name, 'token-monitor');
+  assert.equal(plugin.version, pkg.version, 'plugin.json version must track package.json');
+  assert.ok(plugin.description.length > 20);
+  assert.equal(marketplace.plugins.length, 1);
+  assert.equal(marketplace.plugins[0].name, plugin.name);
+  assert.equal(marketplace.plugins[0].source, './');
+});
+
+test('every plugin command references CLI subcommands that actually exist', () => {
+  const help = spawnSync(process.execPath, [CLI, '--help'], { encoding: 'utf8' }).stdout;
+  const known = new Set(
+    [...help.matchAll(/^\s{2}token-monitor (\w+)/gm)].map((m) => m[1]),
+  );
+  assert.ok(known.size > 5, 'could not parse the CLI help output');
+
+  const dir = join(ROOT, 'commands');
+  const files = readdirSync(dir).filter((f) => f.endsWith('.md'));
+  assert.ok(files.length >= 3);
+  for (const file of files) {
+    const body = readFileSync(join(dir, file), 'utf8');
+    assert.match(body, /^---\ndescription: /, `${file} needs frontmatter with a description`);
+    // Only actual invocations (backticked, npx-prefixed or not) — prose like
+    // "run token-monitor over your logs" is not a command reference.
+    for (const [, cmd] of body.matchAll(/`(?:npx -y @ryandemelo\/)?token-monitor ([a-z-]+)/g)) {
+      assert.ok(known.has(cmd), `${file} tells the agent to run unknown command "${cmd}"`);
+    }
+  }
+});
+
+test('the skill declares itself and states the local-only rule for names', () => {
+  const skill = read('skills', 'token-monitor', 'SKILL.md');
+  assert.match(skill, /^---\nname: token-monitor\n/);
+  assert.match(skill, /description: >/);
+  // The one rule an agent must not lose: names shown locally stay local.
+  assert.match(skill, /never leave/i);
+});
+
+test('the session hook is silent until it is turned on, and never runs collect', () => {
+  const script = join(ROOT, 'hooks', 'session-hint.sh');
+  // Comments explain what the hook refuses to do; the code must not do it.
+  const code = readFileSync(script, 'utf8')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('#'))
+    .join('\n');
+  assert.ok(!code.includes('collect'), 'the hook must never scan logs at session start');
+  assert.ok(!code.includes('npx'), 'the hook must never reach the network');
+
+  // A HOME with no database and no opt-in: exit 0, say nothing.
+  const home = mkdtempSync(join(tmpdir(), 'tm-hook-'));
+  const off = spawnSync('bash', [script], { encoding: 'utf8', env: { ...process.env, HOME: home } });
+  assert.equal(off.status, 0);
+  assert.equal(off.stdout.trim(), '');
+
+  // Opted in, but still nothing collected: still silent, still exit 0.
+  const on = spawnSync('bash', [script], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home, TOKEN_MONITOR_SESSION_HINT: '1' },
+  });
+  assert.equal(on.status, 0);
+  assert.equal(on.stdout.trim(), '');
+
+  assert.match(readJson('hooks', 'hooks.json').hooks.SessionStart[0].hooks[0].command, /session-hint\.sh/);
+});


### PR DESCRIPTION
Closes #85. **Stacked on #97** (base: `feat/context-economics`), because the plugin's `/token-context` and `/token-rules` commands drive subcommands that PR adds — and `test/plugin.test.ts` asserts every command references a subcommand the CLI actually has.

## What

The repo doubles as a single-plugin marketplace:

```
/plugin marketplace add ryandemelo/token-monitor
/plugin install token-monitor
```

- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`
- `commands/` — `/token-report`, `/token-context`, `/token-rules`, each telling the agent what to run and how to report it (quote the numbers the tool produced, keep the `~`, don't invent a trend the tool refused to draw)
- `skills/token-monitor/SKILL.md` — the whole workflow (collect → report → context → analyze → categorize → relay → rules), how to read each metric, and six standing rules including "absent is not zero" and "names stay local"
- `hooks/` — an **opt-in** `SessionStart` hint naming the rules currently firing

## The hook, specifically

Off by default. It turns on with `touch ~/.token-monitor/session-hint` or `TOKEN_MONITOR_SESSION_HINT=1`, and by construction it:

- never runs `collect` — a scan takes seconds and a session start is not the moment;
- never reaches the network (no `npx`; the CLI must already be installed);
- exits 0 with no output on any problem — no CLI, no database, unparseable output, all silent.

Measured at 0.34s against a 165k-row database, inside the 5s timeout.

## Tests

`test/plugin.test.ts`: manifests parse and `plugin.json`'s version tracks `package.json`; every `token-monitor <cmd>` a command file tells an agent to run exists in `--help`; the skill declares its frontmatter and states the local-only rule; the hook is silent both opted-out and opted-in-with-nothing-collected, and its executable lines contain neither `collect` nor `npx`. 281 pass.

No runtime dependencies added — the plugin is markdown and JSON.