### PR TITLE
feat: subscription lens — API-equivalent spend against a seat

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,28 @@ Both context signals appear on the one-line summary in `report` and the dashboar
 
 **Privacy.** Tool and MCP server names are shown by `context` and stay on the machine. They can name a client, an internal system or a private endpoint, so — exactly like subagent type names — they never enter an export, a signed payload, or an `--llm` payload; the LLM payload's tool-error rows are redacted to `mcp:<tool>`. Connected servers are read from the local agent config by **key only**: a server's command, arguments and environment are never parsed or stored.
 
+## Seat value (subscription lens)
+
+Every dollar figure here is **API-equivalent** — what the same tokens would have cost at API rates. Most people run coding agents on a seat, where that number answers nothing on its own. `--plan` converts it:
+
+```sh
+token-monitor report --plan max-20x        # add --annual for annual-billing rates
+```
+
+```
+Seat value
+
+  API-equivalent ~$412/mo against a $200/mo Max 20x — ≈2.1× the seat price. The seat is returning well over what it costs.
+```
+
+Under-utilization gets the inverse framing (`≈0.3× — a lower tier may fit, if the headroom is not what you are paying for`), and a window under a week says so instead of quoting a ratio it can't support.
+
+The plan name rides along in `report --json` / `push` as a self-declared field, so a lead's `merge` shows seat value per member plus one org line — *"$1,240/mo of API-equivalent work on $600/mo of seats"*. Members who declare nothing show `—`; nobody is assumed onto the lead's tier.
+
+Prices live in [`src/plans.ts`](src/plans.ts), checked against claude.com/pricing on 2026-08-22 and meant to be edited to match your contract. Anything the public page doesn't state outright is marked and says why.
+
+**This is not a quota tracker.** Plan limits are multipliers over shifting baselines with their own windows, and nothing local can read them. Vendoring a guess would produce confident-looking wrong numbers, so the tool prices seats and stops there.
+
 ## Data completeness
 
 Agent tools rotate their logs — Claude Code deletes transcripts after `cleanupPeriodDays` (default 30) — so a window can be full of holes without anything saying so. Every report now opens with what it actually covers:
@@ -367,7 +389,7 @@ Org-skill candidates (team-wide)
 
 ```
 token-monitor collect [--source claude-code|gemini-cli|codex|cursor|antigravity|copilot] [--db <path>]
-token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>] [--json] [--no-categories] [--db <path>]
+token-monitor report  [--days 30] [--trend] [--project <name>] [--source <name>] [--json] [--plan <name>] [--annual] [--no-categories] [--db <path>]
 token-monitor categorize [--days 30] [--threshold 0.4] [--min-cluster 2] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
 token-monitor analyze [--days 30] [--llm] [--agent claude|gemini|codex] [--json] [--db <path>]
 token-monitor context [--days 30] [--json] [--db <path>]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { enrichFindings } from './recommendations.js';
 import { reconcile, renderReconcile, PROVIDERS } from './reconcile.js';
 import { computeMetrics } from './metrics.js';
 import { computeToolSurface } from './tool-surface.js';
+import { findPlan, PLAN_IDS } from './plans.js';
 import { buildDonation, writeDonation, resolveSession } from './donate.js';
 import { blendedRates } from './recommendations.js';
 import { renderHtml, renderTeamHtml, renderCategorizeHtml } from './html.js';
@@ -35,7 +36,8 @@ const HELP = `token-monitor — measure how effectively your team spends AI codi
 
 Usage:
   token-monitor collect [--source <name>] [--db <path>]
-  token-monitor report  [--days <n>] [--trend] [--project <name>] [--source <name>] [--json] [--no-categories] [--db <path>]
+  token-monitor report  [--days <n>] [--trend] [--project <name>] [--source <name>] [--json]
+                        [--plan <name>] [--annual] [--no-categories] [--db <path>]
   token-monitor categorize [--days <n>] [--threshold <0-1>] [--min-cluster <n>] [--project <name>] [--source <name>] [--json] [--html <path>] [--db <path>]
   token-monitor analyze [--days <n>] [--llm] [--track] [--agent claude|gemini|codex] [--json] [--db <path>]
   token-monitor relay   [--days <n>] [--threshold <0-1>] [--source <name>] [--json] [--db <path>]
