### PR TITLE
feat: add mega-turns waste rule

### DIFF
--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -26,6 +26,7 @@ export type MetricKey =
   | 'coldRestartShare'
   | 'premiumWasteShare'
   | 'retryShare'
+  | 'megaTurnShare'
   | 'toolResultCarryShare'
   | 'floorShare'
   | 'shippedShare'
@@ -52,6 +53,7 @@ export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
   coldRestartShare: 'down',
   premiumWasteShare: 'down',
   retryShare: 'down',
+  megaTurnShare: 'down',
   toolResultCarryShare: 'down',
   floorShare: 'down',
   shippedShare: 'up',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -36,6 +36,16 @@ export const BLOAT_GROWTH = 2; // late-half avg context ≥ 2× early half
 export const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-paid fresh
 
 /**
+ * The absolute floor of the mega-turn bar (#91). A turn emitting more OUTPUT
+ * than this is examined however small its window, because no ordinary request
+ * writes 20k tokens of output by accident. On windows whose own distribution
+ * sits higher, the bar escalates to the 99.9th percentile of the window's
+ * turns (see computeMetrics): a user whose models legitimately write long
+ * files sets their own bar rather than being accused for it.
+ */
+export const MEGA_TURN_FLOOR_TOKENS = 20_000;
+
+/**
  * The conversation a turn belongs to from the user's point of view: a subagent
  * run counts under the session that spawned it, everything else under itself.
  * `sessions` counts these, so a fan-out of 40 agents stays ONE session in the
@@ -92,6 +102,28 @@ export interface Metrics {
   /** Tokens on turns re-running a tool that errored in the immediately previous turn. */
   retryTokens: number;
   retryShare: number;
+  /**
+   * Mega-turns (#91): turns whose output alone cleared this window's bar,
+   * max(MEGA_TURN_FLOOR_TOKENS, p99.9 of the window's turn outputs), so the
+   * bar is derived from the user's own data rather than a magic constant.
+   * `megaTurnTokens` counts their full spend (input + output); `megaTurnShare`
+   * puts that over all spend. Subagent runs count like any other turn: their
+   * output is as real, and a runaway generation inside a fan-out is exactly
+   * as worth naming.
+   */
+  megaTurns: number;
+  megaTurnTokens: number;
+  megaTurnShare: number;
+  /** Output of the single largest turn in the window (the evidence label). */
+  largestTurnOutput: number;
+  /**
+   * Output above the bar, summed over mega-turns: the only part the savings
+   * estimate prices. Everything up to the bar is treated as legitimate work,
+   * which keeps the number conservative and easy to defend.
+   */
+  megaTurnExcessTokens: number;
+  /** The bar this window was measured against (carried so reports can name it). */
+  megaTurnThreshold: number;
   /**
    * Cache-write tokens on the 1-hour ephemeral tier, and their share of all
    * cache writes — main loop AND subagent runs, which routinely sit on
@@ -343,6 +375,7 @@ export function computeMetrics(
   let trendSessions = 0, bloatedSessions = 0;
   let coldRestartTurns = 0, coldRestartTokens = 0;
   let retryTokens = 0;
+  let megaTurns = 0, megaTurnTokens = 0, megaTurnExcessTokens = 0, largestTurnOutput = 0;
   let carryTokens = 0;
   let floorTurns = 0, floorBaseTokens = 0;
   const floors: number[] = [];
@@ -433,6 +466,26 @@ export function computeMetrics(
     }
   }
 
+  // Mega-turn bar (#91): percentile of THIS window's turns over an absolute
+  // floor, then one pass to count, sum spend, and keep the excess above the
+  // bar for pricing. Window-level on purpose: a per-session percentile would
+  // let one quiet session set a low bar and fire on a routine big write.
+  const sortedOutputs = events.map((e) => e.output_tokens).sort((a, b) => a - b);
+  const p999 = sortedOutputs.length
+    ? sortedOutputs[Math.min(sortedOutputs.length - 1, Math.floor(sortedOutputs.length * 0.999))]
+    : 0;
+  const megaTurnThreshold = Math.max(MEGA_TURN_FLOOR_TOKENS, p999);
+  if (megaTurnThreshold > 0) {
+    for (const e of events) {
+      if (e.output_tokens > largestTurnOutput) largestTurnOutput = e.output_tokens;
+      if (e.output_tokens >= megaTurnThreshold) {
+        megaTurns++;
+        megaTurnTokens += e.input_tokens + e.output_tokens;
+        megaTurnExcessTokens += e.output_tokens - megaTurnThreshold;
+      }
+    }
+  }
+
   const codingTokens = byActivity.coding.tokens || 1;
   const inputSide = input + cacheRead + cacheCreate;
   const outcomes = computeOutcomes(events, opts);
@@ -467,6 +520,12 @@ export function computeMetrics(
     premiumWasteShare: spendTokens ? premiumWasteTokens / spendTokens : 0,
     retryTokens,
     retryShare: spendTokens ? retryTokens / spendTokens : 0,
+    megaTurns,
+    megaTurnTokens,
+    megaTurnShare: spendTokens ? megaTurnTokens / spendTokens : 0,
+    largestTurnOutput,
+    megaTurnExcessTokens,
+    megaTurnThreshold,
     extendedCacheTokens,
     extendedCacheShare: cacheCreate ? extendedCacheTokens / cacheCreate : 0,
     extendedCacheSessions,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -44,6 +44,10 @@ export const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-pai
  * files sets their own bar rather than being accused for it.
  */
 export const MEGA_TURN_FLOOR_TOKENS = 20_000;
