### PR TITLE
chore: release 0.14.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-monitor",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Measure how effectively you spend AI coding-agent tokens: activity breakdown, cache/rework/context-surface signals, and priced recommendations — locally, from the session logs your agents already write.",
   "author": {
     "name": "Ryan de Melo",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "token-monitor",
   "displayName": "Token Monitor",
   "description": "Status-bar token/cost for the current project plus the token-monitor dashboard, for VS Code, Cursor, Windsurf, and Antigravity.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publisher": "ryan653133",
   "license": "MIT",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ryandemelo/token-monitor",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "bin": {
         "token-monitor": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ryandemelo/token-monitor",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Measure how effectively your team spends AI coding-agent tokens (Claude Code, Gemini CLI, Codex, Cursor, Antigravity, Copilot Chat) — activity breakdowns, usage personas, and recommendations.",
   "license": "MIT",
   "author": "Ryan de Melo",


### PR DESCRIPTION
Version bump only — `package.json`, `extension/package.json` and `.claude-plugin/plugin.json` (the plugin manifest's version is asserted against the package in `test/plugin.test.ts`).

**Note on numbering.** 0.11–0.13 were merged but never tagged or published; npm's `latest` is still 0.10.0. Rather than tag three releases nobody saw, this goes straight to **0.14.0** and the release notes cover everything since 0.10.0 — the same call as `be92d8a` ("release 0.13.0 instead of 0.12.0"). The existing **v0.13.0 draft release is now superseded** and can be deleted; a v0.14.0 draft carries its content forward.

Publishing is still gated on rotating the Azure PAT and re-setting `VSCE_PAT`, since `ci.yml` publishes to the VS Code Marketplace on `v*` tags. Order matters: rotate → `gh secret set VSCE_PAT` → `git tag v0.14.0 && git push origin v0.14.0` → `npm publish`.