@@ -117,6 +119,11 @@ Options:
   --by        merge rollup axis: team or discipline (default: discipline)
   --html      write an HTML dashboard to this path (merge: team rollup; categorize: task categories)
   --no-categories  omit task categories from report --json / push exports
+  --plan      compare API-equivalent spend against a subscription seat:
+              ${PLAN_IDS.join(', ')} (add --annual for annual-billing rates).
+              Prices only — this is NOT a quota tracker, and plan limits are
+              not readable from anything local. The name also rides along in
+              exports so a lead's merge can show seat value per member.
   --db        SQLite path (default: ${DEFAULT_DB})
 
 Project families:
@@ -134,10 +141,10 @@ function buildSignedExportJson(
   days: number,
   dbPath?: string,
   filters: { project?: string; source?: string } = {},
-  opts: { noCategories?: boolean } = {},
+  opts: { noCategories?: boolean; plan?: string } = {},
 ): string {
   const events = loadEvents(db, { days, ...filters });
-  const ex = buildExport(events, days);
+  const ex = buildExport(events, days, { plan: opts.plan });
   const persona = assignPersona(ex.overall);
   // Task categories ride along (labels only — see exportCategories) so a
   // lead's merge can cluster tasks across people without members remembering
@@ -249,10 +256,20 @@ async function main() {
       from: { type: 'string' },
       hours: { type: 'string' },
       remove: { type: 'boolean', default: false },
+      plan: { type: 'string' },
+      annual: { type: 'boolean', default: false },
       db: { type: 'string' },
       help: { type: 'boolean', short: 'h', default: false },
     },
   });
