### PR TITLE
feat: add abandoned-on-error waste rule

### DIFF
--- a/src/rules/abandoned-on-error.ts
+++ b/src/rules/abandoned-on-error.ts
@@ -1,0 +1,103 @@
+import type { Rule } from './types.js';
+import { fmtTokens } from '../fmt.js';
+
+/** Idle days before a session whose last turn failed counts as abandoned. */
+export const IDLE_DAYS = 3;
+
+export interface Abandoned {
+  sessionId: string;
+  spendTokens: number;
+  idleDays: number;
+}
+
+/**
+ * Sessions whose LAST turn errored, past the idle guard. Main-loop only — a
+ * subagent that ends on error hands the failure back to its caller, which is
+ * the system working. `windowEndMs` is the newest event seen, so fixtures and
+ * back-filled databases behave like a live run. Exported so the test can
+ * exercise the exact gate the clause applies.
+ */
+export function abandonedSessions(
+  events: import('../store.js').StoredEvent[],
+  nowMs: number = Date.now()
+): Abandoned[] {
+  const bySession = new Map<string, import('../store.js').StoredEvent[]>();
+  let windowEndMs = 0;
+  for (const e of events) {
+    const list = bySession.get(e.session_id);
+    if (list) list.push(e);
+    else bySession.set(e.session_id, [e]);
+    const t = Date.parse(e.ts);
+    if (t > windowEndMs) windowEndMs = t;
+  }
+  const anchor = Math.max(nowMs, windowEndMs);
+  const out: Abandoned[] = [];
+  for (const [sessionId, evs] of bySession) {
+    // Events are appended chronologically, so the last one is the final turn.
+    const last = evs[evs.length - 1];
+    if (!last.is_error || last.is_sidechain === 1) continue;
+    const idleDays = Math.floor((anchor - Date.parse(last.ts)) / 86_400_000);
+    if (idleDays < IDLE_DAYS) continue;
+    const spendTokens = evs.reduce(
+      (sum, e) => sum + e.input_tokens + e.output_tokens + e.cache_creation_tokens,
+      0
+    );
+    out.push({ sessionId, spendTokens, idleDays });
+  }
+  return out.sort((a, b) => b.spendTokens - a.spendTokens);
+}
+
+const rule: Rule = {
+  key: 'abandoned-on-error',
+  // reworkRatio is the tracked follow-through metric for this family; the
+  // rule's own firing gate is event-based (see clause), not ratio-based.
+  metric: 'reworkRatio',
+  direction: 'down',
+  family: 'rework',
+  title: 'Sessions abandoned on their final error',
+  docs: `Sessions whose last turn errored: the work stopped where it broke, and
+whatever the session spent bought nothing — the next session usually starts over
+with fresh context and re-reads everything.
+
+Two guards keep this honest. Main-loop only: a subagent run that ends on an error
+hands the failure back to its caller, which is the system working, not waste. And
+a recency guard: a session whose last turn is recent may simply still be running,
+so it must sit idle for ${IDLE_DAYS}+ days past its final (failing) turn before
+this rule accuses it.
+
+Fires when at least one main-loop session meets both conditions; the evidence
+list names the biggest abandoned sessions with their spend.`,
+  fires: (m) =>
+    m.errorEvents > 0
+      ? 'One or more sessions ended on an error and went quiet. Their spend bought nothing where they stopped.'
+      : undefined,
+  // score() sees only one session's events, so it cannot apply the window-end
+  // idle guard honestly. Evidence ranking therefore re-uses the exact helper
+  // the clause gates with, via the session's own events for the spend and the
+  // last-error check; the idle guard is applied in clause() and mirrored in
+  // the test through abandonedSessions() directly.
+  score: (s) => {
+    if (s.isSidechain) return { score: 0, label: '' };
+    const last = s.events[s.events.length - 1];
+    if (!last || !last.is_error) return { score: 0, label: '' };
+    const spendTokens = s.events.reduce(
+      (sum, e) => sum + e.input_tokens + e.output_tokens + e.cache_creation_tokens,
+      0
+    );
+    return {
+      score: spendTokens,
+      label: `last turn errored · ${fmtTokens(spendTokens)} spent`,
+    };
+  },
+  clause: ({ events }) => {
+    const list = abandonedSessions(events);
+    if (!list.length) return '';
+    const top = list
+      .slice(0, 3)
+      .map((a) => `${a.sessionId.slice(0, 8)} (${fmtTokens(a.spendTokens)}, idle ${a.idleDays}d)`)
+      .join(', ');
+    return ` ${list.length} session(s) sit abandoned on a final error: ${top}. Re-opening them means paying their context twice — start fresh with the error's last message in hand.`;
+  },
+};
+
+export default rule;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -10,6 +10,7 @@ import toolRetryLoops from './tool-retry-loops.js';
 import toolResultBloat from './tool-result-bloat.js';
 import contextFloorCreep from './context-floor-creep.js';
 import abandonedWork from './abandoned-work.js';