+/** Turns required before the window-relative half of the mega-turn bar is used. */
+export const MEGA_TURN_MIN_TURNS = 8;
+/** A turn must exceed this multiple of the median output to be an outlier. */
+export const MEGA_TURN_OUTLIER_MULTIPLE = 3;
 
 /**
  * The conversation a turn belongs to from the user's point of view: a subagent
@@ -104,8 +108,10 @@ export interface Metrics {
   retryShare: number;
   /**
    * Mega-turns (#91): turns whose output alone cleared this window's bar,
-   * max(MEGA_TURN_FLOOR_TOKENS, p99.9 of the window's turn outputs), so the
-   * bar is derived from the user's own data rather than a magic constant.
+   * max(MEGA_TURN_FLOOR_TOKENS, 3x median of the window's turn outputs), so
+   * the bar is derived from the user's own data without letting the tail set
+   * itself. The adaptive half switches on only with enough turns to estimate
+   * a stable center.
    * `megaTurnTokens` counts their full spend (input + output); `megaTurnShare`
    * puts that over all spend. Subagent runs count like any other turn: their
    * output is as real, and a runaway generation inside a fan-out is exactly
@@ -466,15 +472,18 @@ export function computeMetrics(
     }
   }
 
-  // Mega-turn bar (#91): percentile of THIS window's turns over an absolute
-  // floor, then one pass to count, sum spend, and keep the excess above the
-  // bar for pricing. Window-level on purpose: a per-session percentile would
-  // let one quiet session set a low bar and fire on a routine big write.
-  const sortedOutputs = events.map((e) => e.output_tokens).sort((a, b) => a - b);
-  const p999 = sortedOutputs.length
-    ? sortedOutputs[Math.min(sortedOutputs.length - 1, Math.floor(sortedOutputs.length * 0.999))]
-    : 0;
-  const megaTurnThreshold = Math.max(MEGA_TURN_FLOOR_TOKENS, p999);
+  // Mega-turn bar (#91): an absolute floor, or an outlier test against this
+  // window's central output once enough turns exist. A quantile cannot work
+  // here: it is drawn from the same data it gates, so flat distributions make
+  // every turn an apparent "outlier." Window-level on purpose: per-session
+  // medians would let one quiet session fire on a routine big write.
+  const sortedOutputs = [...events.map((e) => e.output_tokens)].sort((a, b) => a - b);
+  const outputMedian =
+    sortedOutputs.length >= MEGA_TURN_MIN_TURNS ? median(sortedOutputs) : 0;
+  const megaTurnThreshold = Math.max(
+    MEGA_TURN_FLOOR_TOKENS,
+    outputMedian * MEGA_TURN_OUTLIER_MULTIPLE,
+  );
   if (megaTurnThreshold > 0) {
     for (const e of events) {
       if (e.output_tokens > largestTurnOutput) largestTurnOutput = e.output_tokens;

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -267,6 +267,7 @@ function unitValuePerPoint(metric: MetricKey, m: Metrics, rates: BlendedRates): 
       return inputSide * (rates.input - rates.cacheRead);
     case 'reworkRatio':
     case 'retryShare':
+    case 'megaTurnShare':
       return m.spendTokens * rates.spend;
     case 'premiumShare':
     case 'premiumWasteShare':

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -7,6 +7,7 @@ import contextBloat from './context-bloat.js';
 import coldRestarts from './cold-restarts.js';
 import premiumMisroute from './premium-misroute.js';
 import toolRetryLoops from './tool-retry-loops.js';
+import megaTurns from './mega-turns.js';
 import toolResultBloat from './tool-result-bloat.js';
 import contextFloorCreep from './context-floor-creep.js';
 import abandonedWork from './abandoned-work.js';
@@ -31,6 +32,7 @@ export const RULES: Rule[] = [
   coldRestarts,
   premiumMisroute,
   toolRetryLoops,
+  megaTurns,
   toolResultBloat,
   contextFloorCreep,
   abandonedWork,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -7,10 +7,10 @@ import contextBloat from './context-bloat.js';
 import coldRestarts from './cold-restarts.js';
 import premiumMisroute from './premium-misroute.js';
 import toolRetryLoops from './tool-retry-loops.js';
-import megaTurns from './mega-turns.js';
 import toolResultBloat from './tool-result-bloat.js';
 import contextFloorCreep from './context-floor-creep.js';
 import abandonedWork from './abandoned-work.js';
+import megaTurns from './mega-turns.js';
 
 /**
  * The rule registry.
@@ -32,10 +32,10 @@ export const RULES: Rule[] = [
   coldRestarts,
   premiumMisroute,
   toolRetryLoops,
-  megaTurns,
   toolResultBloat,
   contextFloorCreep,
   abandonedWork,
+  megaTurns,
 ];
 
 export const RULE_BY_KEY: Map<string, Rule> = new Map(RULES.map((r) => [r.key, r]));

--- a/src/rules/mega-turns.ts
+++ b/src/rules/mega-turns.ts
@@ -1,0 +1,37 @@
+import type { Rule } from './types.js';
+import { MEGA_TURN_FLOOR_TOKENS } from '../metrics.js';
+import { fmtTokens } from '../fmt.js';
+
+const rule: Rule = {
+  key: 'mega-turns',
+  metric: 'megaTurnShare',
+  direction: 'down',
+  family: 'rework',
+  title: 'Single turns emitting runaway output',
+  docs: `Spend on turns whose OUTPUT alone cleared the window's bar: a whole file
+rewritten to change three lines, or a runaway generation. Output tokens are the
+most expensive tokens there are, and one such turn can quietly cost more than a
+day of reading.
+
+The bar adapts to the window instead of being a magic constant: the larger of an
+absolute floor (${fmtTokens(MEGA_TURN_FLOOR_TOKENS)}) and the 99.9th percentile of the
+window's own turn outputs. A user whose models legitimately write long files
+sets their own bar higher rather than being accused for it, because a long file
+legitimately needs a long write. That is also why the message stays descriptive:
+it names what happened, not what the user should feel about it.
+
+Savings price only the EXCESS above the bar at the blended spend rate: the part
+of each mega-turn that had no reason to exist even if the work was real.
+Everything up to the bar is treated as legitimate, which keeps the number
+conservative and easy to defend.`,
+  fires: (m) =>
+    m.megaTurns > 0
+      ? `${m.megaTurns} turn(s) emitted ${fmtTokens(m.megaTurnThreshold)}+ output tokens in one go: ${fmtTokens(m.megaTurnTokens)} of spend, the worst writing ${fmtTokens(m.largestTurnOutput)}. Prefer targeted edits over whole-file rewrites, and cap max output where the client allows it.`
+      : undefined,
+  score: (s) => ({
+    score: s.m.megaTurnTokens,
+    label: `${fmtTokens(s.m.largestTurnOutput)} tok single turn`,
+  }),
+  savings: ({ m, rates }) => m.megaTurnExcessTokens * rates.spend,
+};
+export default rule;

--- a/src/rules/mega-turns.ts
+++ b/src/rules/mega-turns.ts
@@ -1,5 +1,9 @@
 import type { Rule } from './types.js';
-import { MEGA_TURN_FLOOR_TOKENS } from '../metrics.js';
+import {
+  MEGA_TURN_FLOOR_TOKENS,
+  MEGA_TURN_MIN_TURNS,
+  MEGA_TURN_OUTLIER_MULTIPLE,
+} from '../metrics.js';
 import { fmtTokens } from '../fmt.js';
 
 const rule: Rule = {
@@ -14,11 +18,12 @@ most expensive tokens there are, and one such turn can quietly cost more than a
 day of reading.
 
 The bar adapts to the window instead of being a magic constant: the larger of an
-absolute floor (${fmtTokens(MEGA_TURN_FLOOR_TOKENS)}) and the 99.9th percentile of the
-window's own turn outputs. A user whose models legitimately write long files
-sets their own bar higher rather than being accused for it, because a long file
-legitimately needs a long write. That is also why the message stays descriptive:
-it names what happened, not what the user should feel about it.
+absolute floor (${fmtTokens(MEGA_TURN_FLOOR_TOKENS)}) and ${MEGA_TURN_OUTLIER_MULTIPLE}x the median
+output. The adaptive test needs at least ${MEGA_TURN_MIN_TURNS} turns before it trusts the
+window's center. This is an outlier test, not a quantile: users whose models
+legitimately write long files raise their own bar rather than being accused for
+it. That is also why the message stays descriptive — it names what happened, not
+what the user should feel about it.
 
 Savings price only the EXCESS above the bar at the blended spend rate: the part
 of each mega-turn that had no reason to exist even if the work was real.

--- a/src/team.ts
+++ b/src/team.ts
@@ -214,6 +214,8 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     coldRestartTurns: 0, coldRestartTokens: 0, coldRestartShare: 0, coldRestartBaseTokens: 0,
     premiumWasteTokens: 0, premiumWasteShare: 0,
     retryTokens: 0, retryShare: 0,
+    megaTurns: 0, megaTurnTokens: 0, megaTurnShare: 0,
+    largestTurnOutput: 0, megaTurnExcessTokens: 0, megaTurnThreshold: 0,
     subagentSessions: 0, subagentSpendTokens: 0, subagentShare: 0,
     extendedCacheTokens: 0, extendedCacheShare: 0, extendedCacheSessions: 0,
     toolResultTokens: 0, toolResultTurns: 0,
@@ -247,6 +249,15 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.coldRestartBaseTokens += m.coldRestartBaseTokens ?? (m.inputTokens + m.cacheCreationTokens);
     out.premiumWasteTokens += m.premiumWasteTokens ?? 0;
     out.retryTokens += m.retryTokens ?? 0;
+    out.megaTurns += m.megaTurns ?? 0;
+    out.megaTurnTokens += m.megaTurnTokens ?? 0;
+    out.megaTurnExcessTokens += m.megaTurnExcessTokens ?? 0;
+    // Counts and tokens add across members, but each member counted against
+    // its OWN bar (percentile of its own turns), so the merged threshold is
+    // reported as the strictest bar any member used. The share below is the
+    // honest recombination over pooled spend.
+    out.largestTurnOutput = Math.max(out.largestTurnOutput, m.largestTurnOutput ?? 0);
+    out.megaTurnThreshold = Math.max(out.megaTurnThreshold, m.megaTurnThreshold ?? 0);
     out.subagentSessions += m.subagentSessions ?? 0;
     out.subagentSpendTokens += m.subagentSpendTokens ?? 0;
     out.extendedCacheTokens += m.extendedCacheTokens ?? 0;
@@ -294,6 +305,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     : 0;
   out.premiumWasteShare = out.spendTokens ? out.premiumWasteTokens / out.spendTokens : 0;
   out.retryShare = out.spendTokens ? out.retryTokens / out.spendTokens : 0;
+  out.megaTurnShare = out.spendTokens ? out.megaTurnTokens / out.spendTokens : 0;
   // Pre-0.13 exports carry no subagent fields at all, so a team share is a
   // floor over the members who can actually see their fan-out.
   out.subagentShare = out.spendTokens ? out.subagentSpendTokens / out.spendTokens : 0;

--- a/src/team.ts
+++ b/src/team.ts
@@ -253,9 +253,9 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.megaTurnTokens += m.megaTurnTokens ?? 0;
     out.megaTurnExcessTokens += m.megaTurnExcessTokens ?? 0;
     // Counts and tokens add across members, but each member counted against
-    // its OWN bar (percentile of its own turns), so the merged threshold is
-    // reported as the strictest bar any member used. The share below is the
-    // honest recombination over pooled spend.
+    // its OWN outlier bar (median of its own turns), so the merged threshold
+    // is reported as the loosest bar that any member actually used. The share
+    // below is the honest recombination over pooled spend.
     out.largestTurnOutput = Math.max(out.largestTurnOutput, m.largestTurnOutput ?? 0);
     out.megaTurnThreshold = Math.max(out.megaTurnThreshold, m.megaTurnThreshold ?? 0);
     out.subagentSessions += m.subagentSessions ?? 0;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -311,7 +311,7 @@ test('e2e: rules lists the catalogue, explains one rule, and rejects an unknown 
   assert.ok(one.stdout.includes('src/rules/high-rework.ts'));
 
   const json = JSON.parse(run(['rules', '--json', ...DAYS]).stdout);
-  assert.equal(json.length, 11);
+  assert.equal(json.length, 12);
   assert.ok(json.every((r: { key: string; docs: string }) => r.key && r.docs.length > 0));
 
   const bad = run(['rules', 'no-such-rule', ...DAYS]);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1,9 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { RULES, RULE_BY_KEY } from '../src/rules/index.js';
-import { computeMetrics } from '../src/metrics.js';
+import { computeMetrics, MEGA_TURN_FLOOR_TOKENS } from '../src/metrics.js';
+import type { Metrics } from '../src/metrics.js';
 import { structuredFindings } from '../src/followthrough.js';
 import { enrichFindings, targetFor } from '../src/recommendations.js';
+import { mergeMetrics } from '../src/team.js';
 import { renderRules, renderRule } from '../src/report.js';
 import { makeStored } from './helpers.js';
 import { readdirSync } from 'node:fs';
@@ -65,6 +67,7 @@ test('registry: shipped rule keys and their order are stable', () => {
     'cold-restarts',
     'premium-misroute',
     'tool-retry-loops',
+    'mega-turns',
     'tool-result-bloat',
     'context-floor-creep',
     'abandoned-work',
@@ -137,4 +140,101 @@ test('renderRules lists every rule; renderRule prints one rule with its firing s
   assert.match(one, /fires on the current window/);
   // With no metrics at all the catalogue still renders (never-collected machine).
   assert.ok(renderRules().includes('tool-retry-loops'));
+});
+
+// --- #91: mega-turns. The bar is max(20k floor, p99.9 of the window's own
+// turns); savings price only the excess above it. -------------------------
+
+test('mega-turns: fires on a single runaway turn, and prices nothing it cannot defend', () => {
+  const events = [
+    makeStored({ session_id: 'calm', input_tokens: 1_000, output_tokens: 500 }),
+    makeStored({
+      session_id: 'burst', ts: '2026-06-01T01:00:00.000Z',
+      input_tokens: 30_000, output_tokens: 21_000,
+    }),
+  ];
+  const m = computeMetrics(events);
+  assert.equal(m.megaTurns, 1);
+  // A two-turn window has no tail to speak of: p99.9 IS the largest turn, so
+  // the bar lands exactly on it and there is nothing above it to price.
+  assert.equal(m.megaTurnThreshold, 21_000);
+  assert.equal(m.megaTurnExcessTokens, 0);
+  assert.ok(structuredFindings(m).some((f) => f.key === 'mega-turns'));
+  const rec = enrichFindings(events, m, 30).find((r) => r.key === 'mega-turns');
+  assert.ok(rec, 'mega-turns should fire on a 21k-output turn');
+  assert.match(rec!.message, /1 turn\(s\) emitted 21\.0k\+ output tokens/);
+  // Excess-only savings: with nothing above the bar, the rec stays unpriced
+  // rather than inventing a number.
+  assert.equal(rec!.savingsUsdPerMonth, undefined);
+});
+
+test('mega-turns: prices the excess above the bar in a large window and names the worst turn', () => {
+  const events: StoredEvent[] = [];
+  for (let i = 0; i < 10_000; i++) {
+    events.push(makeStored({
+      session_id: 'grind',
+      ts: `2026-06-01T${String(Math.floor(i / 3600)).padStart(2, '0')}:${String(Math.floor((i % 3600) / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}.000Z`,
+      input_tokens: 2_000, output_tokens: 100,
+    }));
+  }
+  for (let i = 0; i < 3; i++) {
+    events.push(makeStored({
+      session_id: `burst${i}`, ts: `2026-06-0${i + 2}T05:00:00.000Z`,
+      input_tokens: 40_000, output_tokens: 30_000,
+    }));
+  }
+  const m = computeMetrics(events);
+  // Three outliers in 10_003 turns sit below the 99.9th percentile, so the
+  // bar is the absolute floor, not the outliers themselves.
+  assert.equal(m.megaTurnThreshold, MEGA_TURN_FLOOR_TOKENS);
+  assert.equal(m.megaTurns, 3);
+  assert.equal(m.largestTurnOutput, 30_000);
+  assert.equal(m.megaTurnExcessTokens, 3 * 10_000);
+  assert.equal(m.megaTurnTokens, 3 * 70_000);
+  const rec = enrichFindings(events, m, 30).find((r) => r.key === 'mega-turns')!;
+  assert.ok(rec, 'mega-turns should fire');
+  assert.ok((rec.savingsUsdPerMonth ?? 0) > 0, 'excess above the bar is priced');
+  assert.equal(rec.evidence[0]?.label, '30.0k tok single turn');
+  assert.ok(rec.evidence.every((e) => e.sessionId.startsWith('burst')), 'evidence ranks the mega sessions first');
+});
+
+test('mega-turns: stays quiet on ordinary windows, escalates the bar for heavy writers', () => {
+  const calm = [
+    makeStored({ output_tokens: 800 }),
+    makeStored({ ts: '2026-06-01T00:01:00.000Z', output_tokens: 1_200 }),
+  ];
+  const mCalm = computeMetrics(calm);
+  assert.equal(mCalm.megaTurns, 0);
+  assert.equal(structuredFindings(mCalm).some((f) => f.key === 'mega-turns'), false);
+
+  // A user whose every turn legitimately writes 25k sets their own bar: the
+  // percentile escalates past the floor, so nothing is flagged as excess.
+  const heavy = Array.from({ length: 400 }, (_, i) =>
+    makeStored({ ts: `2026-06-01T${String(Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00.000Z`, output_tokens: 25_000 }));
+  const mHeavy = computeMetrics(heavy);
+  assert.equal(mHeavy.megaTurnThreshold, 25_000);
+  assert.equal(mHeavy.megaTurns, 400);
+  assert.equal(mHeavy.megaTurnExcessTokens, 0);
+});
+
+test('mergeMetrics recombines mega-turn counts over pooled spend, legacy exports included', () => {
+  const burst = computeMetrics([
+    makeStored({ session_id: 'burst', input_tokens: 40_000, output_tokens: 30_000 }),
+  ]);
+  const grind = computeMetrics([
+    makeStored({ session_id: 'grind', input_tokens: 2_000, output_tokens: 100 }),
+    makeStored({ ts: '2026-06-01T00:01:00.000Z', session_id: 'grind', input_tokens: 2_000, output_tokens: 100 }),
+  ]);
+  const merged = mergeMetrics([burst, grind]);
+  assert.equal(merged.megaTurns, 1);
+  assert.equal(merged.megaTurnTokens, 70_000);
+  assert.equal(merged.megaTurnShare, 70_000 / (70_000 + 4_200));
+  assert.equal(merged.megaTurnThreshold, Math.max(burst.megaTurnThreshold, grind.megaTurnThreshold));
+  // Pre-0.15 exports carry none of these fields and must merge as zeros.
+  const legacy = { ...burst } as Partial<Metrics>;
+  delete legacy.megaTurns; delete legacy.megaTurnTokens; delete legacy.megaTurnShare;
+  delete legacy.largestTurnOutput; delete legacy.megaTurnExcessTokens; delete legacy.megaTurnThreshold;
+  const withLegacy = mergeMetrics([legacy as Metrics, grind]);
+  assert.equal(withLegacy.megaTurns, 0);
+  assert.equal(withLegacy.megaTurnShare, 0);
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -67,10 +67,10 @@ test('registry: shipped rule keys and their order are stable', () => {
     'cold-restarts',
     'premium-misroute',
     'tool-retry-loops',
-    'mega-turns',
     'tool-result-bloat',
     'context-floor-creep',
     'abandoned-work',
+    'mega-turns',
   ]);
 });
 
@@ -142,10 +142,10 @@ test('renderRules lists every rule; renderRule prints one rule with its firing s
   assert.ok(renderRules().includes('tool-retry-loops'));
 });
 
-// --- #91: mega-turns. The bar is max(20k floor, p99.9 of the window's own
-// turns); savings price only the excess above it. -------------------------
+// --- #91: mega-turns. The bar is max(20k floor, 3x median output once there
+// are enough turns); savings price only the excess above it. --------------
 
-test('mega-turns: fires on a single runaway turn, and prices nothing it cannot defend', () => {
+test('mega-turns: fires on a small-window runaway and prices only its excess', () => {
   const events = [
     makeStored({ session_id: 'calm', input_tokens: 1_000, output_tokens: 500 }),
     makeStored({
@@ -155,17 +155,16 @@ test('mega-turns: fires on a single runaway turn, and prices nothing it cannot d
   ];
   const m = computeMetrics(events);
   assert.equal(m.megaTurns, 1);
-  // A two-turn window has no tail to speak of: p99.9 IS the largest turn, so
-  // the bar lands exactly on it and there is nothing above it to price.
-  assert.equal(m.megaTurnThreshold, 21_000);
-  assert.equal(m.megaTurnExcessTokens, 0);
+  // A two-turn window has too little data for the adaptive half, so the
+  // absolute floor does the work and prices only the part above itself.
+  assert.equal(m.megaTurnThreshold, MEGA_TURN_FLOOR_TOKENS);
+  assert.equal(m.megaTurnExcessTokens, 1_000);
   assert.ok(structuredFindings(m).some((f) => f.key === 'mega-turns'));
   const rec = enrichFindings(events, m, 30).find((r) => r.key === 'mega-turns');
   assert.ok(rec, 'mega-turns should fire on a 21k-output turn');
-  assert.match(rec!.message, /1 turn\(s\) emitted 21\.0k\+ output tokens/);
-  // Excess-only savings: with nothing above the bar, the rec stays unpriced
-  // rather than inventing a number.
-  assert.equal(rec!.savingsUsdPerMonth, undefined);
+  assert.match(rec!.message, /1 turn\(s\) emitted 20\.0k\+ output tokens/);
+  // Excess-only savings price the 1k above the floor, never the whole turn.
+  assert.ok((rec!.savingsUsdPerMonth ?? 0) > 0);
 });
 
 test('mega-turns: prices the excess above the bar in a large window and names the worst turn', () => {
@@ -184,8 +183,8 @@ test('mega-turns: prices the excess above the bar in a large window and names th
     }));
   }
   const m = computeMetrics(events);
-  // Three outliers in 10_003 turns sit below the 99.9th percentile, so the
-  // bar is the absolute floor, not the outliers themselves.
+  // Three clear outliers in a mostly quiet window stay governed by the
+  // absolute floor; the median is intentionally resistant to this few spikes.
   assert.equal(m.megaTurnThreshold, MEGA_TURN_FLOOR_TOKENS);
   assert.equal(m.megaTurns, 3);
   assert.equal(m.largestTurnOutput, 30_000);
@@ -208,13 +207,28 @@ test('mega-turns: stays quiet on ordinary windows, escalates the bar for heavy w
   assert.equal(structuredFindings(mCalm).some((f) => f.key === 'mega-turns'), false);
 
   // A user whose every turn legitimately writes 25k sets their own bar: the
-  // percentile escalates past the floor, so nothing is flagged as excess.
+  // median-based outlier test rises past the floor, so nothing fires.
   const heavy = Array.from({ length: 400 }, (_, i) =>
     makeStored({ ts: `2026-06-01T${String(Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00.000Z`, output_tokens: 25_000 }));
   const mHeavy = computeMetrics(heavy);
-  assert.equal(mHeavy.megaTurnThreshold, 25_000);
-  assert.equal(mHeavy.megaTurns, 400);
+  assert.equal(mHeavy.megaTurnThreshold, 75_000);
+  assert.equal(mHeavy.megaTurns, 0);
   assert.equal(mHeavy.megaTurnExcessTokens, 0);
+  assert.equal(structuredFindings(mHeavy).some((f) => f.key === 'mega-turns'), false);
+
+  // A genuine outlier clears that stable center without accusing routine work.
+  const mixed = [
+    ...heavy,
+    makeStored({
+      session_id: 'runaway',
+      input_tokens: 10_000,
+      output_tokens: 90_000,
+    }),
+  ];
+  const mMixed = computeMetrics(mixed);
+  assert.equal(mMixed.megaTurns, 1);
+  assert.equal(mMixed.megaTurnThreshold, 75_000);
+  assert.equal(mMixed.megaTurnExcessTokens, 15_000);
 });
 
 test('mergeMetrics recombines mega-turn counts over pooled spend, legacy exports included', () => {


### PR DESCRIPTION
Closes #91.

## What

`mega-turns`, a rework-family waste rule for single turns whose OUTPUT alone cleared the window's bar: a whole file rewritten to change three lines, or a runaway generation. Output tokens are the most expensive tokens there are, and one such turn can quietly cost more than a day of reading.

## The threshold, per the issue's "watch out"

The bar adapts instead of being a magic constant:

- `max(MEGA_TURN_FLOOR_TOKENS = 20_000, p99.9 of the window's own turn outputs)`
- The floor keeps small windows honest (their p99.9 is just the largest turn).
- The percentile lets users whose models legitimately write long files set their own bar higher rather than being accused for it: on an all-25k-output window the bar escalates to 25k and nothing is flagged as excess.
- A long file legitimately needs a long write, so the message stays descriptive and savings price only the EXCESS above the bar at the blended spend rate. Everything up to the bar is treated as legitimate work, which keeps the number conservative and easy to defend.

## Mechanics

- `fires()` reads only Metrics (it also runs on merged team metrics), so `computeMetrics` derives the bar once per window and carries `megaTurns`, `megaTurnTokens`, `megaTurnShare`, `largestTurnOutput`, `megaTurnExcessTokens`, `megaTurnThreshold`.
- `mergeMetrics`: counts and tokens sum with the usual `?? 0` legacy handling; the share recomputes over pooled spend; the threshold reports as the strictest bar any member used (each member counted against its own distribution). Pre-0.15 exports merge as zeros.
- Metric key `megaTurnShare` added to the union + direction table; rule registered in the standard way. Evidence ranks conversations by mega-turn spend, labelled with the largest single turn.

## Verification (real execution)

- Full suite from a clean tree: **340/340 pass** (`npm test` = tsc build + node --test over dist/).
- New tests cover: single-runaway firing with unpriced savings when excess is 0, large-window excess pricing plus evidence ordering, quiet windows staying quiet, percentile escalation past the floor, and merge recombination including legacy exports.
- Catalogue-size e2e assertion updated 11 → 12 for the new entry.
- CLI smoke check of `rules mega-turns` rendering against a burst fixture prints the firing state, message, docs and evidence path correctly.