+
+  // Resolved once: an unknown plan name is a typo worth failing on, not a
+  // silently-dropped flag that makes a comparison quietly disappear.
+  const plan = values.plan ? findPlan(values.plan) : undefined;
+  if (values.plan && !plan) {
+    console.error(`Unknown plan "${values.plan}". Valid: ${PLAN_IDS.join(', ')}`);
+    process.exit(1);
+  }
 
   const cmd = positionals[0];
   if (values.help || !cmd) {
@@ -368,8 +385,13 @@ Signing fingerprint (send to your team lead for keys.json):
   } else if (cmd === 'push') {
     const config = loadConfig(keyDirFor(values.db) ?? DEFAULT_KEY_DIR);
     const days = Number(values.days) || config.windowDays || 30;
+    // The member's own --plan wins over the team default: a lead's config
+    // says what most people are on, not what this machine is on.
     const where = await pushExport(
-      buildSignedExportJson(db, days, values.db, {}, { noCategories: values['no-categories'] }),
+      buildSignedExportJson(db, days, values.db, {}, {
+        noCategories: values['no-categories'],
+        plan: plan?.id ?? config.plan,
+      }),
       config,
     );
     console.log(`Export (last ${days} days, signed) — ${where}`);
@@ -391,7 +413,7 @@ Signing fingerprint (send to your team lead for keys.json):
     const days = Number(values.days) || 30;
     const filters = { project: values.project, source: values.source };
     if (values.json) {
-      console.log(buildSignedExportJson(db, days, values.db, filters, { noCategories: values['no-categories'] }));
+      console.log(buildSignedExportJson(db, days, values.db, filters, { noCategories: values['no-categories'], plan: plan?.id }));
     } else {
       // With --trend, load both windows in one query and partition, so the
       // current slice and the comparison share the same boundary.
@@ -409,7 +431,7 @@ Signing fingerprint (send to your team lead for keys.json):
       const cat = events.length > 0
         ? categorizeSummary(db, { days, project: values.project, source: values.source })
         : undefined;
-      let out = renderReport(events, { days, follow, categorize: cat, relay: relaySummary(db, { days }) });
+      let out = renderReport(events, { days, follow, categorize: cat, relay: relaySummary(db, { days }), plan, annual: values.annual });
       if (values.trend && events.length > 0) out += '\n' + renderTrend(events, previous, days);
       console.log(out);
     }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { homedir, userInfo, platform } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { DEFAULT_KEY_DIR } from './sign.js';
+import { findPlan, PLAN_IDS } from './plans.js';
 
 /**
  * Team rollout. A lead hosts one config file; each dev (or their MDM /
@@ -22,6 +23,12 @@ export interface TeamDeployConfig {
   scheduleHours?: number;
   /** Export window passed to report; default 30. */
   windowDays?: number;
+  /**
+   * Default subscription plan for members who do not declare one (plans.ts
+   * ids). Optional: a team on mixed tiers simply omits it, and members can
+   * still pass --plan themselves.
+   */
+  plan?: string;
 }
 
 export function validateTeamConfig(data: unknown): TeamDeployConfig {
@@ -41,6 +48,9 @@ export function validateTeamConfig(data: unknown): TeamDeployConfig {
   }
   if (c.windowDays !== undefined && (typeof c.windowDays !== 'number' || c.windowDays < 1)) {
     throw new Error('team config: windowDays must be >= 1');
+  }
+  if (c.plan !== undefined && !findPlan(String(c.plan))) {
+    throw new Error(`team config: plan must be one of ${PLAN_IDS.join(', ')}`);
   }
   return c;
 }

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1,0 +1,111 @@
+/**
+ * Subscription plans, vendored the same way `PRICES` is: a small editable
+ * table with a checked date, and `estimated` on anything the public page
+ * does not state outright.
+ *
+ * Why this exists. Every dollar figure this tool prints is API-equivalent —
+ * what the same tokens would have cost at API rates — but most individuals
+ * and SME teams run coding agents on a **seat**. "You spent $15k this
+ * fortnight" is unanswerable advice for someone paying a flat $200 a month:
+ * the only decision a seat holder actually has is which tier to be on.
+ *
+ * What this deliberately is NOT: a quota or limit tracker. Plan limits are
+ * expressed as multipliers over shifting baselines with their own windows,
+ * and there is no supported programmatic usage API to read them from. Prices
+ * only. A confident-looking wrong quota number would be worse than nothing.
+ */
+
+export interface Plan {
+  id: string;
+  label: string;
+  /** USD per month, billed monthly. Per seat where the plan is per seat. */
+  monthlyUsd: number;
+  /** USD per month when billed annually, where the vendor publishes one. */
+  annualUsd?: number;
+  perSeat?: boolean;
+  /** True when the public price page does not state this number outright. */
+  estimated?: boolean;
+  note?: string;
+}
+
+/**
+ * Checked against https://claude.com/pricing on 2026-08-22. Edit to match
+ * your own contract — that is the intended use, not an oversight.
+ */
+export const PLANS: Plan[] = [
+  { id: 'pro', label: 'Pro', monthlyUsd: 20, annualUsd: 17 },
+  { id: 'max-5x', label: 'Max 5x', monthlyUsd: 100 },
+  {
+    id: 'max-20x',
+    label: 'Max 20x',
+    monthlyUsd: 200,
+    estimated: true,
+    note: 'the pricing page lists Max as "from $100/month" without naming the 20x figure — edit if your invoice says otherwise',
+  },
+  { id: 'team-standard', label: 'Team standard seat', monthlyUsd: 25, annualUsd: 20, perSeat: true },
+  { id: 'team-premium', label: 'Team premium seat', monthlyUsd: 125, annualUsd: 100, perSeat: true },
+];
+
+export const PLAN_IDS = PLANS.map((p) => p.id);
+
+export function findPlan(id: string): Plan | undefined {
+  const wanted = id.trim().toLowerCase();
+  return PLANS.find((p) => p.id === wanted);
+}
+
+export interface SeatComparison {
+  plan: Plan;
+  /** API-equivalent spend for this window, scaled to a month. */
+  apiEquivalentMonthlyUsd: number;
+  seatMonthlyUsd: number;
+  /** API-equivalent ÷ seat price. 2.1 means the seat buys 2.1× its price. */
+  ratio: number;
+  /** True when either side of the ratio rests on an estimate. */
+  estimated: boolean;
+  /** Under this many days the monthly projection is too thin to state. */
+  thin: boolean;
+}
+
+/** Windows shorter than this project too noisily to quote a monthly figure. */
+export const MIN_PROJECTION_DAYS = 7;
+
+export function seatComparison(
+  costUsd: number,
+  days: number,
+  plan: Plan,
+  opts: { estimated?: boolean; annual?: boolean } = {},
+): SeatComparison {
+  const monthly = days > 0 ? costUsd * (30 / days) : 0;
+  const seat = (opts.annual && plan.annualUsd) || plan.monthlyUsd;
+  return {
+    plan,
+    apiEquivalentMonthlyUsd: monthly,
+    seatMonthlyUsd: seat,
+    ratio: seat > 0 ? monthly / seat : 0,
+    estimated: Boolean(opts.estimated || plan.estimated),
+    thin: days < MIN_PROJECTION_DAYS,
+  };
+}
+
+/**
+ * The sentence. Deliberately directional rather than prescriptive: the ratio
+ * says how much value the seat is returning at API-equivalent prices, and a
+ * ratio below 1 is a prompt to look at a lower tier, never an instruction —
+ * plenty of people rightly pay for headroom they rarely use.
+ */
+export function fmtSeatComparison(c: SeatComparison): string {
+  const t = c.estimated ? '~' : '';
+  const usd = (n: number) => (n >= 100 ? n.toFixed(0) : n.toFixed(2));
+  const head = `API-equivalent ${t}$${usd(c.apiEquivalentMonthlyUsd)}/mo against a $${usd(c.seatMonthlyUsd)}/mo ${c.plan.label}`;
+  if (c.thin) {
+    return `${head} — projected from under ${MIN_PROJECTION_DAYS} days of data, so read the ratio as a hint, not a number.`;
+  }
+  const ratio = `≈${c.ratio.toFixed(1)}× the seat price`;
+  if (c.ratio >= 1.5) return `${head} — ${ratio}. The seat is returning well over what it costs.`;
+  if (c.ratio >= 0.8) return `${head} — ${ratio}. About break-even against API rates.`;
+  return `${head} — ${ratio}. A lower tier may fit, if the headroom is not what you are paying for.`;
+}
+
+/** The standing caveat. Printed wherever a seat comparison appears. */
+export const SEAT_CAVEAT =
+  'API-equivalent pricing of subscription traffic is an analogy for value-for-money, not a bill, and this is not a quota tracker — plan limits are not readable from anything local.';

