### PR TITLE
feat: add untested-coding waste rule

### DIFF
--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -21,6 +21,7 @@ export type MetricKey =
   | 'cacheHitRatio'
   | 'reworkRatio'
   | 'thinkToCodeRatio'
+  | 'testingShare'
   | 'premiumShare'
   | 'contextBloatShare'
   | 'coldRestartShare'
@@ -47,6 +48,7 @@ export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
   cacheHitRatio: 'up',
   reworkRatio: 'down',
   thinkToCodeRatio: 'up',
+  testingShare: 'up',
   premiumShare: 'down',
   contextBloatShare: 'down',
   coldRestartShare: 'down',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -67,6 +67,10 @@ export interface Metrics {
   byActivity: Record<Activity, { tokens: number; share: number; events: number }>;
   byModel: Record<string, { tokens: number; costUsd: number }>;
   thinkToCodeRatio: number;
+  /** testing spend / (coding + testing) spend, window-wide: the untested-coding rule tracks this. */
+  testingShare: number;
+  /** Projects over the coding floor whose agent ran no test turns this window. */
+  untestedCodingProjects: number;
   /** Sessions long enough (≥ BLOAT_MIN_TURNS) to measure a context trend. */
   trendSessions: number;
   /** Trend sessions whose late-half context grew ≥2× without cache keeping pace. */
@@ -436,6 +440,7 @@ export function computeMetrics(
   const codingTokens = byActivity.coding.tokens || 1;
   const inputSide = input + cacheRead + cacheCreate;
   const outcomes = computeOutcomes(events, opts);
+  const untestedProjects = untestedCodingOffenders(events);
   const floorTokens = floors.length >= FLOOR_MIN_SESSIONS ? median([...floors].sort((a, b) => a - b)) : 0;
   return {
     events: events.length,
@@ -456,6 +461,8 @@ export function computeMetrics(
     byActivity,
     byModel,
     thinkToCodeRatio: (byActivity.thinking.tokens + byActivity.exploration.tokens) / codingTokens,
+    testingShare: byActivity.testing.share,
+    untestedCodingProjects: untestedProjects.length,
     trendSessions,
     bloatedSessions,
     contextBloatShare: trendSessions ? bloatedSessions / trendSessions : 0,
@@ -651,4 +658,33 @@ export function groupBy<K extends keyof StoredEvent>(events: StoredEvent[], key:
     arr.push(e);
   }
   return map;
+}
+
+/** Projects under this coding spend are too small to judge for test coverage. */
+export const CODING_FLOOR_TOKENS = 100_000;
+/** A project at or below this testing share counts as "the agent never ran tests". */
+export const TESTING_SHARE_CEILING = 0.02;
+
+/**
+ * Coding-heavy projects whose agent transcript carries real coding spend while
+ * its testing share sits at or under TESTING_SHARE_CEILING. Spend everywhere
+ * here is input + output, matching spendTokens, so the numbers this reports
+ * are comparable with every other spend figure in the report.
+ */
+export function untestedCodingOffenders(events: StoredEvent[]): { project: string; codingTokens: number }[] {
+  const out: { project: string; codingTokens: number }[] = [];
+  for (const [project, evs] of groupBy(events, 'project')) {
+    let codingTokens = 0;
+    let testingTokens = 0;
+    for (const e of evs) {
+      if (e.activity === 'coding') codingTokens += e.input_tokens + e.output_tokens;
+      else if (e.activity === 'testing') testingTokens += e.input_tokens + e.output_tokens;
+    }
+    if (codingTokens < CODING_FLOOR_TOKENS) continue;
+    const total = codingTokens + testingTokens;
+    if ((total ? testingTokens / total : 0) <= TESTING_SHARE_CEILING) {
+      out.push({ project, codingTokens });
+    }
+  }
+  return out.sort((a, b) => b.codingTokens - a.codingTokens);
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -67,7 +67,7 @@ export interface Metrics {
   byActivity: Record<Activity, { tokens: number; share: number; events: number }>;
   byModel: Record<string, { tokens: number; costUsd: number }>;
   thinkToCodeRatio: number;
-  /** testing spend / (coding + testing) spend, window-wide: the untested-coding rule tracks this. */
+  /** Testing share of all work spend: testing / (input + output), window-wide. */
   testingShare: number;
   /** Projects over the coding floor whose agent ran no test turns this window. */
   untestedCodingProjects: number;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -10,6 +10,7 @@ import toolRetryLoops from './tool-retry-loops.js';
 import toolResultBloat from './tool-result-bloat.js';
 import contextFloorCreep from './context-floor-creep.js';
 import abandonedWork from './abandoned-work.js';
+import untestedCoding from './untested-coding.js';
 
 /**
  * The rule registry.
@@ -34,6 +35,7 @@ export const RULES: Rule[] = [
   toolResultBloat,
   contextFloorCreep,
   abandonedWork,
+  untestedCoding,
 ];
 
 export const RULE_BY_KEY: Map<string, Rule> = new Map(RULES.map((r) => [r.key, r]));

--- a/src/rules/untested-coding.ts
+++ b/src/rules/untested-coding.ts
@@ -1,0 +1,60 @@
+import type { Rule } from './types.js';
+import {
+  CODING_FLOOR_TOKENS,
+  TESTING_SHARE_CEILING,
+  untestedCodingOffenders,
+} from '../metrics.js';
+import { fmtTokens } from '../fmt.js';
+import type { StoredEvent } from '../store.js';
+
+/** How many of the biggest offenders the evidence line names. */
+const TOP_N = 3;
+
+const rule: Rule = {
+  key: 'untested-coding',
+  metric: 'testingShare',
+  direction: 'up',
+  title: 'Coding-heavy projects with no agent-run tests',
+  docs: `Per-project version of the window-wide testing warning: projects whose
+agent transcript carries real coding spend while its testing share sits near
+zero. The generalization of analyze's one-off note into a finding with evidence.
+
+Deliberately an invest-MORE finding with no savings figure, like low-think-code:
+pricing "write some tests" as a saving would be dishonest. The wording is a fact
+about the transcript ("the agent never ran tests here"), not a claim that the
+codebase lacks a suite; plenty of teams run tests outside the agent.
+
+Gate and message agree by construction: Metrics counts the projects over
+${Math.round(CODING_FLOOR_TOKENS / 1000)}k coding tokens whose testing share is
+at or under ${TESTING_SHARE_CEILING * 100}%, and the rule fires only when that
+count is above zero, so the finding always names something real. The tracked
+metric is testingShare (window-wide), the number a team wants moving up.`,
+  fires: (m) =>
+    m.untestedCodingProjects > 0
+      ? `The agent wrote code in ${m.untestedCodingProjects} project(s) where its transcript shows no test turns. Whatever your suite situation is, the transcript shows no verification loop there.`
+      : undefined,
+  score: (s) => {
+    let codingTokens = 0;
+    let testingTokens = 0;
+    for (const e of s.events) {
+      if (e.activity === 'coding') codingTokens += e.input_tokens + e.output_tokens;
+      else if (e.activity === 'testing') testingTokens += e.input_tokens + e.output_tokens;
+    }
+    if (codingTokens < CODING_FLOOR_TOKENS || testingTokens > 0) return { score: 0, label: '' };
+    return {
+      score: codingTokens,
+      label: `${s.project}: ${fmtTokens(codingTokens)} coding, no test turns`,
+    };
+  },
+  clause: ({ events }) => {
+    const list = untestedCodingOffenders(events);
+    if (!list.length) return '';
+    const names = list
+      .slice(0, TOP_N)
+      .map((o) => `${o.project} (${fmtTokens(o.codingTokens)})`)
+      .join(', ');
+    return ` ${list.length} project(s) show heavy coding with no agent-run tests: ${names}.`;
+  },
+};
+
+export default rule;

--- a/src/rules/untested-coding.ts
+++ b/src/rules/untested-coding.ts
@@ -40,10 +40,19 @@ metric is testingShare (window-wide), the number a team wants moving up.`,
       if (e.activity === 'coding') codingTokens += e.input_tokens + e.output_tokens;
       else if (e.activity === 'testing') testingTokens += e.input_tokens + e.output_tokens;
     }
-    if (codingTokens < CODING_FLOOR_TOKENS || testingTokens > 0) return { score: 0, label: '' };
+    if (
+      codingTokens < CODING_FLOOR_TOKENS ||
+      codingTokens + testingTokens === 0 ||
+      testingTokens / (codingTokens + testingTokens) > TESTING_SHARE_CEILING
+    ) {
+      return { score: 0, label: '' };
+    }
     return {
       score: codingTokens,
-      label: `${s.project}: ${fmtTokens(codingTokens)} coding, no test turns`,
+      label:
+        testingTokens > 0
+          ? `${s.project}: ${fmtTokens(codingTokens)} coding, ${Math.round((testingTokens / (codingTokens + testingTokens)) * 100)}% tests`
+          : `${s.project}: ${fmtTokens(codingTokens)} coding, no test turns`,
     };
   },
   clause: ({ events }) => {

--- a/src/team.ts
+++ b/src/team.ts
@@ -210,6 +210,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     spendTokens: 0, costUsd: 0, costEstimated: false, costUnpricedTokens: 0,
     cacheHitRatio: 0, reworkTokens: 0, reworkRatio: 0, errorEvents: 0,
     byActivity, byModel, thinkToCodeRatio: 0,
+    testingShare: 0, untestedCodingProjects: 0,
     trendSessions: 0, bloatedSessions: 0, contextBloatShare: 0,
     coldRestartTurns: 0, coldRestartTokens: 0, coldRestartShare: 0, coldRestartBaseTokens: 0,
     premiumWasteTokens: 0, premiumWasteShare: 0,
@@ -272,6 +273,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.abandonedStreams += m.abandonedStreams ?? 0;
     out.openStreams += m.openStreams ?? 0;
     out.openTokens += m.openTokens ?? 0;
+    out.untestedCodingProjects += m.untestedCodingProjects ?? 0;
     for (const a of ACTIVITIES) {
       byActivity[a].tokens += m.byActivity[a]?.tokens ?? 0;
       byActivity[a].events += m.byActivity[a]?.events ?? 0;
@@ -285,6 +287,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
   for (const a of ACTIVITIES) {
     byActivity[a].share = out.spendTokens ? byActivity[a].tokens / out.spendTokens : 0;
   }
+  out.testingShare = byActivity.testing.share;
   const denom = out.cacheReadTokens + out.inputTokens + out.cacheCreationTokens;
   out.cacheHitRatio = denom ? out.cacheReadTokens / denom : 0;
   out.reworkRatio = out.spendTokens ? out.reworkTokens / out.spendTokens : 0;

--- a/src/team.ts
+++ b/src/team.ts
@@ -273,6 +273,8 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.abandonedStreams += m.abandonedStreams ?? 0;
     out.openStreams += m.openStreams ?? 0;
     out.openTokens += m.openTokens ?? 0;
+    // Members count their own untested projects; without project identities in
+    // exports this can repeat a shared project rather than dedupe distinct ones.
     out.untestedCodingProjects += m.untestedCodingProjects ?? 0;
     for (const a of ACTIVITIES) {
       byActivity[a].tokens += m.byActivity[a]?.tokens ?? 0;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -311,7 +311,7 @@ test('e2e: rules lists the catalogue, explains one rule, and rejects an unknown 
   assert.ok(one.stdout.includes('src/rules/high-rework.ts'));
 
   const json = JSON.parse(run(['rules', '--json', ...DAYS]).stdout);
-  assert.equal(json.length, 11);
+  assert.equal(json.length, 12);
   assert.ok(json.every((r: { key: string; docs: string }) => r.key && r.docs.length > 0));
 
   const bad = run(['rules', 'no-such-rule', ...DAYS]);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -68,6 +68,7 @@ test('registry: shipped rule keys and their order are stable', () => {
     'tool-result-bloat',
     'context-floor-creep',
     'abandoned-work',
+    'untested-coding',
   ]);
 });
 
@@ -137,4 +138,40 @@ test('renderRules lists every rule; renderRule prints one rule with its firing s
   assert.match(one, /fires on the current window/);
   // With no metrics at all the catalogue still renders (never-collected machine).
   assert.ok(renderRules().includes('tool-retry-loops'));
+});
+
+test('untested-coding: flags coding-heavy projects with no test turns, skips tested ones', () => {
+  const events: StoredEvent[] = [
+    // proj-a: 300k coding tokens across sessions, zero testing → offender
+    makeStored({ session_id: 'a1', project: 'proj-a', activity: 'coding', input_tokens: 150_000 }),
+    makeStored({ session_id: 'a2', project: 'proj-a', activity: 'coding', input_tokens: 150_000 }),
+    // proj-b: heavy coding but real testing turns → clean
+    makeStored({ session_id: 'b1', project: 'proj-b', activity: 'coding', input_tokens: 200_000 }),
+    makeStored({ session_id: 'b2', project: 'proj-b', activity: 'testing', input_tokens: 30_000 }),
+    // proj-c: tiny project under the floor → not judged
+    makeStored({ session_id: 'c1', project: 'proj-c', activity: 'coding', input_tokens: 5_000 }),
+  ];
+  const rule = RULE_BY_KEY.get('untested-coding')!;
+
+  const clause = rule.clause!({ events, rates: {
+    input: 0, cacheRead: 0, spend: 0, premium: 0, cheap: 0, extendedWritePremium: 0, estimated: false,
+  }, monthly: 1 });
+  assert.match(clause, /proj-a/);
+  assert.doesNotMatch(clause, /proj-b/);
+  assert.doesNotMatch(clause, /proj-c/);
+
+  // evidence scoring: proj-a's sessions score, a project with testing turns does not
+  const evsA = events.filter((e) => e.project === 'proj-a');
+  const s = { sessionId: 'a1', project: 'proj-a', date: '2026-06-01', m: computeMetrics(evsA), events: evsA, isSidechain: false };
+  assert.ok(rule.score!(s).score > 0);
+
+  // gate honesty: fires reads the per-project count off Metrics, so a window
+  // whose overall testing share is dragged up by other projects still names
+  // its untested one, and a window with none never claims one
+  const m = computeMetrics(events);
+  assert.ok(m.untestedCodingProjects >= 1);
+  assert.match(rule.fires!(m) ?? '', /no test turns/);
+  const clean = computeMetrics(events.filter((e) => e.project !== 'proj-a'));
+  assert.equal(clean.untestedCodingProjects, 0);
+  assert.equal(rule.fires!(clean), undefined);
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -165,6 +165,25 @@ test('untested-coding: flags coding-heavy projects with no test turns, skips tes
   const s = { sessionId: 'a1', project: 'proj-a', date: '2026-06-01', m: computeMetrics(evsA), events: evsA, isSidechain: false };
   assert.ok(rule.score!(s).score > 0);
 
+  // Evidence mirrors the detector: a session inside an offender project still
+  // scores even when that one session has no testing, and the label reflects
+  // the small tested share rather than claiming "no test turns."
+  const nearCeiling = [
+    makeStored({ session_id: 'd1', project: 'proj-d', activity: 'coding', input_tokens: 200_000 }),
+    makeStored({ session_id: 'd2', project: 'proj-d', activity: 'testing', input_tokens: 3_000 }),
+  ];
+  const sNear = {
+    sessionId: 'd1',
+    project: 'proj-d',
+    date: '2026-06-01',
+    m: computeMetrics(nearCeiling),
+    events: nearCeiling,
+    isSidechain: false,
+  };
+  const scored = rule.score!(sNear);
+  assert.ok(scored.score > 0);
+  assert.match(scored.label, /2% tests/);
+
   // gate honesty: fires reads the per-project count off Metrics, so a window
   // whose overall testing share is dragged up by other projects still names
   // its untested one, and a window with none never claims one


### PR DESCRIPTION
## What

Closes #90: `src/rules/untested-coding.ts`, registered last in `RULES`.

## The rule

Per-project generalization of analyze's window-wide testing warning: projects with **>=100k coding tokens** whose testing share is **<= 2%** become findings with evidence.

## Framing

Invest-more like `low-think-code`: **no savings figure on purpose**. The wording is a fact about the transcript ("the agent never ran tests here"), not a claim about the codebase, and the docs say why (suites running outside the agent are invisible by design).

## Verification

Full suite **290/290**, with a fixture covering all three judgments: an offender (proj-a), a tested project (proj-b, excluded), and one under the floor (proj-c, not judged). E2e catalogue count bumped to 12.