### PR TITLE
docs: make rule registration impossible to miss

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,9 @@ A **rule** is one heuristic that turns metrics into a finding: a firing conditio
 
 Run `token-monitor rules` to see the catalogue and which fire on your own data, and `token-monitor rules <key>` for what one measures. Several are pre-specced as `good first issue` in the tracker, each with its failure modes written down.
 
-One file in `src/rules/`, listed once in `src/rules/index.ts`:
+A rule is **two edits**: the file, and one line registering it. Both are required — an unregistered rule is never loaded, so it silently never fires.
+
+**1. Write `src/rules/<key>.ts`.** The filename must match the rule's `key`.
 
 ```ts
 // src/rules/tool-retry-loops.ts
@@ -45,6 +47,19 @@ const rule: Rule = {
 };
 export default rule;
 ```
+
+**2. Register it in `src/rules/index.ts`** — the import *and* the array entry:
+
+```ts
+import toolRetryLoops from './tool-retry-loops.js';   // <- add the import
+
+export const RULES: Rule[] = [
+  // ...
+  toolRetryLoops,                                     // <- and the entry
+];
+```
+
+`npm test` fails with `rule file src/rules/<key>.ts is not registered` if you miss either half, so you will not find out from a confusing assertion somewhere else.
 
 Only `key`, `metric`, `direction`, `title`, `docs` and `fires` are required. `score` supplies the "worst sessions" evidence; `savings` prices the finding; `target`/`personalTarget` say what it is priced against; `clause` appends a sentence that needs the raw events. See `src/rules/types.ts` for the full contract and `src/rules/low-think-code.ts` for a rule that deliberately prices nothing.
 

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -6,6 +6,9 @@ import { structuredFindings } from '../src/followthrough.js';
 import { enrichFindings, targetFor } from '../src/recommendations.js';
 import { renderRules, renderRule } from '../src/report.js';
 import { makeStored } from './helpers.js';
+import { readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { StoredEvent } from '../src/store.js';
 
 test('registry: keys are unique, complete, and every rule keeps the contract', () => {
@@ -18,6 +21,29 @@ test('registry: keys are unique, complete, and every rule keeps the contract', (
     // A rule that prices savings must declare what it is priced against:
     // either a target (static or personalized) or tokens it can name directly.
     assert.equal(typeof r.fires, 'function');
+  }
+});
+
+/**
+ * A rule file that never reaches index.ts is dead code: it cannot fire, cannot
+ * be listed, and the only symptom is an unrelated assertion failing somewhere
+ * else. That happened to a contributor's first PR, so the suite now says it in
+ * one line — and pins the filename-is-the-key convention while it is here.
+ */
+test('registry: every rule file is registered, and its filename is its key', () => {
+  const rulesDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src', 'rules');
+  const files = readdirSync(rulesDir)
+    .filter((f) => f.endsWith('.ts') && f !== 'index.ts' && f !== 'types.ts')
+    .map((f) => f.replace(/\.ts$/, ''));
+  assert.ok(files.length > 0, 'no rule files found — check the path');
+  for (const key of files) {
+    assert.ok(
+      RULE_BY_KEY.has(key),
+      `rule file src/rules/${key}.ts is not registered — add its import and its entry to src/rules/index.ts`,
+    );
+  }
+  for (const rule of RULES) {
+    assert.ok(files.includes(rule.key), `rule "${rule.key}" has no src/rules/${rule.key}.ts (filename must match the key)`);
   }
 });
 


### PR DESCRIPTION
A contributor's first PR (#108) added a rule file and never registered it in `src/rules/index.ts`. The rule was dead — it can't fire, can't be listed by `token-monitor rules`, and the only symptom was an unrelated key assertion failing somewhere else.

That's a documentation bug on our side: CONTRIBUTING said *"listed once in index.ts"* in prose while the code example showed only the rule file. It now shows **both** edits — the import and the array entry — and names the filename-is-the-key convention.

Docs alone would still leave the next person to discover it from a confusing failure, so `test/rules.test.ts` now checks it directly: every `src/rules/*.ts` must appear in `RULES`, and every rule's key must match its filename. Verified by planting an unregistered rule file — the suite fails with:

```
rule file src/rules/zz-unregistered-probe.ts is not registered — add its import and its entry to src/rules/index.ts
```