--- a/src/report.ts
+++ b/src/report.ts
@@ -21,6 +21,8 @@ import { fmtTokens } from './fmt.js';
 import type { Rule } from './rules/index.js';
 import { RULES, RULE_BY_KEY } from './rules/index.js';
 import type { ToolSurface } from './tool-surface.js';
+import type { Plan } from './plans.js';
+import { findPlan, seatComparison, fmtSeatComparison, SEAT_CAVEAT } from './plans.js';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -115,7 +117,7 @@ const STATUS_LABEL: Record<FollowRow['status'], string> = {
 
 export function renderReport(
   events: StoredEvent[],
-  opts: { days: number; follow?: FollowRow[]; categorize?: CategorizeSummary; relay?: RelaySummary },
+  opts: { days: number; follow?: FollowRow[]; categorize?: CategorizeSummary; relay?: RelaySummary; plan?: Plan; annual?: boolean },
 ): string {
   if (events.length === 0) {
     return 'No events in range. Run `token-monitor collect` first, or widen --days.';
@@ -226,6 +228,14 @@ export function renderReport(
         }),
       ),
     );
+  }
+
+  if (opts.plan) {
+    const seat = seatComparison(m.costUsd, opts.days, opts.plan, { estimated: m.costEstimated, annual: opts.annual });
+    out.push(section('Seat value'));
+    out.push(`  ${BOLD}${fmtSeatComparison(seat)}${RESET}`);
+    if (opts.plan.note) out.push(`  ${DIM}${opts.plan.label}: ${opts.plan.note}.${RESET}`);
+    out.push(`  ${DIM}${SEAT_CAVEAT}${RESET}`);
   }
 
   out.push(`\n${DIM}Cost figures marked ~ use placeholder prices — edit src/pricing.ts.${RESET}\n`);
@@ -702,6 +712,42 @@ export function renderTeamReport(
       if (m.byActivity[a].tokens === 0) continue;
       out.push(`    ${a.padEnd(13)} ${bar(m.byActivity[a].share)} ${(m.byActivity[a].share * 100).toFixed(1)}%`);
     }
