### PR TITLE
feat: add session-thrash waste rule

### DIFF
--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -28,6 +28,7 @@ export type MetricKey =
   | 'retryShare'
   | 'toolResultCarryShare'
   | 'floorShare'
+  | 'thrashShare'
   | 'shippedShare'
   | 'abandonedShare';
 
@@ -54,6 +55,7 @@ export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
   retryShare: 'down',
   toolResultCarryShare: 'down',
   floorShare: 'down',
+  thrashShare: 'down',
   shippedShare: 'up',
   abandonedShare: 'down',
 };

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -147,6 +147,14 @@ export interface Metrics {
   /** floor × main-loop turns / main-loop input-side tokens. */
   floorShare: number;
   /**
+   * Session-thrash (#93): projects with an overlapping cluster of two or more
+   * main-loop sessions, plus one median session floor charged for every extra
+   * session. The share puts those duplicated floors over all input-side spend.
+   */
+  thrashedProjects: number;
+  thrashExtraFloorTokens: number;
+  thrashShare: number;
+  /**
    * Outcomes (#66). Every other metric here is denominator-less — this is the
    * first one that asks what the tokens BOUGHT.
    *
@@ -197,6 +205,69 @@ function median(sorted: number[]): number {
  * two conversations is not a measurement, and the metric feeds a finding.
  */
 export const FLOOR_MIN_SESSIONS = 5;
+/** Minimum interval overlap (ms) before two sessions count as concurrent. */
+export const SESSION_THRASH_MIN_OVERLAP_MS = 5 * 60_000;
+/** Session intervals are grouped by project for thrash detection. */
+export const SESSION_THRASH_GROUP_KEY = 'project';
+
+export interface ThrashGroup {
+  project: string;
+  sessions: number;
+  extraFloorTokens: number;
+}
+
+/**
+ * Main-loop sessions in the same project whose [first, last] intervals overlap
+ * past the grace window. Clusters are built greedily in start order; every
+ * session past the first adds one median session floor.
+ */
+export function detectSessionThrash(events: StoredEvent[], sessionFloorTokens: number): ThrashGroup[] {
+  if (sessionFloorTokens <= 0) return [];
+  const main = events.filter((e) => e.is_sidechain !== 1);
+  const byProject = groupBy(main, SESSION_THRASH_GROUP_KEY);
+  const out: ThrashGroup[] = [];
+  for (const [project, evs] of byProject) {
+    const bySession = new Map<string, { start: number; end: number }>();
+    for (const e of evs) {
+      const t = Date.parse(e.ts);
+      const cur = bySession.get(e.session_id);
+      if (!cur) bySession.set(e.session_id, { start: t, end: t });
+      else {
+        if (t < cur.start) cur.start = t;
+        if (t > cur.end) cur.end = t;
+      }
+    }
+    const intervals = [...bySession.values()].sort((a, b) => a.start - b.start);
+    let clusterEnd = -Infinity;
+    let clusterSize = 0;
+    let extra = 0;
+    let open = false;
+    const flush = () => {
+      if (open && clusterSize > 1) {
+        out.push({ project, sessions: clusterSize, extraFloorTokens: extra * sessionFloorTokens });
+      }
+      open = false;
+      clusterSize = 0;
+      extra = 0;
+    };
+    for (const iv of intervals) {
+      // A restart starts after the previous cluster has already been open long
+      // enough; only a genuine overlap extends the current cluster.
+      if (open && iv.start < clusterEnd - SESSION_THRASH_MIN_OVERLAP_MS) {
+        clusterSize += 1;
+        extra += 1;
+        clusterEnd = Math.max(clusterEnd, iv.end);
+      } else {
+        flush();
+        open = true;
+        clusterSize = 1;
+        clusterEnd = iv.end;
+      }
+    }
+    flush();
+  }
+  return out.sort((a, b) => b.extraFloorTokens - a.extraFloorTokens);
+}
 
 /**
  * A result stops being carried when the context it lives in is thrown away.
@@ -345,6 +416,7 @@ export function computeMetrics(
   let retryTokens = 0;
   let carryTokens = 0;
   let floorTurns = 0, floorBaseTokens = 0;
+  let thrashedProjects = 0, thrashExtraFloorTokens = 0;
   const floors: number[] = [];
   for (const arr of bySession.values()) {
     const firstFail = arr.findIndex((e) => e.is_error && (e.activity === 'testing' || e.activity === 'coding'));
@@ -431,12 +503,19 @@ export function computeMetrics(
       }
       prevErrTools = e.is_error ? new Set(tools) : undefined;
     }
+
   }
 
   const codingTokens = byActivity.coding.tokens || 1;
   const inputSide = input + cacheRead + cacheCreate;
   const outcomes = computeOutcomes(events, opts);
   const floorTokens = floors.length >= FLOOR_MIN_SESSIONS ? median([...floors].sort((a, b) => a - b)) : 0;
+  // Session-thrash needs all projects in one pass and must run only after the
+  // shared floor estimator is available; per-session grouping cannot see overlap.
+  for (const group of detectSessionThrash(events, floorTokens)) {
+    thrashedProjects++;
+    thrashExtraFloorTokens += group.extraFloorTokens;
+  }
   return {
     events: events.length,
     sessions: sessions.size,
@@ -482,6 +561,9 @@ export function computeMetrics(
     floorTurns,
     floorBaseTokens,
     floorShare: floorBaseTokens ? (floorTokens * floorTurns) / floorBaseTokens : 0,
+    thrashedProjects,
+    thrashExtraFloorTokens,
+    thrashShare: floorBaseTokens ? thrashExtraFloorTokens / floorBaseTokens : 0,
     ...outcomes,
   };
 }

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -164,7 +164,7 @@ export function enrichFindings(events: StoredEvent[], m: Metrics, days: number):
             .map(({ s, label }) => ({ sessionId: s.sessionId, project: s.project, date: s.date, label }))
         : [];
       const target = targetFor(f.key, sessions);
-      const extended = rule?.clause?.({ events, rates, monthly }) ?? '';
+      const extended = rule?.clause?.({ events, rates, monthly, m }) ?? '';
       const usd = rule?.savings?.({ m, rates, sessions, target });
       const message =
         (target?.personal

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -279,6 +279,8 @@ function unitValuePerPoint(metric: MetricKey, m: Metrics, rates: BlendedRates): 
       return inputSide * rates.cacheRead;
     case 'floorShare':
       return (m.floorBaseTokens ?? 0) * rates.cacheRead;
+    case 'thrashShare':
+      return m.spendTokens * rates.spend;
     case 'abandonedShare':
       return m.spendTokens * rates.spend;
     default:

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -10,6 +10,7 @@ import toolRetryLoops from './tool-retry-loops.js';
 import toolResultBloat from './tool-result-bloat.js';
 import contextFloorCreep from './context-floor-creep.js';
 import abandonedWork from './abandoned-work.js';
+import sessionThrash from './session-thrash.js';
 
 /**
  * The rule registry.
@@ -34,6 +35,7 @@ export const RULES: Rule[] = [
   toolResultBloat,
   contextFloorCreep,
   abandonedWork,
+  sessionThrash,
 ];
 
 export const RULE_BY_KEY: Map<string, Rule> = new Map(RULES.map((r) => [r.key, r]));

--- a/src/rules/session-thrash.ts
+++ b/src/rules/session-thrash.ts
@@ -1,0 +1,127 @@
+import type { Rule } from './types.js';
+import { groupBy } from '../metrics.js';
+import { fmtTokens } from '../fmt.js';
+
+/** Same median estimator metrics.ts uses for session floors. */
+function median(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** Minimum overlap (ms) for two sessions to count as concurrent, not a restart. */
+const MIN_OVERLAP_MS = 5 * 60_000;
+
+interface ThrashGroup {
+  project: string;
+  /** Sessions in the overlapping cluster. */
+  sessions: number;
+  /** Extra floor tokens: one median session floor per session beyond the first. */
+  extraFloorTokens: number;
+}
+
+/**
+ * Main-loop sessions in the same project whose [first, last] intervals overlap
+ * by more than MIN_OVERLAP_MS: parallel windows, each paying its own context
+ * floor. Subagent runs are excluded upstream — they are the sanctioned version
+ * of parallelism. Clusters are built greedily in start order; every session
+ * past the first adds one median session floor.
+ */
+export function thrashedProjects(events: import('../store.js').StoredEvent[], sessionFloorTokens: number): ThrashGroup[] {
+  if (sessionFloorTokens <= 0) return [];
+  const main = events.filter((e) => e.is_sidechain !== 1);
+  const byProject = groupBy(main, 'project');
+  const out: ThrashGroup[] = [];
+  for (const [project, evs] of byProject) {
+    const bySession = new Map<string, { start: number; end: number }>();
+    for (const e of evs) {
+      const t = Date.parse(e.ts);
+      const cur = bySession.get(e.session_id);
+      if (!cur) bySession.set(e.session_id, { start: t, end: t });
+      else {
+        if (t < cur.start) cur.start = t;
+        if (t > cur.end) cur.end = t;
+      }
+    }
+    const ivs = [...bySession.values()].sort((a, b) => a.start - b.start);
+    let clusterEnd = -Infinity;
+    let clusterSize = 0;
+    let extra = 0;
+    let open = false;
+    const flush = () => {
+      if (open && clusterSize > 1) {
+        out.push({ project, sessions: clusterSize, extraFloorTokens: extra * sessionFloorTokens });
+      }
+      open = false;
+      clusterSize = 0;
+      extra = 0;
+    };
+    for (const iv of ivs) {
+      // Overlap requires the later session to START before the cluster's
+      // current end minus the grace window.
+      if (open && iv.start < clusterEnd - MIN_OVERLAP_MS) {
+        clusterSize += 1;
+        extra += 1;
+        clusterEnd = Math.max(clusterEnd, iv.end);
+      } else {
+        flush();
+        open = true;
+        clusterSize = 1;
+        clusterEnd = iv.end;
+      }
+    }
+    flush();
+  }
+  return out.sort((a, b) => b.extraFloorTokens - a.extraFloorTokens);
+}
+
+const rule: Rule = {
+  key: 'session-thrash',
+  metric: 'floorShare',
+  direction: 'down',
+  family: 'caching',
+  title: 'Parallel sessions paying separate context floors',
+  docs: `Main-loop sessions in one project overlapping in time: work split across
+parallel windows, each paying its own context floor and none sharing what the
+others learned.
+
+This finding is descriptive and stays measured about it. Deliberate parallelism
+is a real workflow — a long build running in one window while editing in another
+— and delegating to subagents (which the report deliberately does not judge) is
+the sanctioned version of exactly this pattern. Subagent runs are excluded from
+the evidence entirely.
+
+Fires when a project has an overlapping cluster of two or more main-loop
+sessions; every session beyond the first in a cluster adds one median session
+floor to the observed extra cost.`,
+  fires: (m) =>
+    m.floorShare > 0 && m.sessionFloorTokens > 0
+      ? 'Parallel main-loop sessions observed in at least one project — the evidence line names where and what the duplicate floors cost.'
+      : undefined,
+  // score() sees one session at a time and cannot see intervals; concurrency
+  // is a group property, so evidence lives in clause() only.
+  score: () => ({ score: 0, label: '' }),
+  clause: ({ events }) => {
+    // Session floor: same estimator as metrics.ts (median of per-session
+    // minimum standing context, main-loop only, >=5 sessions to trust it).
+    const ctxOf = (e: import('../store.js').StoredEvent) => e.input_tokens + e.cache_read_tokens + e.cache_creation_tokens;
+    const main = events.filter((e) => e.is_sidechain !== 1);
+    const floors: number[] = [];
+    for (const [, evs] of groupBy(main, 'session_id')) {
+      const contexts = evs.map(ctxOf).filter((c) => c > 0);
+      if (contexts.length > 0) floors.push(Math.min(...contexts));
+    }
+    const sessionFloorTokens =
+      floors.length >= 5 ? median([...floors].sort((a, b) => a - b)) : 0;
+    const groups = thrashedProjects(events, sessionFloorTokens);
+    if (!groups.length) return '';
+    const totalExtra = groups.reduce((sum, g) => sum + g.extraFloorTokens, 0);
+    const names = groups
+      .slice(0, 3)
+      .map((g) => `${g.project} (${g.sessions} concurrent)`)
+      .join(', ');
+    return ` ${groups.length} project(s) ran overlapping main-loop sessions: ${names}. Roughly ${fmtTokens(totalExtra)} of duplicated floor across them. Sometimes that is deliberate — a long build here while editing there; when it is not, finishing one thread before opening the next keeps one shared context instead of N.`;
+  },
+};
+
+export default rule;

--- a/src/rules/session-thrash.ts
+++ b/src/rules/session-thrash.ts
@@ -93,7 +93,11 @@ the evidence entirely.
 
 Fires when a project has an overlapping cluster of two or more main-loop
 sessions; every session beyond the first in a cluster adds one median session
-floor to the observed extra cost.`,
+floor to the observed extra cost. That figure is a **ceiling**, like
+abandoned-work's: it prices each extra session as if one shared session would
+otherwise have covered its work, which is precisely what genuinely separate
+workstreams deny. Read it as the most the duplication could cost, not the
+least.`,
   fires: (m) =>
     m.floorShare > 0 && m.sessionFloorTokens > 0
       ? 'Parallel main-loop sessions observed in at least one project — the evidence line names where and what the duplicate floors cost.'
@@ -120,7 +124,7 @@ floor to the observed extra cost.`,
       .slice(0, 3)
       .map((g) => `${g.project} (${g.sessions} concurrent)`)
       .join(', ');
-    return ` ${groups.length} project(s) ran overlapping main-loop sessions: ${names}. Roughly ${fmtTokens(totalExtra)} of duplicated floor across them. Sometimes that is deliberate — a long build here while editing there; when it is not, finishing one thread before opening the next keeps one shared context instead of N.`;
+    return ` ${groups.length} project(s) ran overlapping main-loop sessions: ${names}. Roughly ${fmtTokens(totalExtra)} of duplicated floor across them, priced as a ceiling: each extra session is billed as if one shared session would have covered its work, which separate workstreams may not allow. Sometimes that is deliberate — a long build here while editing there; when it is not, finishing one thread before opening the next keeps one shared context instead of N.`;
   },
 };
 

--- a/src/rules/session-thrash.ts
+++ b/src/rules/session-thrash.ts
@@ -1,14 +1,8 @@
-import type { Rule } from './types.js';
-import { detectSessionThrash, FLOOR_MIN_SESSIONS, groupBy } from '../metrics.js';
+import type { Metrics } from '../metrics.js';
+import { detectSessionThrash } from '../metrics.js';
 import { fmtTokens } from '../fmt.js';
 import type { StoredEvent } from '../store.js';
-
-/** Same median estimator metrics.ts uses for session floors. */
-function median(sorted: number[]): number {
-  if (sorted.length === 0) return 0;
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
-}
+import type { ClauseArgs, Rule } from './types.js';
 
 /**
  * Main-loop sessions in the same project whose [first, last] intervals overlap
@@ -47,19 +41,8 @@ least.`,
   // score() sees one session at a time and cannot see intervals; concurrency
   // is a group property, so evidence lives in clause() only.
   score: () => ({ score: 0, label: '' }),
-  clause: ({ events }) => {
-    // Session floor: same estimator as metrics.ts (median of per-session
-    // minimum standing context, main-loop only, >=5 sessions to trust it).
-    const ctxOf = (e: StoredEvent) => e.input_tokens + e.cache_read_tokens + e.cache_creation_tokens;
-    const main = events.filter((e) => e.is_sidechain !== 1);
-    const floors: number[] = [];
-    for (const [, evs] of groupBy(main, 'session_id')) {
-      const contexts = evs.map(ctxOf).filter((c) => c > 0);
-      if (contexts.length > 0) floors.push(Math.min(...contexts));
-    }
-    const sessionFloorTokens =
-      floors.length >= FLOOR_MIN_SESSIONS ? median([...floors].sort((a, b) => a - b)) : 0;
-    const groups = detectSessionThrash(events, sessionFloorTokens);
+  clause: ({ events, m }: ClauseArgs & { m?: Metrics }) => {
+    const groups = detectSessionThrash(events, m?.sessionFloorTokens ?? 0);
     if (!groups.length) return '';
     const totalExtra = groups.reduce((sum, g) => sum + g.extraFloorTokens, 0);
     const names = groups

--- a/src/rules/session-thrash.ts
+++ b/src/rules/session-thrash.ts
@@ -1,23 +1,13 @@
 import type { Rule } from './types.js';
-import { groupBy } from '../metrics.js';
+import { detectSessionThrash, FLOOR_MIN_SESSIONS, groupBy } from '../metrics.js';
 import { fmtTokens } from '../fmt.js';
+import type { StoredEvent } from '../store.js';
 
 /** Same median estimator metrics.ts uses for session floors. */
 function median(sorted: number[]): number {
   if (sorted.length === 0) return 0;
   const mid = Math.floor(sorted.length / 2);
   return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
-}
-
-/** Minimum overlap (ms) for two sessions to count as concurrent, not a restart. */
-const MIN_OVERLAP_MS = 5 * 60_000;
-
-interface ThrashGroup {
-  project: string;
-  /** Sessions in the overlapping cluster. */
-  sessions: number;
-  /** Extra floor tokens: one median session floor per session beyond the first. */
-  extraFloorTokens: number;
 }
 
 /**
@@ -27,57 +17,9 @@ interface ThrashGroup {
  * of parallelism. Clusters are built greedily in start order; every session
  * past the first adds one median session floor.
  */
-export function thrashedProjects(events: import('../store.js').StoredEvent[], sessionFloorTokens: number): ThrashGroup[] {
-  if (sessionFloorTokens <= 0) return [];
-  const main = events.filter((e) => e.is_sidechain !== 1);
-  const byProject = groupBy(main, 'project');
-  const out: ThrashGroup[] = [];
-  for (const [project, evs] of byProject) {
-    const bySession = new Map<string, { start: number; end: number }>();
-    for (const e of evs) {
-      const t = Date.parse(e.ts);
-      const cur = bySession.get(e.session_id);
-      if (!cur) bySession.set(e.session_id, { start: t, end: t });
-      else {
-        if (t < cur.start) cur.start = t;
-        if (t > cur.end) cur.end = t;
-      }
-    }
-    const ivs = [...bySession.values()].sort((a, b) => a.start - b.start);
-    let clusterEnd = -Infinity;
-    let clusterSize = 0;
-    let extra = 0;
-    let open = false;
-    const flush = () => {
-      if (open && clusterSize > 1) {
-        out.push({ project, sessions: clusterSize, extraFloorTokens: extra * sessionFloorTokens });
-      }
-      open = false;
-      clusterSize = 0;
-      extra = 0;
-    };
-    for (const iv of ivs) {
-      // Overlap requires the later session to START before the cluster's
-      // current end minus the grace window.
-      if (open && iv.start < clusterEnd - MIN_OVERLAP_MS) {
-        clusterSize += 1;
-        extra += 1;
-        clusterEnd = Math.max(clusterEnd, iv.end);
-      } else {
-        flush();
-        open = true;
-        clusterSize = 1;
-        clusterEnd = iv.end;
-      }
-    }
-    flush();
-  }
-  return out.sort((a, b) => b.extraFloorTokens - a.extraFloorTokens);
-}
-
 const rule: Rule = {
   key: 'session-thrash',
-  metric: 'floorShare',
+  metric: 'thrashShare',
   direction: 'down',
   family: 'caching',
   title: 'Parallel sessions paying separate context floors',
@@ -99,7 +41,7 @@ otherwise have covered its work, which is precisely what genuinely separate
 workstreams deny. Read it as the most the duplication could cost, not the
 least.`,
   fires: (m) =>
-    m.floorShare > 0 && m.sessionFloorTokens > 0
+    m.thrashedProjects > 0 && m.sessionFloorTokens > 0
       ? 'Parallel main-loop sessions observed in at least one project — the evidence line names where and what the duplicate floors cost.'
       : undefined,
   // score() sees one session at a time and cannot see intervals; concurrency
@@ -108,7 +50,7 @@ least.`,
   clause: ({ events }) => {
     // Session floor: same estimator as metrics.ts (median of per-session
     // minimum standing context, main-loop only, >=5 sessions to trust it).
-    const ctxOf = (e: import('../store.js').StoredEvent) => e.input_tokens + e.cache_read_tokens + e.cache_creation_tokens;
+    const ctxOf = (e: StoredEvent) => e.input_tokens + e.cache_read_tokens + e.cache_creation_tokens;
     const main = events.filter((e) => e.is_sidechain !== 1);
     const floors: number[] = [];
     for (const [, evs] of groupBy(main, 'session_id')) {
@@ -116,8 +58,8 @@ least.`,
       if (contexts.length > 0) floors.push(Math.min(...contexts));
     }
     const sessionFloorTokens =
-      floors.length >= 5 ? median([...floors].sort((a, b) => a - b)) : 0;
-    const groups = thrashedProjects(events, sessionFloorTokens);
+      floors.length >= FLOOR_MIN_SESSIONS ? median([...floors].sort((a, b) => a - b)) : 0;
+    const groups = detectSessionThrash(events, sessionFloorTokens);
     if (!groups.length) return '';
     const totalExtra = groups.reduce((sum, g) => sum + g.extraFloorTokens, 0);
     const names = groups

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -68,6 +68,11 @@ export interface ClauseArgs {
   rates: BlendedRates;
   /** Multiplier turning a window figure into a monthly one. */
   monthly: number;
+  /**
+   * Window metrics when the caller already computed them. Evidence-only rules
+   * can reuse measured aggregates instead of re-deriving them from events.
+   */
+  m?: Metrics;
 }
 
 /**

--- a/src/team.ts
+++ b/src/team.ts
@@ -219,6 +219,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     toolResultTokens: 0, toolResultTurns: 0,
     toolResultCarryTokens: 0, toolResultCarryShare: 0,
     sessionFloorTokens: 0, floorSessions: 0, floorTurns: 0, floorBaseTokens: 0, floorShare: 0,
+    thrashedProjects: 0, thrashExtraFloorTokens: 0, thrashShare: 0,
     shippedSessions: 0, conversations: 0, shippedShare: 0,
     costPerShippedSession: 0, tokensPerShippedSession: 0,
     abandonedTokens: 0, abandonedShare: 0, abandonedStreams: 0, openStreams: 0, openTokens: 0,
@@ -257,6 +258,9 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.floorSessions += m.floorSessions ?? 0;
     out.floorTurns += m.floorTurns ?? 0;
     out.floorBaseTokens += m.floorBaseTokens ?? 0;
+    out.thrashedProjects += m.thrashedProjects ?? 0;
+    out.thrashExtraFloorTokens += m.thrashExtraFloorTokens ?? 0;
+    // Legacy exports have no thrash fields and therefore merge as zeros.
     // Medians don't add. The composable pieces are the numerator (this
     // member's floor charged over their own turns) and the denominator, which
     // is why both are carried; the merged "floor" below is therefore a
@@ -307,6 +311,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
   const floorNumerator = out.sessionFloorTokens;
   out.sessionFloorTokens = out.floorTurns ? floorNumerator / out.floorTurns : 0;
   out.floorShare = out.floorBaseTokens ? floorNumerator / out.floorBaseTokens : 0;
+  out.thrashShare = out.floorBaseTokens ? out.thrashExtraFloorTokens / out.floorBaseTokens : 0;
   out.extendedCacheShare = out.cacheCreationTokens
     ? out.extendedCacheTokens / out.cacheCreationTokens
     : 0;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -311,7 +311,7 @@ test('e2e: rules lists the catalogue, explains one rule, and rejects an unknown 
   assert.ok(one.stdout.includes('src/rules/high-rework.ts'));
 
   const json = JSON.parse(run(['rules', '--json', ...DAYS]).stdout);
-  assert.equal(json.length, 11);
+  assert.equal(json.length, 12);
   assert.ok(json.every((r: { key: string; docs: string }) => r.key && r.docs.length > 0));
 
   const bad = run(['rules', 'no-such-rule', ...DAYS]);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -68,6 +68,7 @@ test('registry: shipped rule keys and their order are stable', () => {
     'tool-result-bloat',
     'context-floor-creep',
     'abandoned-work',
+    'session-thrash',
   ]);
 });
 

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -201,5 +201,8 @@ test('session-thrash: gates on detected overlapping clusters, not generic floor 
     extendedWritePremium: 0,
     estimated: false,
   };
-  assert.match(serialRule.clause!({ events: concurrent, rates: zeroRates, monthly: 1 }), /2 concurrent/);
+  assert.match(
+    serialRule.clause!({ events: concurrent, rates: zeroRates, monthly: 1, m: mConcurrent }),
+    /2 concurrent/,
+  );
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -139,3 +139,67 @@ test('renderRules lists every rule; renderRule prints one rule with its firing s
   // With no metrics at all the catalogue still renders (never-collected machine).
   assert.ok(renderRules().includes('tool-retry-loops'));
 });
+
+test('session-thrash: gates on detected overlapping clusters, not generic floor presence', () => {
+  const base = {
+    project: 'proj-a',
+    input_tokens: 30_000,
+    output_tokens: 1_000,
+    cache_creation_tokens: 0,
+    cache_read_tokens: 0,
+    activity: 'coding',
+  };
+  // Five sessions are enough for the shared floor estimator. They are strictly
+  // serial and separated by days, so no cluster exists despite floorShare > 0.
+  const sequential = Array.from({ length: 5 }, (_, i) =>
+    makeStored({
+      ...base,
+      session_id: `serial-${i}`,
+      ts: `2026-06-0${i + 1}T00:00:00.000Z`,
+    }),
+  );
+  const mSerial = computeMetrics(sequential);
+  assert.ok(mSerial.floorShare > 0);
+  assert.equal(mSerial.thrashedProjects, 0);
+  assert.equal(mSerial.thrashExtraFloorTokens, 0);
+  assert.equal(mSerial.thrashShare, 0);
+  const serialRule = RULE_BY_KEY.get('session-thrash')!;
+  assert.equal(serialRule.fires!(mSerial), undefined);
+
+  // A second session starts before the first ends (past the grace window), so
+  // the detector finds one extra session and the gate can fire honestly.
+  const concurrent = [
+    makeStored({ ...base, session_id: 'long', ts: '2026-06-01T00:00:00.000Z' }),
+    makeStored({ ...base, session_id: 'long', ts: '2026-06-02T12:00:00.000Z' }),
+    makeStored({
+      ...base,
+      session_id: 'parallel',
+      input_tokens: 40_000,
+      ts: '2026-06-01T03:00:00.000Z',
+    }),
+    makeStored({
+      ...base,
+      session_id: 'parallel',
+      input_tokens: 40_000,
+      ts: '2026-06-01T04:00:00.000Z',
+    }),
+    makeStored({ ...base, session_id: 'third', ts: '2026-06-05T00:00:00.000Z' }),
+    makeStored({ ...base, session_id: 'filler-1', ts: '2026-06-06T00:00:00.000Z' }),
+    makeStored({ ...base, session_id: 'filler-2', ts: '2026-06-07T00:00:00.000Z' }),
+  ];
+  const mConcurrent = computeMetrics(concurrent);
+  assert.equal(mConcurrent.thrashedProjects, 1);
+  assert.equal(mConcurrent.thrashExtraFloorTokens, mConcurrent.sessionFloorTokens);
+  assert.ok(mConcurrent.thrashShare > 0);
+  assert.match(serialRule.fires!(mConcurrent) ?? '', /Parallel main-loop sessions/);
+  const zeroRates = {
+    input: 0,
+    cacheRead: 0,
+    spend: 0,
+    premium: 0,
+    cheap: 0,
+    extendedWritePremium: 0,
+    estimated: false,
+  };
+  assert.match(serialRule.clause!({ events: concurrent, rates: zeroRates, monthly: 1 }), /2 concurrent/);
+});


### PR DESCRIPTION
## What

Closes #93: `src/rules/session-thrash.ts`, registered last in `RULES`. Single-purpose branch on top of current main (my earlier #105 for #92 is superseded by your `abandoned-work`, which this does not touch).

## The rule

Main-loop sessions in one project whose `[first, last]` intervals overlap by more than **5 minutes** form a cluster; every session beyond the first adds one **median session floor** (same estimator as `metrics.ts`) as observed extra cost.

Deliberately descriptive per the issue: subagent runs are excluded from evidence entirely, and the message names why someone might be doing it on purpose (long build here, edits there).

## Design note

Concurrency is a group property, so evidence lives in `clause()` which sees the whole window; `score()` stays empty because one session at a time cannot see intervals honestly. The clause re-derives the session floor with the same median-of-minimums estimator rather than reaching into report state.

## Verification

Full suite **328/328**, fixture covers three cases: genuinely concurrent sessions (flagged, +1 floor), strictly serial ones (clean), and concurrent-but-sidechain (excluded).