### PR TITLE
feat: per-category model-routing advisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,27 @@ Both context signals appear on the one-line summary in `report` and the dashboar
 
 **Privacy.** Tool and MCP server names are shown by `context` and stay on the machine. They can name a client, an internal system or a private endpoint, so — exactly like subagent type names — they never enter an export, a signed payload, or an `--llm` payload; the LLM payload's tool-error rows are redacted to `mcp:<tool>`. Connected servers are read from the local agent config by **key only**: a server's command, arguments and environment are never parsed or stored.
 
+## Routing by task
+
+The `premium-misroute` finding is activity-level: premium tokens on reading and chat. The task-level version is sharper — *in this recurring category, your cheap-tier sessions show no worse outcomes than your premium ones* — and `categorize` reports it when the data supports it:
+
+```
+Routing by task (categories that ran on both tiers)
+
+  Category            Sessions  Premium  Cheap  Δ rework  Δ errors  Premium $  Verdict              If routed down
+  ──────────────────  ────────  ───────  ─────  ────────  ────────  ─────────  ───────────────────  ─────────────
+◦ deploy pipeline fix        6        3      3  +1pp      −2pp      $12.50     ≈ no measurable gap  ~$40/mo
+```
+
+Every knob is set toward silence, because the row argues with someone's judgement:
+
+- **Gates**: at least 6 sessions in the category and 2 on *each* tier. Below that, nothing is printed at all — a table of "not enough data" rows teaches people to skim past the rows that matter.
+- **Simpson's guard**: if the two tiers were used in different projects, that is a comparison of projects, not of tiers. The row is confined to a project where both appeared, and marked `◦` when it is.
+- **The verdict never overclaims**: "no measurable outcome gap in this category, on your data" — never "premium adds nothing". Within-category comparison reduces the *harder-tasks-go-to-the-premium-tier* bias; it does not remove it.
+- The savings figure overlaps `premium-misroute` and `premium-model-overuse`, so it is shown as per-category evidence and is **not** added to the report's headline potential.
+
+**One honest limitation.** The ±5pp noise band is a stated assumption, not a measurement. Calibrating it needs a corpus where the same recurring task ran on both tiers, and the maintainer's own machine runs 122.6M premium tokens against 0.04M non-premium — no two-tier population to measure against. The band is deliberately wider than the per-session spread on that corpus so ordinary variation cannot read as "no gap", and it lives in one constant in [`src/routing.ts`](src/routing.ts). If your data can calibrate it, that PR is very welcome.
+
 ## Skill ROI: did codifying it actually work?
 
 `categorize` ends every duplicate-work finding with the same advice — *codify it as a shared skill instead of re-deriving it*. This closes that loop.

--- a/src/categorize.ts
+++ b/src/categorize.ts
@@ -18,7 +18,7 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { loadEvents, recordIntents, loadIntents } from './store.js';
 import type { StoredEvent, IntentRow } from './store.js';
-import { groupByRootSession, parseTools } from './metrics.js';
+import { computeMetrics, groupByRootSession, parseTools } from './metrics.js';
 import { costOf } from './pricing.js';
 import { ADAPTERS } from './adapters/index.js';
 import type { Source } from './types.js';
@@ -28,6 +28,9 @@ import type { ClusterItem } from './cluster.js';
 import type { ExportCategory } from './team.js';
 import type { SkillReport } from './skills.js';
 import { skillReport } from './skills.js';