+  }
+
+  // Seat value, only for the members who declared a plan. A team on mixed
+  // tiers still gets rows for the ones who did; members without a plan show
+  // "—" rather than being quietly assumed onto the lead's own tier.
+  const declared = exports.filter((e) => e.plan && findPlan(e.plan));
+  if (declared.length > 0) {
+    out.push(section('Seat value (members who declared a plan)'));
+    let seatTotal = 0;
+    let apiTotal = 0;
+    let anyEstimated = false;
+    const rows = declared.map((e) => {
+      const plan = findPlan(e.plan!)!;
+      const c = seatComparison(e.overall.costUsd, e.days, plan, { estimated: e.overall.costEstimated });
+      seatTotal += c.seatMonthlyUsd;
+      apiTotal += c.apiEquivalentMonthlyUsd;
+      anyEstimated ||= c.estimated;
+      return [
+        displayName(e, opts.keyring),
+        plan.label,
+        `$${c.seatMonthlyUsd.toFixed(0)}/mo`,
+        `${c.estimated ? '~' : ''}$${c.apiEquivalentMonthlyUsd.toFixed(0)}/mo`,
+        c.thin ? `${DIM}thin window${RESET}` : `${c.ratio.toFixed(1)}×`,
+      ];
+    });
+    const undeclared = exports.length - declared.length;
+    if (undeclared > 0) {
+      rows.push([`${DIM}${undeclared} member(s) with no declared plan${RESET}`, `${DIM}—${RESET}`, `${DIM}—${RESET}`, `${DIM}—${RESET}`, `${DIM}—${RESET}`]);
+    }
+    out.push(table(['Member', 'Plan', 'Seat', 'API-equivalent', 'Ratio'], rows));
+    const t = anyEstimated ? '~' : '';
+    out.push(
+      `\n  ${BOLD}${t}$${apiTotal.toFixed(0)}/mo of API-equivalent work on $${seatTotal.toFixed(0)}/mo of seats${RESET}` +
+        ` ${DIM}(${seatTotal > 0 ? (apiTotal / seatTotal).toFixed(1) : '0'}× across the declared seats)${RESET}`,
+    );
+    out.push(`  ${DIM}${SEAT_CAVEAT}${RESET}`);
   }
 
   const stale = staleMembers(exports, opts.keyring);

--- a/src/team.ts
+++ b/src/team.ts
@@ -64,10 +64,18 @@ export interface ExportV1 {
    * apart from a genuinely quiet member.
    */
   coverage?: SourceCoverage[];
+  /**
+   * Self-declared subscription plan id (see plans.ts) — additive and optional
+   * on version 1, like `categories`. It is the ONLY new field the seat lens
+   * needs, it is a string the member chose from a fixed list, and no account
+   * data is read from anywhere to produce it.
+   */
+  plan?: string;
 }
 
