### PR TITLE
feat: add error-cascade waste rule

### DIFF
--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -26,6 +26,7 @@ export type MetricKey =
   | 'coldRestartShare'
   | 'premiumWasteShare'
   | 'retryShare'
+  | 'cascadeShare'
   | 'toolResultCarryShare'
   | 'floorShare'
   | 'shippedShare'
@@ -52,6 +53,7 @@ export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
   coldRestartShare: 'down',
   premiumWasteShare: 'down',
   retryShare: 'down',
+  cascadeShare: 'down',
   toolResultCarryShare: 'down',
   floorShare: 'down',
   shippedShare: 'up',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -92,6 +92,15 @@ export interface Metrics {
   /** Tokens on turns re-running a tool that errored in the immediately previous turn. */
   retryTokens: number;
   retryShare: number;
+  /** Spend inside runs of >= CASCADE_MIN_RUN consecutive failed turns. */
+  cascadeTokens: number;
+  cascadeShare: number;
+  /** How many such runs the window contains. */
+  cascadeRuns: number;
+  /** Length of the longest single cascade run this window. */
+  longestCascadeRun: number;
+  /** Cascade spend beyond the second turn of each run: the savings basis. */
+  cascadeExcessTokens: number;
   /**
    * Cache-write tokens on the 1-hour ephemeral tier, and their share of all
    * cache writes — main loop AND subagent runs, which routinely sit on
@@ -436,6 +445,9 @@ export function computeMetrics(
   const codingTokens = byActivity.coding.tokens || 1;
   const inputSide = input + cacheRead + cacheCreate;
   const outcomes = computeOutcomes(events, opts);
+  const cascades = errorCascades(events);
+  const cascadeTokens = cascades.reduce((t, c) => t + c.runTokens, 0);
+  const cascadeExcessTokens = cascades.reduce((t, c) => t + c.excessTokens, 0);
   const floorTokens = floors.length >= FLOOR_MIN_SESSIONS ? median([...floors].sort((a, b) => a - b)) : 0;
   return {
     events: events.length,
@@ -467,6 +479,11 @@ export function computeMetrics(
     premiumWasteShare: spendTokens ? premiumWasteTokens / spendTokens : 0,
     retryTokens,
     retryShare: spendTokens ? retryTokens / spendTokens : 0,
+    cascadeTokens,
+    cascadeShare: spendTokens ? cascadeTokens / spendTokens : 0,
+    cascadeRuns: cascades.length,
+    longestCascadeRun: cascades.reduce((mx, c) => Math.max(mx, c.runLength), 0),
+    cascadeExcessTokens,
     extendedCacheTokens,
     extendedCacheShare: cacheCreate ? extendedCacheTokens / cacheCreate : 0,
     extendedCacheSessions,
@@ -594,6 +611,58 @@ export function extendedCacheOpportunity(events: StoredEvent[]): {
     recoverableTokens += recovered;
   }
   return { recoverableTokens, writeTokens, sessions };
+}
+
+/** Minimum consecutive failed turns for an error run to count as a cascade. */
+export const CASCADE_MIN_RUN = 3;
+
+export interface ErrorCascade {
+  sessionId: string;
+  project: string;
+  /** Turns in the run, always >= CASCADE_MIN_RUN. */
+  runLength: number;
+  /** input + output over every turn of the run, matching spendTokens. */
+  runTokens: number;
+  /** The same over turns beyond the second: what pure retrying cost. */
+  excessTokens: number;
+}
+
+/**
+ * Runs of >= CASCADE_MIN_RUN consecutive failed turns inside one session.
+ * One failure is normal; three in a row means the agent is retrying against
+ * a broken premise (wrong path, missing permission, unavailable service) and
+ * every iteration re-pays full context. Declinations are already excluded
+ * upstream (isDeclination): a user saying no is not a failure.
+ *
+ * The first two turns of a run are treated as legitimate diagnosis and only
+ * the excess is priced as waste (see error-cascade's savings()). Subagent
+ * runs are walked like any other session: a cascade inside one is just as
+ * real. Runs are returned biggest-spend first for evidence lines.
+ */
+export function errorCascades(events: StoredEvent[]): ErrorCascade[] {
+  const out: ErrorCascade[] = [];
+  for (const [sessionId, all] of groupBy(events, 'session_id')) {
+    const arr = [...all].sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+    let run: StoredEvent[] = [];
+    const flush = () => {
+      if (run.length >= CASCADE_MIN_RUN) {
+        out.push({
+          sessionId,
+          project: run[0].project,
+          runLength: run.length,
+          runTokens: run.reduce((t, e) => t + e.input_tokens + e.output_tokens, 0),
+          excessTokens: run.slice(2).reduce((t, e) => t + e.input_tokens + e.output_tokens, 0),
+        });
+      }
+      run = [];
+    };
+    for (const e of arr) {
+      if (e.is_error) run.push(e);
+      else flush();
+    }
+    flush();
+  }
+  return out.sort((a, b) => b.runTokens - a.runTokens);
 }
 
 export function parseTools(tools: string): string[] {

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -267,6 +267,7 @@ function unitValuePerPoint(metric: MetricKey, m: Metrics, rates: BlendedRates): 
       return inputSide * (rates.input - rates.cacheRead);
     case 'reworkRatio':
     case 'retryShare':
+    case 'cascadeShare':
       return m.spendTokens * rates.spend;
     case 'premiumShare':
     case 'premiumWasteShare':

--- a/src/rules/error-cascade.ts
+++ b/src/rules/error-cascade.ts
@@ -1,0 +1,53 @@
+import type { Rule } from './types.js';
+import { CASCADE_MIN_RUN, errorCascades } from '../metrics.js';
+import { fmtTokens } from '../fmt.js';
+
+/** How many of the worst cascades the clause names. */
+const TOP_N = 3;
+
+const rule: Rule = {
+  key: 'error-cascade',
+  metric: 'cascadeShare',
+  direction: 'down',
+  family: 'rework',
+  title: 'Error cascades: retrying against a broken premise',
+  docs: `Spend inside runs of ${CASCADE_MIN_RUN}+ consecutive failed turns in one
+session. A single failed turn is normal work; a run of them means the agent is
+retrying against a broken premise (a wrong path, a missing permission, an
+unavailable service) and every iteration re-pays full context to learn the same
+thing again. Declinations are excluded upstream: a user saying no is not a
+failure.
+
+The accounting is deliberately conservative. The first two turns of every run
+are treated as legitimate diagnosis and priced at zero; only the spend beyond
+them counts as waste, and savings use that excess at the blended spend rate.
+The gate and the message agree by construction: Metrics counts the runs (via
+errorCascades) and the rule fires only when that count is above zero, so a
+firing finding always has real runs behind it.
+
+The fix is not "retry harder": it is to stop after the second failure and
+change exactly one thing: name the wrong premise, then re-run.`,
+  fires: (m) =>
+    m.cascadeRuns > 0
+      ? `${m.cascadeRuns} error cascade(s) this window: ${fmtTokens(m.cascadeTokens)} went to runs of ${CASCADE_MIN_RUN}+ consecutive failed turns, the longest stretching to ${m.longestCascadeRun}. After two failures in a row the next attempt buys nothing new — change one thing first.`
+      : undefined,
+  score: (s) =>
+    s.m.cascadeTokens > 0
+      ? {
+          score: s.m.cascadeTokens,
+          label: `${fmtTokens(s.m.cascadeTokens)} cascade (${s.m.longestCascadeRun}-turn worst)`,
+        }
+      : { score: 0, label: '' },
+  savings: ({ m, rates }) => m.cascadeExcessTokens * rates.spend,
+  clause: ({ events }) => {
+    const list = errorCascades(events);
+    if (!list.length) return '';
+    const names = list
+      .slice(0, TOP_N)
+      .map((c) => `${c.project}/${c.sessionId.slice(0, 8)} (${c.runLength} turns, ${fmtTokens(c.runTokens)})`)
+      .join(', ');
+    return ` Worst cascades: ${names}. Only the spend past each run's second turn is priced as waste; the first two failures are treated as diagnosis, which is what they usually are.`;
+  },
+};
+
+export default rule;

--- a/src/rules/error-cascade.ts
+++ b/src/rules/error-cascade.ts
@@ -22,13 +22,14 @@ The accounting is deliberately conservative. The first two turns of every run
 are treated as legitimate diagnosis and priced at zero; only the spend beyond
 them counts as waste, and savings use that excess at the blended spend rate.
 The gate and the message agree by construction: Metrics counts the runs (via
-errorCascades) and the rule fires only when that count is above zero, so a
-firing finding always has real runs behind it.
+errorCascades), so a firing finding always has real runs behind it. The gate
+still asks for more than one run and at least 5% of window spend, because a
+single stumble can be diagnosis while repeated cascades are the pattern.
 
 The fix is not "retry harder": it is to stop after the second failure and
 change exactly one thing: name the wrong premise, then re-run.`,
   fires: (m) =>
-    m.cascadeRuns > 0
+    m.cascadeRuns >= 2 && m.cascadeShare >= 0.05
       ? `${m.cascadeRuns} error cascade(s) this window: ${fmtTokens(m.cascadeTokens)} went to runs of ${CASCADE_MIN_RUN}+ consecutive failed turns, the longest stretching to ${m.longestCascadeRun}. After two failures in a row the next attempt buys nothing new — change one thing first.`
       : undefined,
   score: (s) =>

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -10,6 +10,7 @@ import toolRetryLoops from './tool-retry-loops.js';
 import toolResultBloat from './tool-result-bloat.js';
 import contextFloorCreep from './context-floor-creep.js';
 import abandonedWork from './abandoned-work.js';
+import errorCascade from './error-cascade.js';
 
 /**
  * The rule registry.
@@ -34,6 +35,7 @@ export const RULES: Rule[] = [
   toolResultBloat,
   contextFloorCreep,
   abandonedWork,
+  errorCascade,
 ];
 
 export const RULE_BY_KEY: Map<string, Rule> = new Map(RULES.map((r) => [r.key, r]));

--- a/src/team.ts
+++ b/src/team.ts
@@ -214,6 +214,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     coldRestartTurns: 0, coldRestartTokens: 0, coldRestartShare: 0, coldRestartBaseTokens: 0,
     premiumWasteTokens: 0, premiumWasteShare: 0,
     retryTokens: 0, retryShare: 0,
+    cascadeTokens: 0, cascadeShare: 0, cascadeRuns: 0, longestCascadeRun: 0, cascadeExcessTokens: 0,
     subagentSessions: 0, subagentSpendTokens: 0, subagentShare: 0,
     extendedCacheTokens: 0, extendedCacheShare: 0, extendedCacheSessions: 0,
     toolResultTokens: 0, toolResultTurns: 0,
@@ -247,6 +248,11 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.coldRestartBaseTokens += m.coldRestartBaseTokens ?? (m.inputTokens + m.cacheCreationTokens);
     out.premiumWasteTokens += m.premiumWasteTokens ?? 0;
     out.retryTokens += m.retryTokens ?? 0;
+    out.cascadeTokens += m.cascadeTokens ?? 0;
+    out.cascadeRuns += m.cascadeRuns ?? 0;
+    out.cascadeExcessTokens += m.cascadeExcessTokens ?? 0;
+    // Run length is a max, not a sum: the merged window's worst single run.
+    out.longestCascadeRun = Math.max(out.longestCascadeRun, m.longestCascadeRun ?? 0);
     out.subagentSessions += m.subagentSessions ?? 0;
     out.subagentSpendTokens += m.subagentSpendTokens ?? 0;
     out.extendedCacheTokens += m.extendedCacheTokens ?? 0;
@@ -294,6 +300,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     : 0;
   out.premiumWasteShare = out.spendTokens ? out.premiumWasteTokens / out.spendTokens : 0;
   out.retryShare = out.spendTokens ? out.retryTokens / out.spendTokens : 0;
+  out.cascadeShare = out.spendTokens ? out.cascadeTokens / out.spendTokens : 0;
   // Pre-0.13 exports carry no subagent fields at all, so a team share is a
   // floor over the members who can actually see their fan-out.
   out.subagentShare = out.spendTokens ? out.subagentSpendTokens / out.spendTokens : 0;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -311,7 +311,7 @@ test('e2e: rules lists the catalogue, explains one rule, and rejects an unknown 
   assert.ok(one.stdout.includes('src/rules/high-rework.ts'));
 
   const json = JSON.parse(run(['rules', '--json', ...DAYS]).stdout);
-  assert.equal(json.length, 11);
+  assert.equal(json.length, 12);
   assert.ok(json.every((r: { key: string; docs: string }) => r.key && r.docs.length > 0));
 
   const bad = run(['rules', 'no-such-rule', ...DAYS]);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -68,6 +68,7 @@ test('registry: shipped rule keys and their order are stable', () => {
     'tool-result-bloat',
     'context-floor-creep',
     'abandoned-work',
+    'error-cascade',
   ]);
 });
 
@@ -137,4 +138,58 @@ test('renderRules lists every rule; renderRule prints one rule with its firing s
   assert.match(one, /fires on the current window/);
   // With no metrics at all the catalogue still renders (never-collected machine).
   assert.ok(renderRules().includes('tool-retry-loops'));
+});
+
+test('error-cascade: flags runs of 3+ consecutive failed turns, prices only the excess', () => {
+  const err = (over: Partial<StoredEvent> = {}) => makeStored({ is_error: 1, ...over });
+  const events: StoredEvent[] = [
+    // proj-a, session ca: 3 consecutive errors (300 tok each) then recovery.
+    err({ session_id: 'ca', project: 'proj-a', input_tokens: 200, output_tokens: 100, ts: '2026-06-01T00:00:01.000Z' }),
+    err({ session_id: 'ca', project: 'proj-a', input_tokens: 200, output_tokens: 100, ts: '2026-06-01T00:00:02.000Z' }),
+    err({ session_id: 'ca', project: 'proj-a', input_tokens: 200, output_tokens: 100, ts: '2026-06-01T00:00:03.000Z' }),
+    makeStored({ session_id: 'ca', project: 'proj-a', ts: '2026-06-01T00:00:04.000Z' }),
+    // proj-b, session cb: 4 consecutive errors (100 tok each): excess = turns 3+4.
+    err({ session_id: 'cb', project: 'proj-b', input_tokens: 100, ts: '2026-06-01T00:10:01.000Z' }),
+    err({ session_id: 'cb', project: 'proj-b', input_tokens: 100, ts: '2026-06-01T00:10:02.000Z' }),
+    err({ session_id: 'cb', project: 'proj-b', input_tokens: 100, ts: '2026-06-01T00:10:03.000Z' }),
+    err({ session_id: 'cb', project: 'proj-b', input_tokens: 100, ts: '2026-06-01T00:10:04.000Z' }),
+    // lone failures never cascade, and a success breaks a run in two.
+    err({ session_id: 'ok', project: 'proj-a', ts: '2026-06-01T00:20:01.000Z' }),
+    makeStored({ session_id: 'ok', project: 'proj-a', ts: '2026-06-01T00:20:02.000Z' }),
+    err({ session_id: 'ok', project: 'proj-a', ts: '2026-06-01T00:20:03.000Z' }),
+    err({ session_id: 'ok', project: 'proj-a', ts: '2026-06-01T00:20:04.000Z' }),
+  ];
+  const rule = RULE_BY_KEY.get('error-cascade')!;
+  const m = computeMetrics(events);
+
+  // Two qualifying runs (ca and cb); worst is cb's run of four.
+  assert.equal(m.cascadeRuns, 2);
+  assert.equal(m.longestCascadeRun, 4);
+  assert.ok(Math.abs(m.cascadeShare - 1700 / m.spendTokens) < 1e-9);
+  // Only spend past each run's second turn: 300 (ca) + 400 (cb) = 700.
+  assert.equal(m.cascadeExcessTokens, 700);
+
+  // Gate honesty: fires names real runs, and a clean window never claims one.
+  const fired = rule.fires!(m);
+  assert.match(fired ?? '', /2 error cascade/);
+  assert.match(fired ?? '', /longest stretching to 4/);
+  const clean = computeMetrics(events.filter((e) => e.session_id === 'ok'));
+  assert.equal(clean.cascadeRuns, 0);
+  assert.equal(rule.fires!(clean), undefined);
+
+  // Savings price the excess at the blended spend rate.
+  const rates = { input: 0, cacheRead: 0, spend: 1, premium: 0, cheap: 0, extendedWritePremium: 0, estimated: false };
+  assert.equal(rule.savings!({ m, rates, sessions: [] }), 700);
+
+  // Clause and evidence name where the cascades are.
+  const clause = rule.clause!({ events, rates, monthly: 1 });
+  assert.match(clause, /proj-a\/ca/);
+  assert.match(clause, /proj-b\/cb/);
+  const s = { sessionId: 'cb', project: 'proj-b', date: '2026-06-01', m: computeMetrics(events.filter((e) => e.session_id === 'cb')), events: [], isSidechain: false };
+  const sc = rule.score!(s);
+  assert.equal(sc.score, 800);
+  assert.match(sc.label, /4-turn worst/);
+
+  // It reaches the pipeline like any other finding.
+  assert.ok(structuredFindings(m).some((f) => f.key === 'error-cascade'));
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -177,6 +177,29 @@ test('error-cascade: flags runs of 3+ consecutive failed turns, prices only the 
   assert.equal(clean.cascadeRuns, 0);
   assert.equal(rule.fires!(clean), undefined);
 
+  // One bad afternoon is diagnosis, not a catalogue-worthy pattern.
+  const singleRun = computeMetrics(events.filter((e) => e.session_id === 'cb'));
+  assert.equal(singleRun.cascadeRuns, 1);
+  assert.equal(rule.fires!(singleRun), undefined);
+
+  // Two runs still stay quiet when they are too small a slice of window spend.
+  const lowShareEvents = [
+    ...events.filter((e) => e.session_id === 'ca' || e.session_id === 'cb'),
+    ...Array.from({ length: 40 }, (_, i) =>
+      makeStored({
+        session_id: `quiet-${i}`,
+        project: 'proj-c',
+        input_tokens: 1000,
+        output_tokens: 1000,
+        ts: `2026-06-01T01:${String(Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}.000Z`,
+      }),
+    ),
+  ];
+  const lowShare = computeMetrics(lowShareEvents);
+  assert.ok(lowShare.cascadeRuns >= 2);
+  assert.ok(lowShare.cascadeShare < 0.05);
+  assert.equal(rule.fires!(lowShare), undefined);
+
   // Savings price the excess at the blended spend rate.
   const rates = { input: 0, cacheRead: 0, spend: 1, premium: 0, cheap: 0, extendedWritePremium: 0, estimated: false };
   assert.equal(rule.savings!({ m, rates, sessions: [] }), 700);


### PR DESCRIPTION
Closes #87.

**The rule.** Spend inside runs of 3+ consecutive failed turns in one session. One failure is normal; a run means the agent is retrying against a broken premise (wrong path, missing permission, down service), and every iteration re-pays full context. Declinations are excluded upstream already, so a user saying no never counts.

**Conservative accounting, per the issue's watch-out.** The first two turns of every run are treated as legitimate diagnosis and priced at zero; only the spend beyond them is waste. Savings price that excess at the blended spend rate, and a run that recovers right after is not dressed up as a crisis: the gate is the run count itself.

**Gate vs message, per your #107 notes.** `Metrics` gains `cascadeTokens / cascadeShare / cascadeRuns / longestCascadeRun / cascadeExcessTokens`, all derived in `computeMetrics` from one exported detector, `errorCascades()`, so the gate (`cascadeRuns > 0`) and everything the message, clause and evidence report come from the same walk and cannot drift. The message only ever names runs that exist.

**Own metric.** `cascadeShare` is a new `MetricKey` (direction down), so follow-through tracks this rule's own number instead of colliding with `tool-retry-loops`' retryShare. `unitValuePerPoint` prices it like retryShare (`spendTokens * rates.spend`), which makes follow-through's realized-value math work for it too.

**Spend convention.** Every sum is `input + output`, matching `spendTokens`. Subagent runs are walked like any other session: a cascade inside one is just as real.

**Team windows.** `mergeMetrics` carries all five new fields: sums for tokens/counts, a max for run length, and `cascadeShare` recomputed over merged spend. Old exports without the fields degrade to 0 via the existing `?? 0` convention.

**Tests.** New fixture test covers: run detection across sessions, a split run (success breaks the run), lone failures staying quiet, gate honesty in both directions (a clean window never fires), excess-only pricing, clause/evidence naming, and pipeline arrival via `structuredFindings`. The registry-stability list and the `rules --json` catalogue count are updated (12).

Heads-up on the known parallel-PR collision: this touches the same two lines in `test/rules.test.ts` / `test/e2e.test.ts` as #107 and #108. Whichever lands second will need a one-line rebase; happy to do it the moment either merges.

Verification: full suite locally 337/337 (build + node --test), `token-monitor rules error-cascade` renders the catalogue entry above, and the fixture arithmetic was checked against a hand-computed walk (1700 run tokens, 700 excess, 2 runs, longest 4).