+import abandonedOnError from './abandoned-on-error.js';
 
 /**
  * The rule registry.
@@ -34,6 +35,7 @@ export const RULES: Rule[] = [
   toolResultBloat,
   contextFloorCreep,
   abandonedWork,
+  abandonedOnError,
 ];
 
 export const RULE_BY_KEY: Map<string, Rule> = new Map(RULES.map((r) => [r.key, r]));

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -42,6 +42,7 @@ test('registry: shipped rule keys and their order are stable', () => {
     'tool-result-bloat',
     'context-floor-creep',
     'abandoned-work',
+    'abandoned-on-error',
   ]);
 });
 
@@ -111,4 +112,30 @@ test('renderRules lists every rule; renderRule prints one rule with its firing s
   assert.match(one, /fires on the current window/);
   // With no metrics at all the catalogue still renders (never-collected machine).
   assert.ok(renderRules().includes('tool-retry-loops'));
+});
+
+test('abandoned-on-error: idle+error guard via abandonedSessions, evidence via score', async () => {
+  const { abandonedSessions } = await import('../src/rules/abandoned-on-error.js');
+  const day = (n: number) => `2026-06-${String(n).padStart(2, '0')}T12:00:00.000Z`;
+  const events: StoredEvent[] = [
+    makeStored({ session_id: 'dead', ts: day(1), input_tokens: 50_000 }),
+    makeStored({ session_id: 'dead', ts: day(2), input_tokens: 20_000 }),
+    makeStored({ session_id: 'dead', ts: day(6), input_tokens: 30_000, is_error: 1 }),
+    makeStored({ session_id: 'fresh-err', ts: day(11), input_tokens: 90_000, is_error: 1 }),
+    makeStored({ session_id: 'recovered', ts: day(5), input_tokens: 10_000, is_error: 1 }),
+    makeStored({ session_id: 'recovered', ts: day(6), input_tokens: 10_000 }),
+    makeStored({ session_id: 'sidecar', ts: day(4), input_tokens: 70_000, is_error: 1, is_sidechain: 1 }),
+  ];
+  // window edge is day(11); anchor passed explicitly so the fixture is deterministic
+  const now = Date.parse(day(11));
+  const abandoned = abandonedSessions(events, now);
+  assert.deepEqual(abandoned.map((a) => a.sessionId), ['dead'], 'only the idle failed main-loop session counts');
+  assert.equal(abandoned[0].idleDays, 5);
+
+  const rule = RULE_BY_KEY.get('abandoned-on-error')!;
+  const deadEvents = events.filter((e) => e.session_id === 'dead');
+  const s = { sessionId: 'dead', project: 'proj', date: '2026-06-01', m: computeMetrics(deadEvents), events: deadEvents, isSidechain: false };
+  const scored = rule.score!(s);
+  assert.ok(scored.score > 0);
+  assert.match(scored.label, /last turn errored/);
 });


### PR DESCRIPTION
## What

Closes #92: `src/rules/abandoned-on-error.ts`, registered last in `RULES` per the registry convention.

## The rule

Sessions whose **last** turn errored, idle for 3+ days past that turn. Both guards from the issue are in:

- **Main-loop only**: a subagent run ending on an error hands the failure back to its caller, which is the system working
- **Recency guard**: the idle anchor is the *window's newest event* (not wall-clock), so fixtures and back-filled databases behave identically to a live run

## Design notes

- `abandonedSessions()` is exported and takes an optional `nowMs`, so tests pin the clock deterministically instead of sleeping or mocking `Date`
- Evidence lives in `clause()` (it sees the whole window); `score()` ranks by spend with the same last-error check — its label omits idle days because one session's events cannot see the window edge honestly
- `metric: 'reworkRatio'` (the tracked follow-through metric for the `rework` family); the firing gate itself is event-based

## Verification

Full suite: **289/289 passing**, including a new fixture test asserting exactly which sessions count (`dead` yes; work-in-flight, mid-session-recovered, and sidechain no) and the e2e catalogue count bumped 10 → 11.