-export function buildExport(events: StoredEvent[], days: number): ExportV1 {
+export function buildExport(events: StoredEvent[], days: number, opts: { plan?: string } = {}): ExportV1 {
   return {
+    ...(opts.plan ? { plan: opts.plan } : {}),
     version: 1,
     user: userInfo().username,
     host: hostname(),

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -185,6 +185,30 @@ test('e2e: report --trend renders the trend section (empty previous window)', ()
   assert.ok(stdout.includes('No events in the previous window'));
 });
 
+test('e2e: --plan compares against a seat, rides into the export, and shows up in merge', () => {
+  const seat = run(['report', '--plan', 'pro', ...DAYS]);
+  assert.equal(seat.code, 0);
+  assert.ok(seat.stdout.includes('Seat value'));
+  assert.ok(seat.stdout.includes('not a quota tracker'));
+
+  const bad = run(['report', '--plan', 'max-50x', ...DAYS]);
+  assert.equal(bad.code, 1);
+  assert.ok(bad.stderr.includes('Unknown plan'));
+
+  // The declared plan is a signed field, so it survives merge --verify.
+  const exported = run(['report', '--json', '--plan', 'team-premium', ...DAYS]).stdout;
+  assert.equal(JSON.parse(exported).plan, 'team-premium');
+  writeFileSync(join(HOME, 'seat.json'), exported);
+  const merged = run(['merge', join(HOME, 'seat.json'), '--verify']);
+  assert.equal(merged.code, 0);
+  assert.ok(merged.stdout.includes('Seat value'));
+  assert.ok(merged.stdout.includes('Team premium seat'));
+
+  // No plan declared: no seat section anywhere.
+  writeFileSync(join(HOME, 'noplan.json'), run(['report', '--json', ...DAYS]).stdout);
+  assert.ok(!run(['merge', join(HOME, 'noplan.json')]).stdout.includes('Seat value'));
+});
+
 test('e2e: donate-fixture writes a synthetic, re-collectable copy of one session', () => {
   const listed = run(['analyze', '--json', ...DAYS]);
   assert.equal(listed.code, 0);

--- a/test/plans.test.ts
+++ b/test/plans.test.ts
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PLANS, PLAN_IDS, findPlan, seatComparison, fmtSeatComparison, MIN_PROJECTION_DAYS } from '../src/plans.js';
+import { renderReport, renderTeamReport } from '../src/report.js';
+import { buildExport } from '../src/team.js';
+import { validateTeamConfig } from '../src/deploy.js';
+import { computeMetrics } from '../src/metrics.js';
+import { makeStored } from './helpers.js';
+import type { SignedExport } from '../src/team.js';
+import type { StoredEvent } from '../src/store.js';
+
+test('the plan table is well formed and every id is unique', () => {
+  assert.equal(new Set(PLAN_IDS).size, PLANS.length);
+  for (const p of PLANS) {
+    assert.ok(p.monthlyUsd > 0, `${p.id} needs a price`);
+    if (p.annualUsd !== undefined) {
+      assert.ok(p.annualUsd <= p.monthlyUsd, `${p.id}: annual billing should not cost more per month`);
+    }
+    // Anything the public page does not state outright must say so.
+    if (p.estimated) assert.ok(p.note, `${p.id} is estimated and needs a note explaining why`);
+  }
+});
+
+test('findPlan is forgiving about case and spacing, strict about names', () => {
+  assert.equal(findPlan('  MAX-20X ')?.id, 'max-20x');
+  assert.equal(findPlan('pro')?.monthlyUsd, 20);
+  assert.equal(findPlan('max-50x'), undefined);
+});
+
+test('seatComparison projects the window to a month and divides by the seat', () => {
+  const pro = findPlan('pro')!;
+  // $70 over 15 days -> $140/mo against a $20 seat = 7x.
+  const c = seatComparison(70, 15, pro);
+  assert.equal(c.apiEquivalentMonthlyUsd, 140);
+  assert.equal(c.seatMonthlyUsd, 20);
+  assert.equal(c.ratio, 7);
+  assert.equal(c.thin, false);
+  assert.equal(c.estimated, false);
+
+  // --annual prices against the annual-billing rate where one is published.
+  assert.equal(seatComparison(70, 15, pro, { annual: true }).seatMonthlyUsd, 17);
+  // ...and falls back to the monthly rate where none is.
+  assert.equal(seatComparison(70, 15, findPlan('max-5x')!, { annual: true }).seatMonthlyUsd, 100);
+});
+
+test('an estimated plan price or an estimated cost marks the comparison', () => {
+  assert.equal(seatComparison(100, 30, findPlan('max-20x')!).estimated, true);
+  assert.equal(seatComparison(100, 30, findPlan('pro')!, { estimated: true }).estimated, true);
+  assert.equal(seatComparison(100, 30, findPlan('pro')!).estimated, false);
+});
+
+test('a short window is projected but flagged, not quoted as a ratio', () => {
+  const c = seatComparison(10, MIN_PROJECTION_DAYS - 1, findPlan('pro')!);
+  assert.equal(c.thin, true);
+  assert.match(fmtSeatComparison(c), /read the ratio as a hint, not a number/);
+});
+
+test('the sentence changes direction with the ratio, and never instructs', () => {
+  const pro = findPlan('pro')!;
+  assert.match(fmtSeatComparison(seatComparison(100, 30, pro)), /returning well over what it costs/);
+  assert.match(fmtSeatComparison(seatComparison(20, 30, pro)), /About break-even/);
+  const low = fmtSeatComparison(seatComparison(4, 30, pro));
+  assert.match(low, /A lower tier may fit/);
+  assert.ok(!/you should|downgrade now/i.test(low), 'the low-usage wording must stay a suggestion');
+});
+
+function window(costEvents = 6): StoredEvent[] {
+  return Array.from({ length: costEvents }, (_, i) =>
+    makeStored({
+      session_id: `s${i}`,
+      ts: `2026-06-0${i + 1}T10:00:00.000Z`,
+      model: 'claude-haiku-4-5',
+      input_tokens: 1_000_000,
+      output_tokens: 100_000,
+    }),
+  );
+}
+
+test('report shows the seat section only when a plan is given', () => {
+  const events = window();
+  assert.ok(!renderReport(events, { days: 30 }).includes('Seat value'));
+  const withPlan = renderReport(events, { days: 30, plan: findPlan('max-5x')! });
+  assert.match(withPlan, /Seat value/);
+  assert.match(withPlan, /Max 5x/);
+  assert.match(withPlan, /not a quota tracker/);
+});
+
+test('exports carry the plan only when one was declared', () => {
+  const events = window();
+  assert.equal(buildExport(events, 30).plan, undefined);
+  assert.equal(buildExport(events, 30, { plan: 'team-premium' }).plan, 'team-premium');
+});
+
+function member(user: string, plan: string | undefined, costMultiplier: number): SignedExport {
+  const events = window(costMultiplier);
+  const ex = buildExport(events, 30, { plan });
+  return { ...ex, user, overall: computeMetrics(events) } as SignedExport;
+}
+
+test('merge prices seats per member, totals the declared ones, and never assumes a plan', () => {
+  const exports = [member('alice', 'max-5x', 8), member('bob', 'pro', 2), member('carol', undefined, 4)];
+  const out = renderTeamReport(exports, {});
+  assert.match(out, /Seat value \(members who declared a plan\)/);
+  assert.match(out, /alice/);
+  assert.match(out, /Max 5x/);
+  assert.match(out, /1 member\(s\) with no declared plan/);
+  // Org line sums both sides across the declared seats only ($100 + $20).
+  assert.match(out, /\$120\/mo of seats/);
+});
+
+test('merge stays silent about seats when nobody declared a plan', () => {
+  const out = renderTeamReport([member('alice', undefined, 4)], {});
+  assert.ok(!out.includes('Seat value'));
+});
+
+test('team config validates the plan name it distributes', () => {
+  const base = { teamName: 't', push: { type: 'path' as const, dir: '/tmp/x' } };
+  assert.equal(validateTeamConfig({ ...base, plan: 'team-standard' }).plan, 'team-standard');
+  assert.throws(() => validateTeamConfig({ ...base, plan: 'max-50x' }), /plan must be one of/);
+});


### PR DESCRIPTION
Closes #70.

## Why now

The session that produced this branch ended with me telling the maintainer "your window is \$15.3k API-equivalent" — a number he cannot act on, because he is on a seat. That is the whole gap: the tool prices tokens at API rates and most of its users buy a flat monthly plan, where the only real decision is *which tier*.

## What

```sh
token-monitor report --plan max-20x        # --annual for annual-billing rates
```

```
Seat value

  API-equivalent ~$412/mo against a $200/mo Max 20x — ≈2.1× the seat price. The seat is returning well over what it costs.
```

- Three bands, and the low one stays a suggestion (`a lower tier may fit, if the headroom is not what you are paying for`) — plenty of people rightly pay for headroom they rarely use. A test asserts that wording never becomes an instruction.
- A window under 7 days is projected but **flagged** instead of being quoted as a ratio.
- `--plan` is validated against the table, so a typo fails loudly rather than silently dropping the comparison.

**Merge.** The plan name is a self-declared, optional, additive `ExportV1` field (the `categories` precedent — no version bump). A lead's merge gets a per-member seat table and one org line — *"\$1,240/mo of API-equivalent work on \$600/mo of seats"* — counting **only** the members who declared a plan. Undeclared members show a dash; nobody is assumed onto the lead's tier. Team configs can distribute a default, and a member's own `--plan` wins over it.

## Prices

`src/plans.ts`, vendored exactly like `PRICES`: editable, source-dated (checked against claude.com/pricing on 2026-08-22), per-seat flags, and annual rates where the vendor publishes them. **Max 20x ships `estimated` with a note**, because the public page states only "from \$100/month" for Max and does not name the 20x figure — the table refuses to present a number the source does not.

## What this deliberately is not

A quota or limit tracker. Plan limits are multipliers over shifting baselines with their own windows, and no supported local surface exposes them. `SEAT_CAVEAT` prints next to every comparison saying so, and that API-equivalent pricing of subscription traffic is an analogy for value-for-money, not a bill.

## Privacy

One new export field: a string the member chose from a fixed list. No account data is read from anywhere.

## Tests

`test/plans.test.ts` — table integrity (unique ids, annual ≤ monthly, every estimated entry carries its reason), lookup strictness, projection and ratio math, annual fallback where no annual rate exists, estimate propagation from either side, the thin-window refusal, all three sentence bands, report gating, export field presence, the merge table and org total, silence when nobody declared, and config validation. Plus e2e covering `--plan`, the bad-plan exit, the signed round trip through `merge --verify`, and merge staying silent without plans. 300 pass.