### PR TITLE
feat: donate-fixture — scrub a real session into a committable fixture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,17 @@ Four rules to write by:
 3. **Ship the caveat with the rule.** If your signal is a proxy (tool arguments aren't stored; a source doesn't report thinking tokens), the message says so. Sources that can't measure something report *nothing*, not zero.
 4. **Justify thresholds against real data in the PR.** Persona and cluster thresholds set the precedent: a number you picked because it looked round is a number nobody can defend later.
 
+### Getting data to write it against
+
+`makeStored` builds synthetic turns by hand, which is enough for most rules. When you need the shape of *real* work — a fix loop, a fan-out, a session that bloats — donate one of your own sessions:
+
+```sh
+token-monitor report                       # session ids appear as recommendation evidence
+token-monitor donate-fixture <id-prefix>   # -> test/fixtures/donated/
+```
+
+The generator reads the **database**, not your transcripts, and the database has no column that can hold prompt or code text. What survives is what rules measure: turn count, timing, token counts, models, tool names, error flags, result sizes and the subagent structure. Projects and branches are renamed, MCP tool names are replaced (keeping their classifier class so the session's activity mix survives the round trip), and timestamps are shifted to a fixed start with every gap preserved. Read the files before you attach them to a PR anyway — the tool's privacy claims should not be the only thing between your session and a public repo.
+
 Then a test in `test/rules.test.ts` (or its own file) with a synthetic window from `makeStored`: one case where it fires, one where it must stay silent, and — if it prices savings — one asserting the arithmetic. `npm test` must pass.
 
 If your new rule needs a metric that doesn't exist yet, add it to `Metrics` in `src/metrics.ts` and to the `MetricKey` union in `src/followthrough.ts` so follow-through can track whether the advice worked.

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>]
 token-monitor categorize [--days 30] [--threshold 0.4] [--min-cluster 2] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor context [--days 30] [--json] [--db <path>]
+token-monitor donate-fixture <session-id-or-prefix> [--out <dir>] [--db <path>]
 token-monitor rules   [<rule-key>] [--days 30] [--json] [--db <path>]
 token-monitor html    [--out report.html] [--days 30] [--db <path>]
 token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline] [--verify] [--keys keys.json] [--threshold 0.4] [--min-cluster 2] [--json] [--html team.html]
@@ -380,7 +381,7 @@ token-monitor reconcile [--provider anthropic|openai] [--days 30] [--db <path>]
 
 Two ways in, both documented in [CONTRIBUTING.md](CONTRIBUTING.md):
 