+import type { RoutingRow } from './routing.js';
+import { computeRouting, sessionFacts } from './routing.js';
+import { blendedRates } from './recommendations.js';
 
 export interface CategoryRow {
   id: string;
@@ -60,6 +63,10 @@ export interface CategorizeResult {
   sessionDates?: Map<string, string[]>;
   /** Skill adoption and ROI (#67); absent until `categorize` computes it. */
   skills?: SkillReport;
+  /** Category name -> its session ids, for the per-category routing comparison (#71). */
+  members?: Map<string, string[]>;
+  /** Per-category premium-vs-cheap routing evidence (#71). */
+  routing?: RoutingRow[];
 }
 
 interface SessionAgg {
@@ -174,6 +181,14 @@ export function runCategorize(
   const frozen = loadIntents(db, aggs.map((a) => a.sessionId));
   const result = buildResult(aggs, frozen, days, opts);
   result.skills = skillReport(db, result.categories, result.sessionDates!, { days });
+  // Routing needs per-session model mix and outcomes, so it runs off the same
+  // events the categories were built from rather than a second query.
+  result.routing = computeRouting(
+    result.members!,
+    sessionFacts(events),
+    blendedRates(computeMetrics(events)),
+    days,
+  );
   return result;
 }
 
@@ -227,12 +242,18 @@ function buildResult(
   const sessionDates = new Map<string, string[]>(
     clusters.map((c) => [c.id, c.items.map((it) => aggById.get(it.id)?.date ?? '').filter(Boolean)]),
   );
+  // Keyed by NAME for routing (which reports names) and by id for skill ROI
+  // (which joins on the cluster id) — the two consumers want different keys.
+  const members = new Map<string, string[]>(
+    clusters.map((c) => [categories.find((cat) => cat.id === c.id)?.name ?? c.name, c.items.map((it) => it.id)]),
+  );
 
   return {
     days,
     totalSessions: aggs.length,
     textSessions,
     sessionDates,
+    members,
     categories: [...categories].sort(byCostThenSessions),
     duplicates: categories.filter((c) => c.duplicate).sort((a, b) => b.cost - a.cost || byCostThenSessions(a, b)),
     skillCandidates: categories.filter((c) => c.hasText && c.sessions >= minCluster).sort(byCostThenSessions),

--- a/src/report.ts
+++ b/src/report.ts
@@ -15,6 +15,8 @@ import type { SourceCoverage } from './coverage.js';
 import { computeCoverage, fmtCoverage, readRetentionDays, retentionNote, trendIsComparable } from './coverage.js';
 import type { CategorizeResult, CategorizeSummary } from './categorize.js';
 import { ROI_MIN_BEFORE_SESSIONS } from './skills.js';
+import type { RoutingRow } from './routing.js';
+import { MIN_CATEGORY_SESSIONS, MIN_PER_SIDE, NOISE_BAND, ROUTING_CAVEAT } from './routing.js';
 import { fmtCategorizeSummary } from './categorize.js';
 import type { MergedCategories, OrgCategory } from './team-categories.js';
 import type { RelayResult, RelaySummary } from './relay-scan.js';
@@ -392,12 +394,60 @@ export function renderCategorize(r: CategorizeResult, days: number): string {
     );
   }
 
+  out.push(...renderRouting(r.routing ?? []));
   out.push(...renderSkillAdoption(r));
 
   out.push(
     `\n  ${DIM}Labels are derived on-device from redacted prompts; raw prompt text is never stored.${RESET}\n`,
   );
   return out.join('\n');
+}
+
+const ROUTING_VERDICT: Record<RoutingRow['verdict'], string> = {
+  'no-measurable-gap': '≈ no measurable gap',
+  'premium-better': '↑ premium did better',
+  'cheap-worse-unclear': '— unclear',
+};
+
+/**
+ * Per-category routing evidence: where a recurring task ran on both tiers and
+ * the cheaper one showed no measurably worse outcome. Empty for most people,
+ * on purpose — the gates are strict because the row is an argument about
+ * someone's judgement.
+ */
+export function renderRouting(rows: RoutingRow[]): string[] {
+  const out: string[] = [];
+  if (rows.length === 0) return out;
+  out.push(section('Routing by task (categories that ran on both tiers)'));
+  out.push(
+    table(
+      ['Category', 'Sessions', 'Premium', 'Cheap', 'Δ rework', 'Δ errors', 'Premium $', 'Verdict', 'If routed down'],
+      rows.slice(0, 10).map((r) => [
+        (r.projectScoped ? '◦ ' : '') + (r.category.length > 22 ? r.category.slice(0, 21) + '…' : r.category),
+        String(r.sessions),
+        String(r.premiumSessions),
+        String(r.cheapSessions),
+        (r.reworkDelta >= 0 ? '+' : '−') + Math.abs(r.reworkDelta * 100).toFixed(0) + 'pp',
+        (r.errorDelta >= 0 ? '+' : '−') + Math.abs(r.errorDelta * 100).toFixed(0) + 'pp',
+        '$' + r.premiumCostUsd.toFixed(2),
+        ROUTING_VERDICT[r.verdict],
+        r.savingsUsdPerMonth ? `${GREEN}~$${r.savingsUsdPerMonth.toFixed(0)}/mo${RESET}` : `${DIM}—${RESET}`,
+      ]),
+    ),
+  );
+  out.push(
+    `\n  ${DIM}Δ is the cheap side minus the premium side, in percentage points: positive means the cheaper tier did worse. Gates: ≥${MIN_CATEGORY_SESSIONS} sessions in the category and ≥${MIN_PER_SIDE} on each tier, and differences within ±${(NOISE_BAND * 100).toFixed(0)}pp count as no gap.${RESET}`,
+  );
+  if (rows.some((r) => r.projectScoped)) {
+    out.push(
+      `  ${DIM}◦ marks a comparison confined to the one project where both tiers were actually used — comparing across projects would compare the projects, not the tiers.${RESET}`,
+    );
+  }
+  out.push(`  ${DIM}${ROUTING_CAVEAT}${RESET}`);
+  out.push(
+    `  ${DIM}The "if routed down" figure overlaps the premium-misroute and premium-model-overuse findings; it is shown here as per-category evidence and is deliberately NOT added to the report's headline potential.${RESET}`,
+  );
+  return out;
 }
 
 const ROI_STATUS: Record<string, string> = {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,0 +1,168 @@
+import type { StoredEvent } from './store.js';
+import { computeMetrics, groupByRootSession, premiumShare } from './metrics.js';
+import { PREMIUM_MODEL_RE } from './pricing.js';
+import type { BlendedRates } from './rules/types.js';
+
+/**
+ * Per-category model routing (#71).
+ *
+ * The existing routing findings are activity-level: premium tokens on
+ * exploration or conversation turns. The sharper, more persuasive version is
+ * task-level — "in THIS recurring category, your cheap-tier sessions show no
+ * worse outcomes than your premium ones" — because personalized evidence beats
+ * generic advice, the same reasoning behind personalized targets.
+ *
+ * This feature makes an accusation about someone's judgement, so every knob
+ * below is set toward silence.
+ *
+ * ## The calibration caveat, stated because it matters
+ *
+ * The noise band could NOT be calibrated against real data. The only corpus
+ * available for dogfooding runs 122.6M premium tokens against 0.04M
+ * non-premium — 106 premium-only sessions, 2 cheap-only, 2 mixed — so there is
+ * no two-tier population to measure a "not worse" threshold on. NOISE_BAND is
+ * therefore an explicit assumption, not a measurement: five percentage points
+ * on each outcome, chosen to be wider than the per-session spread observed on
+ * that corpus (rework sd ≈ 0.041, error sd ≈ 0.042) so ordinary variation
+ * cannot read as "no gap". Change it in one place when a mixed-tier corpus
+ * exists to measure it against.
+ */
+
+/** A category needs this many sessions before any comparison is attempted. */
+export const MIN_CATEGORY_SESSIONS = 6;
+/** ...and this many on EACH side. One session is an anecdote. */
+export const MIN_PER_SIDE = 2;
+/** A session counts as premium when most of its spend was on a premium model. */
+export const PREMIUM_SESSION_SHARE = 0.5;
+/** Absolute outcome difference below which the two sides are called comparable. */
+export const NOISE_BAND = 0.05;
+
+export interface RoutingRow {
+  category: string;
+  sessions: number;
+  premiumSessions: number;
+  cheapSessions: number;
+  premiumTokens: number;
+  premiumCostUsd: number;
+  /** cheap-side minus premium-side; positive means the cheap tier did worse. */
+  reworkDelta: number;
+  errorDelta: number;
+  verdict: 'no-measurable-gap' | 'premium-better' | 'cheap-worse-unclear';
+  /** Only present on a no-measurable-gap row; always `~`-marked in display. */
+  savingsUsdPerMonth?: number;
+  /**
+   * True when the comparison was confined to the single project both sides
+   * shared — the Simpson's guard. A category spanning projects where the two
+   * tiers were used in DIFFERENT projects is not a comparison at all.
+   */
+  projectScoped: boolean;
+}
+
+interface SessionFacts {
+  premium: boolean;
+  project: string;
+  rework: number;
+  errorRate: number;
+  premiumTokens: number;
+  premiumCostUsd: number;
+}
+
+/** Per-root-session facts the comparison needs. Root sessions: fan-out counts with its driver. */
+export function sessionFacts(events: StoredEvent[]): Map<string, SessionFacts> {
+  const out = new Map<string, SessionFacts>();
+  for (const [id, evs] of groupByRootSession(events)) {
+    const m = computeMetrics(evs);
+    let premiumTokens = 0, premiumCostUsd = 0;
+    for (const [model, v] of Object.entries(m.byModel)) {
+      if (!PREMIUM_MODEL_RE.test(model)) continue;
+      premiumTokens += v.tokens;
+      premiumCostUsd += v.costUsd;
+    }
+    out.set(id, {
+      premium: premiumShare(m) >= PREMIUM_SESSION_SHARE,
+      project: evs[0]?.project ?? 'unknown',
+      rework: m.reworkRatio,
+      errorRate: m.events ? m.errorEvents / m.events : 0,
+      premiumTokens,
+      premiumCostUsd,
+    });
+  }
+  return out;
+}
+
+const mean = (xs: number[]) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Compare tiers within each category. `members` maps a category name to its
+ * session ids; anything that fails a gate is dropped silently rather than
+ * reported with a caveat, because a table full of "not enough data" rows
+ * teaches people to skim past the rows that do mean something.
+ */
+export function computeRouting(
+  members: Map<string, string[]>,
+  facts: Map<string, SessionFacts>,
+  rates: BlendedRates,
+  days: number,
+): RoutingRow[] {
+  const monthly = days > 0 ? 30 / days : 1;
+  const rows: RoutingRow[] = [];
+
+  for (const [category, ids] of members) {
+    const all = ids.map((id) => facts.get(id)).filter((f): f is SessionFacts => Boolean(f));
+    if (all.length < MIN_CATEGORY_SESSIONS) continue;
+
+    // Simpson's guard: if both tiers appear inside one project, compare there.
+    // Otherwise the "comparison" may just be two different projects.
+    let population = all;
+    let projectScoped = false;
+    const byProject = new Map<string, SessionFacts[]>();
+    for (const f of all) byProject.set(f.project, [...(byProject.get(f.project) ?? []), f]);
+    if (byProject.size > 1) {
+      const usable = [...byProject.values()].find(
+        (list) =>
+          list.filter((f) => f.premium).length >= MIN_PER_SIDE &&
+          list.filter((f) => !f.premium).length >= MIN_PER_SIDE,
+      );
+      if (!usable) continue; // tiers never met inside one project: not comparable
+      population = usable;
+      projectScoped = true;
+    }
+
+    const premium = population.filter((f) => f.premium);
+    const cheap = population.filter((f) => !f.premium);
+    if (premium.length < MIN_PER_SIDE || cheap.length < MIN_PER_SIDE) continue;
+
+    const reworkDelta = mean(cheap.map((f) => f.rework)) - mean(premium.map((f) => f.rework));
+    const errorDelta = mean(cheap.map((f) => f.errorRate)) - mean(premium.map((f) => f.errorRate));
+    const premiumTokens = premium.reduce((s, f) => s + f.premiumTokens, 0);
+    const premiumCostUsd = premium.reduce((s, f) => s + f.premiumCostUsd, 0);
+
+    let verdict: RoutingRow['verdict'] = 'cheap-worse-unclear';
+    let savingsUsdPerMonth: number | undefined;
+    if (reworkDelta > NOISE_BAND || errorDelta > NOISE_BAND) {
+      // The cheap tier did measurably worse here. Say nothing about savings.
+      verdict = 'premium-better';
+    } else if (Math.abs(reworkDelta) <= NOISE_BAND && Math.abs(errorDelta) <= NOISE_BAND) {
+      verdict = 'no-measurable-gap';
+      savingsUsdPerMonth = premiumTokens * Math.max(0, rates.premium - rates.cheap) * monthly;
+    }
+
+    rows.push({
+      category, sessions: population.length,
+      premiumSessions: premium.length, cheapSessions: cheap.length,
+      premiumTokens, premiumCostUsd, reworkDelta, errorDelta, verdict,
+      savingsUsdPerMonth, projectScoped,
+    });
+  }
+
+  return rows.sort((a, b) => (b.savingsUsdPerMonth ?? -1) - (a.savingsUsdPerMonth ?? -1));
+}
+
+/**
+ * The standing caveat, printed with the table. Within-category comparison
+ * reduces selection bias — people route harder work to the premium tier — but
+ * it does not remove it, which is why the verdict is always phrased as an
+ * absence of measurable difference rather than a claim about the model.
+ */
+export const ROUTING_CAVEAT =
+  'Within-category comparison reduces the "harder tasks go to the premium tier" bias but does not remove it. A row says there is no measurable outcome gap in THIS category on YOUR data — never that the premium model adds nothing.';

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeRouting, sessionFacts, MIN_CATEGORY_SESSIONS, MIN_PER_SIDE, NOISE_BAND,
+} from '../src/routing.js';
+import { renderRouting } from '../src/report.js';
+import { blendedRates } from '../src/recommendations.js';
+import { computeMetrics } from '../src/metrics.js';
+import { makeStored } from './helpers.js';
+import type { StoredEvent } from '../src/store.js';
+
+const PREMIUM = 'claude-opus-4-7';
+const CHEAP = 'claude-haiku-4-5';
+
+/** One session: n turns on a model, with `errors` of them failing. */
+function session(id: string, model: string, opts: { errors?: number; turns?: number; project?: string; rework?: boolean } = {}): StoredEvent[] {
+  const turns = opts.turns ?? 4;
+  const out: StoredEvent[] = [];
+  for (let i = 0; i < turns; i++) {
+    out.push(makeStored({
+      session_id: id,
+      project: opts.project ?? 'p1',
+      model,
+      ts: `2026-06-0${1 + (i % 9)}T0${i % 10}:00:00.000Z`,
+      activity: opts.rework && i > 0 ? 'coding' : i === 0 ? 'testing' : 'coding',
+      is_error: opts.rework && i === 0 ? 1 : (opts.errors ?? 0) > i ? 1 : 0,
+      input_tokens: 20_000,
+      output_tokens: 2_000,
+    }));
+  }
+  return out;
+}
+
+function ratesFor(events: StoredEvent[]) {
+  return blendedRates(computeMetrics(events));
+}
+
+test('a session is classified by where the majority of its spend went', () => {
+  const events = [...session('prem', PREMIUM), ...session('cheap', CHEAP)];
+  const facts = sessionFacts(events);
+  assert.equal(facts.get('prem')!.premium, true);
+  assert.equal(facts.get('cheap')!.premium, false);
+  assert.ok(facts.get('prem')!.premiumTokens > 0);
+  assert.equal(facts.get('cheap')!.premiumTokens, 0);
+});
+
+test('comparable outcomes on both tiers produce a priced no-gap row', () => {
+  const events = [
+    ...session('p1', PREMIUM), ...session('p2', PREMIUM), ...session('p3', PREMIUM),
+    ...session('c1', CHEAP), ...session('c2', CHEAP), ...session('c3', CHEAP),
+  ];
+  const members = new Map([['deploy pipeline fix', ['p1', 'p2', 'p3', 'c1', 'c2', 'c3']]]);
+  const [row] = computeRouting(members, sessionFacts(events), ratesFor(events), 30);
+  assert.equal(row.verdict, 'no-measurable-gap');
+  assert.equal(row.premiumSessions, 3);
+  assert.equal(row.cheapSessions, 3);
+  assert.ok(row.savingsUsdPerMonth! > 0);
+  assert.equal(row.projectScoped, false);
+});
+
+test('a measurably worse cheap tier is reported as premium-better and priced at nothing', () => {
+  const events = [
+    ...session('p1', PREMIUM), ...session('p2', PREMIUM), ...session('p3', PREMIUM),
+    // Every cheap session fails most of its turns.
+    ...session('c1', CHEAP, { errors: 3 }), ...session('c2', CHEAP, { errors: 3 }), ...session('c3', CHEAP, { errors: 3 }),
+  ];
+  const members = new Map([['deploy pipeline fix', ['p1', 'p2', 'p3', 'c1', 'c2', 'c3']]]);
+  const [row] = computeRouting(members, sessionFacts(events), ratesFor(events), 30);
+  assert.equal(row.verdict, 'premium-better');
+  assert.equal(row.savingsUsdPerMonth, undefined);
+  assert.ok(row.errorDelta > NOISE_BAND);
+});
+
+test('the gates stay silent rather than reporting a thin comparison', () => {
+  const facts = (ids: Array<[string, string]>) =>
+    sessionFacts(ids.flatMap(([id, model]) => session(id, model)));
+
+  // Too few sessions overall.
+  const thin: Array<[string, string]> = [['p1', PREMIUM], ['p2', PREMIUM], ['c1', CHEAP]];
+  assert.ok(thin.length < MIN_CATEGORY_SESSIONS);
+  assert.deepEqual(computeRouting(new Map([['x', thin.map((t) => t[0])]]), facts(thin), ratesFor(session('p1', PREMIUM)), 30), []);
+
+  // Enough sessions, but only one on the cheap side.
+  const lopsided: Array<[string, string]> = [
+    ['p1', PREMIUM], ['p2', PREMIUM], ['p3', PREMIUM], ['p4', PREMIUM], ['p5', PREMIUM], ['c1', CHEAP],
+  ];
+  assert.ok(MIN_PER_SIDE > 1);
+  assert.deepEqual(computeRouting(new Map([['x', lopsided.map((t) => t[0])]]), facts(lopsided), ratesFor(session('p1', PREMIUM)), 30), []);
+});
+
+test("Simpson's guard: tiers used in different projects are not a comparison", () => {
+  const events = [
+    ...session('p1', PREMIUM, { project: 'alpha' }), ...session('p2', PREMIUM, { project: 'alpha' }),
+    ...session('p3', PREMIUM, { project: 'alpha' }),
+    ...session('c1', CHEAP, { project: 'beta' }), ...session('c2', CHEAP, { project: 'beta' }),
+    ...session('c3', CHEAP, { project: 'beta' }),
+  ];
+  const members = new Map([['x', ['p1', 'p2', 'p3', 'c1', 'c2', 'c3']]]);
+  assert.deepEqual(computeRouting(members, sessionFacts(events), ratesFor(events), 30), []);
+});
+
+test("...but a project where both tiers were used is compared, and marked", () => {
+  const events = [
+    ...session('p1', PREMIUM, { project: 'alpha' }), ...session('p2', PREMIUM, { project: 'alpha' }),
+    ...session('c1', CHEAP, { project: 'alpha' }), ...session('c2', CHEAP, { project: 'alpha' }),
+    // Noise from another project that only ever used one tier.
+    ...session('p3', PREMIUM, { project: 'beta' }), ...session('p4', PREMIUM, { project: 'beta' }),
+  ];
+  const members = new Map([['x', ['p1', 'p2', 'c1', 'c2', 'p3', 'p4']]]);
+  const [row] = computeRouting(members, sessionFacts(events), ratesFor(events), 30);
+  assert.equal(row.projectScoped, true);
+  assert.equal(row.sessions, 4, 'only the project where both tiers appeared is compared');
+});
+
+test('the rendered table explains the delta, the gates, and refuses the stronger claim', () => {
+  const out = renderRouting([{
+    category: 'deploy pipeline fix', sessions: 6, premiumSessions: 3, cheapSessions: 3,
+    premiumTokens: 500_000, premiumCostUsd: 12.5, reworkDelta: 0.01, errorDelta: -0.02,
+    verdict: 'no-measurable-gap', savingsUsdPerMonth: 40, projectScoped: true,
+  }]).join('\n');
+  assert.match(out, /Routing by task/);
+  assert.match(out, /no measurable gap/);
+  assert.match(out, /never that the premium model adds nothing/);
+  assert.match(out, /deliberately NOT added to the report's headline potential/);
+  assert.match(out, /◦ marks a comparison confined to the one project/);
+  // Nothing to say is said with silence, not with an empty table.
+  assert.deepEqual(renderRouting([]), []);
+});


### PR DESCRIPTION
Closes #71 — the last unbuilt item from the #72 backlog.

## What

`premium-misroute` is activity-level: premium tokens on reading and chat. This is the task-level version — *in this recurring category, your cheap-tier sessions show no worse outcomes than your premium ones* — joining frozen categories with per-session model mix and hygiene outcomes.

```
Routing by task (categories that ran on both tiers)

  Category            Sessions  Premium  Cheap  Δ rework  Δ errors  Premium $  Verdict              If routed down
  ──────────────────  ────────  ───────  ─────  ────────  ────────  ─────────  ───────────────────  ─────────────
◦ deploy pipeline fix        6        3      3  +1pp      −2pp      $12.50     ≈ no measurable gap  ~$40/mo
```

## Set toward silence

- **Gates**: ≥6 sessions in the category, ≥2 on each tier. Below that nothing prints — a table of "not enough data" rows trains people to skim past the rows that mean something.
- **Simpson's guard**: tiers used in *different* projects is a comparison of projects. The row is confined to a project where both appeared, and marked `◦`.
- **Never the stronger claim**: "no measurable outcome gap in this category, on your data". Within-category comparison reduces the harder-tasks-go-premium bias; it does not remove it, and the caveat prints with the table.
- **No double counting**: the savings figure overlaps `premium-misroute` / `premium-model-overuse`, so it is per-category evidence and is **not** added to the headline potential. The max-within-family de-overlap only protects among rules, and this is not one.

## The limitation, stated rather than hidden

The issue left the noise band as an open question to "decide against real data during dogfood". **That could not be done.** The only corpus available runs **122.6M premium tokens against 0.04M non-premium** — 106 premium-only sessions, 2 cheap-only, 2 mixed — so there is no two-tier population to calibrate a "not worse" threshold on.

Rather than quietly picking a number and calling it measured, the ±5pp band ships as an **explicit assumption**: wider than the per-session spread observed on that corpus (rework sd ≈ 0.041, error sd ≈ 0.042) so ordinary variation cannot read as "no gap", documented as uncalibrated at the top of `src/routing.ts`, and living in a single constant. On the maintainer's own data the feature is correctly silent — verified, not assumed.

The issue's other open question — whether Haiku-class and Sonnet-class should be separate cheap tiers or pooled — stays pooled for the same reason: nothing here can distinguish them yet.

## Tests

`test/routing.test.ts` — tier classification by majority spend, a priced no-gap row, a measurably-worse cheap tier priced at nothing, both gates staying silent, the Simpson's guard rejecting cross-project pairs *and* accepting a project where both tiers appeared, and the renderer's wording including the refusal to make the stronger claim. 335 pass.