-- **A waste rule** — one file in `src/rules/`, one fixture, one test. Several are pre-specced as `good first issue`.
+- **A waste rule** — one file in `src/rules/`, one fixture, one test. Several are pre-specced as `good first issue`, and `token-monitor donate-fixture <session>` turns one of your own sessions into a synthetic fixture to write it against.
 - **An adapter for another agent CLI** (Aider, OpenCode, Windsurf…) — bigger, and the highest-value change when a tool nobody has covered writes logs somewhere.
 
 `npm test` runs the suite; CI covers Node 24/25 on Linux + macOS.

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -34,6 +34,25 @@ export function norm(name: string): string {
 }
 
 /**
+ * Which class of tool this is, by normalized name. Exported because the
+ * classifier is not the only thing that needs it: `donate-fixture` renames MCP
+ * tools, and a rename that moved a tool from one class to another would change
+ * the donated session's activity mix — the fixture has to re-classify to what
+ * the original was.
+ */
+export type ToolClass = 'read' | 'write' | 'shell' | 'plan' | 'interactive' | 'other';
+
+export function toolClass(name: string): ToolClass {
+  const t = norm(name);
+  if (WRITE_TOOLS.has(t)) return 'write';
+  if (PLAN_TOOLS.has(t)) return 'plan';
+  if (INTERACTIVE_TOOLS.has(t)) return 'interactive';
+  if (READ_TOOLS.has(t)) return 'read';
+  if (SHELL_TOOLS.has(t)) return 'shell';
+  return 'other';
+}
+
+/**
  * Classify a turn by what its tool calls did. Priority order matters:
  * shipping/testing are detected from shell commands, coding from write
  * tools, planning from plan tools, exploration from read-only tools.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { parseArgs } from 'node:util';
 import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { ADAPTERS } from './adapters/index.js';
 import {
   openDb, insertEvents, loadEvents, DEFAULT_DB,
@@ -20,6 +21,7 @@ import { enrichFindings } from './recommendations.js';
 import { reconcile, renderReconcile, PROVIDERS } from './reconcile.js';
 import { computeMetrics } from './metrics.js';
 import { computeToolSurface } from './tool-surface.js';
+import { buildDonation, writeDonation, resolveSession } from './donate.js';
 import { blendedRates } from './recommendations.js';
 import { renderHtml, renderTeamHtml, renderCategorizeHtml } from './html.js';
 import { renderAnalysis, deepAnalysis, buildLlmPrompt, buildLlmTrackPrompt, runLlm, runLlmCapture, parseLlmFindings, renderTrackedLlm, detectAgent } from './analyze.js';
@@ -38,6 +40,7 @@ Usage:
   token-monitor analyze [--days <n>] [--llm] [--track] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor relay   [--days <n>] [--threshold <0-1>] [--source <name>] [--json] [--db <path>]
   token-monitor context [--days <n>] [--json] [--db <path>]
+  token-monitor donate-fixture <session-id-or-prefix> [--out <dir>] [--db <path>]
   token-monitor rules   [<rule-key>] [--days <n>] [--json] [--db <path>]
   token-monitor html    [--out report.html] [--days <n>] [--db <path>]
   token-monitor merge   <export.json>... [--team teams.yaml] [--by team|discipline]
@@ -68,6 +71,14 @@ Commands:
             turn re-reads, the tool results still riding along in it, per-MCP-
             server spend, and connected servers nothing ever invoked. Server
             and tool names are shown locally and never leave the machine.
+  donate-fixture
+            Turn one of your sessions into a SYNTHETIC transcript that can be
+            committed as a test fixture: same turn count, timing, token counts,
+            models, tool names, error flags and fan-out shape; no prompt or code
+            content (the database has no column that can hold any), projects and
+            branches renamed, MCP tool names replaced, timestamps shifted to a
+            fixed start with every gap preserved. Read the file before attaching
+            it to a PR.
   rules     List the waste rules that produce findings — what each measures,
             which fire on your current window, and where its file lives. With a
             rule key, print that rule's documentation. Each rule is one file in
@@ -495,6 +506,30 @@ Signing fingerprint (send to your team lead for keys.json):
     const { rows, breach } = await reconcile(provider, events, days);
     console.log(renderReconcile(provider, rows, days));
     if (breach) process.exit(1);
+  } else if (cmd === 'donate-fixture') {
+    const wanted = positionals[1];
+    if (!wanted) {
+      console.error('donate-fixture needs a session id or prefix (report prints them as evidence: "worst: db0a7d17 (…)").');
+      process.exit(1);
+    }
+    let sessionId: string;
+    try {
+      sessionId = resolveSession(db, wanted);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    const outDir = values.out && values.out !== 'report.html' ? values.out : join('test', 'fixtures', 'donated');
+    const { files, result } = buildDonation(db, sessionId);
+    writeDonation(outDir, files);
+    const shown = result.files.slice(0, 5);
+    console.log(
+      `Wrote ${result.files.length} file(s), ${(result.bytes / 1024).toFixed(0)} KB, under ${outDir}:\n` +
+        [...shown, ...(result.files.length > shown.length ? [`… ${result.files.length - shown.length} more`] : [])]
+          .map((f) => `  ${f}`).join('\n') +
+        `\n\n${result.turns} main-loop turn(s), ${result.agentRuns} subagent run(s). Projects, branches and MCP names are synthetic; timestamps shifted by ${Math.round(result.shiftMs / 86_400_000)}d with gaps preserved.\n` +
+        'Read the files before attaching them to a PR — the tool\'s privacy claims should not be the only thing between your session and a public repo.',
+    );
   } else if (cmd === 'context') {
     const days = Number(values.days) || 30;
     const events = loadEvents(db, { days, project: values.project, source: values.source });

--- a/src/donate.ts
+++ b/src/donate.ts
@@ -1,0 +1,255 @@
+import type { DatabaseSync } from 'node:sqlite';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { StoredEvent } from './store.js';
+import { loadEvents, findSessions } from './store.js';
+import { parseResultChars, parseTools } from './metrics.js';
+import { serverOf } from './tool-surface.js';
+import { toolClass } from './classify.js';
+
+/**
+ * Turn one real session into a synthetic transcript a contributor can commit.
+ *
+ * Writing a waste rule needs data with the shape of real work in it — a fix
+ * loop, a fan-out, a session that bloats — and the only corpus for that is
+ * whatever happens to be on the author's own machine. This command makes that
+ * corpus shareable.
+ *
+ * The privacy argument is structural rather than a promise: the generator
+ * reads the DATABASE, not the transcript, and the database has no column that
+ * can hold prompt or response text. What survives is what the rules actually
+ * measure — turn count, timing, token counts, model, tool names, error flags,
+ * result SIZES, the sidechain structure — and everything else is synthesized.
+ *
+ * The three judgement calls, all made toward saying less:
+ *
+ * - **Projects and branches** become `project-1`, `main`. A branch name is the
+ *   same sensitivity class as a file path: it names features and clients.
+ * - **MCP tool names** become `mcp__server-1__tool-1`. Built-in tool names are
+ *   kept, because which built-in was called is the signal a rule reads and
+ *   `Bash` says nothing about anyone. Server names are local-only everywhere
+ *   else in this codebase, and a donated fixture is the most public artifact
+ *   there is.
+ * - **Timestamps** are shifted so the first turn lands on a fixed date, with
+ *   every gap preserved exactly. Gaps are what cold-restart and session-shape
+ *   rules measure; the wall-clock hour someone works is nobody's business.
+ */
+
+/** Every donated fixture starts here, so two donations diff against each other. */
+const EPOCH = Date.parse('2026-01-01T09:00:00.000Z');
+
+export interface DonateResult {
+  /** Files written, relative to the output directory. */
+  files: string[];
+  /** Total bytes written — a fixture nobody wants to review is not a fixture. */
+  bytes: number;
+  sessionId: string;
+  turns: number;
+  agentRuns: number;
+  /** Milliseconds every timestamp was shifted by. */
+  shiftMs: number;
+}
+
+/**
+ * A stand-in name for each class of tool, chosen so the CLASSIFIER sees the
+ * same thing it saw originally. A server's tool called `read_file` is read-only
+ * work; renaming it to `tool-1` would make the donated turn classify as coding
+ * (unknown tools act on the world) and quietly change the session's activity
+ * mix — which is exactly what a rule under test is reading.
+ */
+const CLASS_STANDIN: Record<string, string> = {
+  read: 'read_file',
+  write: 'write_file',
+  shell: 'run_command',
+  plan: 'todowrite',
+  interactive: 'ask_user',
+};
+
+/** Tool names a rule can read without naming anyone: built-ins keep their name. */
+export function anonymizeTool(tool: string, servers: Map<string, number>, tools: Map<string, number>): string {
+  const server = serverOf(tool);
+  if (!server) return tool;
+  if (!servers.has(server)) servers.set(server, servers.size + 1);
+  if (!tools.has(tool)) tools.set(tool, tools.size + 1);
+  const standin = CLASS_STANDIN[toolClass(tool)] ?? `tool-${tools.get(tool)}`;
+  return `mcp__server-${servers.get(server)}__${standin}`;
+}
+
+/**
+ * A shell command that re-classifies to the activity the stored turn had.
+ *
+ * The fixture has to survive a round trip: `collect` re-derives activity from
+ * tools and commands, so a donated turn whose command is dropped would come
+ * back as a different activity and the rule under test would see a different
+ * session. Real command strings can carry paths, hostnames and ticket ids, so
+ * they are replaced rather than kept.
+ */
+function commandFor(activity: string): string | undefined {
+  if (activity === 'testing') return 'npm test';
+  if (activity === 'shipping') return 'git commit -m "synthetic"';
+  return undefined;
+}
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj);
+}
+
+/** One turn as the Claude Code transcript format writes it, plus its result sizes. */
+function turnLines(
+  e: StoredEvent,
+  index: number,
+  opts: { shiftMs: number; sidechain?: { agentId: string; parentSessionId: string }; sessionId: string; servers: Map<string, number>; toolIds: Map<string, number> },
+): string[] {
+  const uuid = `${opts.sidechain ? opts.sidechain.agentId : opts.sessionId}-t${index}`;
+  const ts = new Date(Date.parse(e.ts) + opts.shiftMs).toISOString();
+  const tools = parseTools(e.tools).map((t) => anonymizeTool(t, opts.servers, opts.toolIds));
+  const sizes = parseResultChars(e.tool_result_chars);
+  const command = commandFor(e.activity);
+
+  const content: unknown[] = [];
+  if (e.has_thinking) content.push({ type: 'thinking', thinking: 'synthetic' });
+  if (tools.length === 0) content.push({ type: 'text', text: 'synthetic' });
+  tools.forEach((name, i) => {
+    content.push({
+      type: 'tool_use',
+      id: `${uuid}-c${i}`,
+      name,
+      // Only the shell-command field is reproduced, and only as the generic
+      // string the classifier needs; no other tool input is carried at all.
+      input: command && i === 0 ? { command } : {},
+    });
+  });
+
+  const out = [
+    line({
+      type: 'assistant',
+      uuid,
+      sessionId: opts.sidechain ? opts.sidechain.parentSessionId : opts.sessionId,
+      ...(opts.sidechain ? { agentId: opts.sidechain.agentId, isSidechain: true, ...(e.agent_type ? { attributionAgent: 'general-purpose' } : {}) } : {}),
+      cwd: '/Users/dev/project-1',
+      gitBranch: 'main',
+      timestamp: ts,
+      message: {
+        model: e.model,
+        usage: {
+          input_tokens: e.input_tokens,
+          output_tokens: e.output_tokens,
+          cache_read_input_tokens: e.cache_read_tokens,
+          cache_creation_input_tokens: e.cache_creation_tokens,
+          ...(e.cache_creation_1h_tokens
+            ? { cache_creation: { ephemeral_5m_input_tokens: Math.max(0, e.cache_creation_tokens - e.cache_creation_1h_tokens), ephemeral_1h_input_tokens: e.cache_creation_1h_tokens } }
+            : {}),
+        },
+        content,
+      },
+    }),
+  ];
+
+  // Results: one user line carrying an is_error flag where the turn failed and
+  // a padded body of exactly the recorded LENGTH — the size is the datum, the
+  // characters are filler.
+  const results = tools
+    .map((name, i) => {
+      const original = parseTools(e.tools)[i];
+      const chars = sizes[original] ?? 0;
+      const isError = e.is_error === 1 && i === 0;
+      if (chars === 0 && !isError) return undefined;
+      return {
+        type: 'tool_result',
+        tool_use_id: `${uuid}-c${i}`,
+        ...(isError ? { is_error: true } : {}),
+        content: 'x'.repeat(chars),
+      };
+    })
+    .filter(Boolean);
+  if (results.length > 0) {
+    out.push(
+      line({
+        type: 'user',
+        uuid: `${uuid}-r`,
+        sessionId: opts.sidechain ? opts.sidechain.parentSessionId : opts.sessionId,
+        timestamp: ts,
+        message: { content: results },
+      }),
+    );
+  }
+  return out;
+}
+
+/**
+ * Build the fixture for one session. Subagent runs are emitted as their own
+ * `subagents/agent-<n>.jsonl` files under the session directory, because the
+ * fan-out IS the shape a lot of interesting rules need and it exists nowhere
+ * else in the fixture corpus.
+ */
+export function buildDonation(
+  db: DatabaseSync,
+  sessionId: string,
+  opts: { now?: number } = {},
+): { files: Array<{ path: string; body: string }>; result: DonateResult } {
+  const rows = loadEvents(db, { session: sessionId });
+  if (rows.length === 0) throw new Error(`no stored turns for session ${sessionId}`);
+  const agents = loadEvents(db, {}).filter((e) => e.is_sidechain === 1 && e.parent_session_id === sessionId);
+
+  const first = Math.min(...[...rows, ...agents].map((e) => Date.parse(e.ts)));
+  const shiftMs = EPOCH - first;
+  const servers = new Map<string, number>();
+  const toolIds = new Map<string, number>();
+  const dir = '-Users-dev-project-1';
+  const synthetic = 'session-1';
+
+  const main = rows
+    .filter((e) => e.is_sidechain !== 1)
+    .flatMap((e, i) => turnLines(e, i, { shiftMs, sessionId: synthetic, servers, toolIds }));
+
+  const files = [{ path: join(dir, `${synthetic}.jsonl`), body: main.join('\n') + '\n' }];
+
+  const byAgent = new Map<string, StoredEvent[]>();
+  for (const e of agents) {
+    const list = byAgent.get(e.session_id) ?? [];
+    list.push(e);
+    byAgent.set(e.session_id, list);
+  }
+  let n = 0;
+  for (const [, runRows] of byAgent) {
+    n++;
+    const agentId = String(n);
+    const body = runRows
+      .flatMap((e, i) => turnLines(e, i, { shiftMs, sessionId: synthetic, servers, toolIds, sidechain: { agentId, parentSessionId: synthetic } }))
+      .join('\n');
+    // The adapter keys a run on the id in its FILENAME (`agent-<id>.jsonl`),
+    // so the id and the name have to agree.
+    files.push({ path: join(dir, synthetic, 'subagents', `agent-${agentId}.jsonl`), body: body + '\n' });
+  }
+
+  return {
+    files,
+    result: {
+      files: files.map((f) => f.path),
+      bytes: files.reduce((n, f) => n + Buffer.byteLength(f.body), 0),
+      sessionId: synthetic,
+      turns: main.length > 0 ? rows.filter((e) => e.is_sidechain !== 1).length : 0,
+      agentRuns: byAgent.size,
+      shiftMs,
+    },
+  };
+}
+
+export function writeDonation(outDir: string, files: Array<{ path: string; body: string }>): void {
+  for (const f of files) {
+    const full = join(outDir, f.path);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, f.body);
+  }
+}
+
+/** Resolve a session id or unique prefix; throws with guidance when ambiguous. */
+export function resolveSession(db: DatabaseSync, prefix: string): string {
+  const matches = findSessions(db, prefix);
+  if (matches.length === 0) throw new Error(`no session id starts with "${prefix}" — ids are printed as evidence by \`report\``);
+  if (matches.length > 1) {
+    const list = matches.slice(0, 5).map((m) => `  ${m.session_id}  ${m.turns} turns, last ${m.last_ts.slice(0, 10)}`).join('\n');
+    throw new Error(`"${prefix}" matches ${matches.length} sessions:\n${list}\nUse more characters.`);
+  }
+  return matches[0].session_id;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -384,7 +384,7 @@ export function syncIntentProjects(db: DatabaseSync): number {
 
 export function loadEvents(
   db: DatabaseSync,
-  opts: { days?: number; project?: string; source?: string } = {},
+  opts: { days?: number; project?: string; source?: string; session?: string } = {},
 ): StoredEvent[] {
   const where: string[] = [];
   const params: (string | number)[] = [];
@@ -400,6 +400,10 @@ export function loadEvents(
     where.push(`source = ?`);
     params.push(opts.source);
   }
+  if (opts.session) {
+    where.push(`session_id = ?`);
+    params.push(opts.session);
+  }
   // Subagent columns are selected defensively: a DB whose migration couldn't
   // run (read-only, older binary holding it) must still read, and the defaults
   // it substitutes are the truth for pre-subagent rows anyway.
@@ -414,6 +418,21 @@ export function loadEvents(
       ${col('cache_creation_1h_tokens', '0')}, ${col('tool_result_chars', 'NULL')}
     FROM events ${where.length ? 'WHERE ' + where.join(' AND ') : ''} ORDER BY ts`;
   return db.prepare(sql).all(...params) as unknown as StoredEvent[];
+}
+
+/**
+ * Session ids starting with `prefix`, newest activity first. `donate-fixture`
+ * takes the 8-character prefix the report prints as evidence, so it has to be
+ * able to resolve one — and to refuse when a prefix is ambiguous rather than
+ * picking a session the user did not mean.
+ */
+export function findSessions(db: DatabaseSync, prefix: string): Array<{ session_id: string; project: string; source: string; turns: number; last_ts: string }> {
+  return db
+    .prepare(
+      `SELECT session_id, project, source, COUNT(*) AS turns, MAX(ts) AS last_ts
+         FROM events WHERE session_id LIKE ? GROUP BY session_id ORDER BY last_ts DESC`,
+    )
+    .all(prefix + '%') as unknown as Array<{ session_id: string; project: string; source: string; turns: number; last_ts: string }>;
 }
 
 /**

--- a/test/donate.test.ts
+++ b/test/donate.test.ts
@@ -1,0 +1,187 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { openDb, insertEvents, loadEvents } from '../src/store.js';
+import { buildDonation, writeDonation, resolveSession, anonymizeTool } from '../src/donate.js';
+import { collectClaudeCode } from '../src/adapters/claude-code.js';
+import { computeMetrics } from '../src/metrics.js';
+import { classify } from '../src/classify.js';
+import { makeEvent } from './helpers.js';
+import type { Activity, UsageEvent } from '../src/types.js';
+import type { StoredEvent } from '../src/store.js';
+
+/** A session worth donating: a fix loop, an MCP call with a big result, a fan-out. */
+function seed(): UsageEvent[] {
+  const base = (i: number, extra: Partial<UsageEvent> = {}): UsageEvent =>
+    makeEvent({
+      sessionId: 'aabbccdd-1111-2222-3333-444455556666',
+      project: 'acme-billing',
+      gitBranch: 'feat/acme-invoice-export',
+      timestamp: `2026-05-0${1 + Math.floor(i / 6)}T1${i % 6}:07:00.000Z`,
+      inputTokens: 1_000 + i,
+      outputTokens: 200 + i,
+      cacheReadTokens: 50_000,
+      cacheCreationTokens: i === 0 ? 8_000 : 0,
+      cacheCreation1hTokens: i === 0 ? 6_000 : 0,
+      ...extra,
+    });
+  return [
+    base(0, { tools: ['Read'], toolResultChars: { Read: 40_000 } }),
+    base(1, {
+      tools: ['mcp__acme_warehouse__query'],
+      toolResultChars: { 'mcp__acme_warehouse__query': 12_000 },
+    }),
+    base(2, { tools: ['Bash'], commands: ['npm test'], isError: true }),
+    base(3, { tools: ['Edit'] }),
+    base(4, { tools: ['Bash'], commands: ['git commit -m "fix acme invoice rounding"'] }),
+    base(5, { hasThinking: true }),
+    // One subagent run under the same session.
+    makeEvent({
+      sessionId: 'agent-run-xyz',
+      parentSessionId: 'aabbccdd-1111-2222-3333-444455556666',
+      isSidechain: true,
+      agentType: 'acme-secret-auditor',
+      project: 'acme-billing',
+      timestamp: '2026-05-01T13:30:00.000Z',
+      tools: ['Grep'],
+      toolResultChars: { Grep: 4_000 },
+      inputTokens: 900,
+      outputTokens: 90,
+      cacheReadTokens: 20_000,
+    }),
+    makeEvent({
+      sessionId: 'agent-run-xyz',
+      parentSessionId: 'aabbccdd-1111-2222-3333-444455556666',
+      isSidechain: true,
+      agentType: 'acme-secret-auditor',
+      project: 'acme-billing',
+      timestamp: '2026-05-01T13:31:00.000Z',
+      tools: ['Edit'],
+      inputTokens: 500,
+      outputTokens: 50,
+      cacheReadTokens: 21_000,
+    }),
+  ];
+}
+
+function donateToDisk(): { dir: string; source: StoredEvent[]; body: string } {
+  const dbDir = mkdtempSync(join(tmpdir(), 'tm-donate-db-'));
+  const db = openDb(join(dbDir, 'db.sqlite'));
+  const events = seed().map((e) => ({ ...e, activity: classifyish(e) }));
+  insertEvents(db, events);
+  const sessionId = resolveSession(db, 'aabbccdd');
+  const { files } = buildDonation(db, sessionId);
+  const dir = mkdtempSync(join(tmpdir(), 'tm-donate-out-'));
+  writeDonation(dir, files);
+  return {
+    dir,
+    source: loadEvents(db, {}),
+    body: files.map((f) => f.body).join('\n'),
+  };
+}
+
+/** Seed rows the way `collect` would: the real classifier, same as the adapter. */
+function classifyish(e: UsageEvent): Activity {
+  return classify(e);
+}
+
+test('donated fixture round-trips: same turns, tokens, errors, activities, fan-out', () => {
+  const { dir, source } = donateToDisk();
+  const { events } = collectClaudeCode(dir);
+
+  const asStored = (e: (typeof events)[number]): StoredEvent => ({
+    source: e.source, session_id: e.sessionId, project: e.project, ts: e.timestamp, model: e.model,
+    input_tokens: e.inputTokens, output_tokens: e.outputTokens, cache_read_tokens: e.cacheReadTokens,
+    cache_creation_tokens: e.cacheCreationTokens, thinking_tokens: e.thinkingTokens,
+    tools: JSON.stringify(e.tools), has_thinking: e.hasThinking ? 1 : 0, is_error: e.isError ? 1 : 0,
+    activity: e.activity ?? 'conversation', is_sidechain: e.isSidechain ? 1 : 0,
+    parent_session_id: e.parentSessionId ?? null, agent_type: e.agentType ?? null,
+    cache_creation_1h_tokens: e.cacheCreation1hTokens ?? 0,
+    tool_result_chars: e.toolResultChars ? JSON.stringify(e.toolResultChars) : null,
+  });
+
+  const before = computeMetrics(source);
+  const after = computeMetrics(events.map(asStored));
+
+  assert.equal(after.events, before.events);
+  assert.equal(after.spendTokens, before.spendTokens);
+  assert.equal(after.cacheReadTokens, before.cacheReadTokens);
+  assert.equal(after.cacheCreationTokens, before.cacheCreationTokens);
+  assert.equal(after.extendedCacheTokens, before.extendedCacheTokens);
+  assert.equal(after.errorEvents, before.errorEvents);
+  assert.equal(after.subagentSessions, before.subagentSessions);
+  assert.equal(after.toolResultTokens, before.toolResultTokens);
+  assert.equal(after.toolResultCarryTokens, before.toolResultCarryTokens);
+  for (const a of ['coding', 'testing', 'shipping', 'exploration', 'thinking'] as const) {
+    assert.equal(after.byActivity[a].events, before.byActivity[a].events, `activity ${a} changed`);
+  }
+});
+
+test('donated fixture carries no project, branch, session id, MCP or agent-type name', () => {
+  const { body } = donateToDisk();
+  for (const secret of [
+    'acme-billing',
+    'feat/acme-invoice-export',
+    'aabbccdd-1111-2222-3333-444455556666',
+    'agent-run-xyz',
+    'acme_warehouse',
+    'acme-secret-auditor',
+    'fix acme invoice rounding',
+  ]) {
+    assert.ok(!body.includes(secret), `donated fixture leaked "${secret}"`);
+  }
+  assert.ok(body.includes('/Users/dev/project-1'));
+  // The MCP tool keeps its CLASS so the fixture re-classifies identically.
+  assert.ok(body.includes('mcp__server-1__'));
+});
+
+test('timestamps are shifted to a fixed start with every gap preserved', () => {
+  const { dir, source } = donateToDisk();
+  const { events } = collectClaudeCode(dir);
+  const gaps = (list: string[]) => {
+    const t = list.map((s) => Date.parse(s)).sort((a, b) => a - b);
+    return t.slice(1).map((v, i) => v - t[i]);
+  };
+  assert.deepEqual(gaps(events.map((e) => e.timestamp)), gaps(source.map((e) => e.ts)));
+  const earliest = Math.min(...events.map((e) => Date.parse(e.timestamp)));
+  assert.equal(new Date(earliest).toISOString(), '2026-01-01T09:00:00.000Z');
+});
+
+test('subagent runs land in their own files the adapter can key on', () => {
+  const { dir } = donateToDisk();
+  const sub = join(dir, '-Users-dev-project-1', 'session-1', 'subagents');
+  const files = readdirSync(sub);
+  assert.deepEqual(files, ['agent-1.jsonl']);
+  const line = JSON.parse(readFileSync(join(sub, files[0]), 'utf8').split('\n')[0]);
+  assert.equal(line.agentId, '1');
+  assert.equal(line.isSidechain, true);
+  // The run's TYPE is replaced: a custom agent can be named after anything.
+  assert.equal(line.attributionAgent, 'general-purpose');
+});
+
+test('anonymizeTool keeps built-ins and numbers MCP servers stably', () => {
+  const servers = new Map<string, number>();
+  const tools = new Map<string, number>();
+  assert.equal(anonymizeTool('Bash', servers, tools), 'Bash');
+  // Unknown tools stay unknown (they classify as acting on the world)...
+  assert.equal(anonymizeTool('mcp__alpha__refund_invoice', servers, tools), 'mcp__server-1__tool-1');
+  // ...and tools the classifier recognizes keep their class, not their name.
+  assert.equal(anonymizeTool('mcp__alpha__read_file', servers, tools), 'mcp__server-1__read_file');
+  assert.equal(anonymizeTool('mcp__beta__write_file', servers, tools), 'mcp__server-2__write_file');
+  assert.equal(anonymizeTool('mcp__alpha__refund_invoice', servers, tools), 'mcp__server-1__tool-1');
+});
+
+test('resolveSession refuses an ambiguous or unknown prefix', () => {
+  const dbDir = mkdtempSync(join(tmpdir(), 'tm-donate-db2-'));
+  const db = openDb(join(dbDir, 'db.sqlite'));
+  insertEvents(db, [
+    makeEvent({ sessionId: 'dupe-aaa', eventKey: 'k1' }),
+    makeEvent({ sessionId: 'dupe-bbb', eventKey: 'k2' }),
+    makeEvent({ sessionId: 'unique-1', eventKey: 'k3' }),
+  ]);
+  assert.equal(resolveSession(db, 'unique'), 'unique-1');
+  assert.throws(() => resolveSession(db, 'dupe'), /matches 2 sessions/);
+  assert.throws(() => resolveSession(db, 'nothing'), /no session id starts with/);
+});

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -185,6 +185,39 @@ test('e2e: report --trend renders the trend section (empty previous window)', ()
   assert.ok(stdout.includes('No events in the previous window'));
 });
 
+test('e2e: donate-fixture writes a synthetic, re-collectable copy of one session', () => {
+  const listed = run(['analyze', '--json', ...DAYS]);
+  assert.equal(listed.code, 0);
+  const out = join(HOME, 'donated');
+
+  // The fixture sessions are seeded from test/fixtures; take one by prefix.
+  const bad = run(['donate-fixture', 'zzzzzzzz', '--out', out]);
+  assert.equal(bad.code, 1);
+  assert.ok(bad.stderr.includes('no session id starts with'));
+
+  const missing = run(['donate-fixture']);
+  assert.equal(missing.code, 1);
+
+  const ok = run(['donate-fixture', 's1', '--out', out]);
+  assert.equal(ok.code, 0, ok.stderr);
+  assert.ok(ok.stdout.includes('-Users-dev-project-1/session-1.jsonl'));
+  assert.ok(ok.stdout.includes('Read the files before attaching them to a PR'));
+
+  // It must re-collect: point a fresh HOME at it and run the real pipeline.
+  const home2 = mkdtempSync(join(tmpdir(), 'tm-donated-home-'));
+  mkdirSync(join(home2, '.claude'), { recursive: true });
+  cpSync(out, join(home2, '.claude', 'projects'), { recursive: true });
+  const collected = run(['collect', '--source', 'claude-code'], { home: home2 });
+  assert.equal(collected.code, 0);
+  assert.ok(/claude-code\s+\d+ files\s+[1-9]/.test(collected.stdout), collected.stdout);
+
+  const report = run(['report', ...DAYS], { home: home2 });
+  assert.equal(report.code, 0);
+  assert.ok(report.stdout.includes('project-1'));
+  // Nothing from the donor's own labels comes along.
+  assert.ok(!report.stdout.includes('proj-alpha'));
+});
+
 test('e2e: context reports the surface, and keeps tool/server names out of exports', () => {
   const { stdout, code } = run(['context', ...DAYS]);
   assert.equal(code, 0);


### PR DESCRIPTION
Closes #86. The enabler for the eight `good first issue` rules (#87–#94): a contributor can now write a rule against the shape of real work instead of hand-rolling `makeStored` calls and hoping.

## What

`token-monitor donate-fixture <session-id-or-prefix> [--out <dir>]` writes a synthetic Claude Code transcript — main loop plus each subagent run as its own `agent-<n>.jsonl` — that re-collects to the same numbers.

The privacy argument is **structural rather than a promise**: the generator reads the database, and the database has no column that can hold prompt or code text. What survives is what rules measure — turn count, timing, token counts, model, tool names, error flags, result sizes, fan-out shape.

Three judgement calls, all made toward saying less:
- projects and branches become `project-1` / `main` (a branch name is the same sensitivity class as a file path);
- MCP tool names and subagent type names are replaced;
- timestamps shift to a fixed start with every gap preserved — gaps are what the cold-restart and session-shape rules read, the wall-clock hour someone works is nobody's business.

## The bug the round-trip test caught

Renaming a server's `read_file` to `tool-1` moved it from the classifier's read set into "unknown tools act on the world", so a read-only turn came back as a **coding** turn and the donated session's activity mix silently differed from the original — precisely the thing a rule under test reads. MCP tools are now renamed to a stand-in for their *class* (`read_file`, `write_file`, `run_command`, `todowrite`, `ask_user`, or an opaque `tool-N` for genuinely unknown ones), and `classify.ts` exports `toolClass()` so the donor and the classifier cannot drift apart.

## Tests

`test/donate.test.ts` — round-trip fidelity across turns, tokens, cache split, errors, subagent runs, carry and every activity bucket; a leak test asserting the output contains none of the source's project, branch, session id, MCP server name, agent type or commit message; gap-preserving timestamp shift; subagent filenames the adapter can key on; stable anonymization; ambiguous/unknown prefix handling. Plus an e2e case that donates a fixture, re-collects it under a fresh `$HOME`, and asserts the donor's own project label does not come along. 288 pass.