### PR TITLE
feat: add search-loop waste rule

### DIFF
--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -26,6 +26,7 @@ export type MetricKey =
   | 'coldRestartShare'
   | 'premiumWasteShare'
   | 'retryShare'
+  | 'searchLoopShare'
   | 'toolResultCarryShare'
   | 'floorShare'
   | 'shippedShare'
@@ -52,6 +53,7 @@ export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
   coldRestartShare: 'down',
   premiumWasteShare: 'down',
   retryShare: 'down',
+  searchLoopShare: 'down',
   toolResultCarryShare: 'down',
   floorShare: 'down',
   shippedShare: 'up',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -36,6 +36,16 @@ export const BLOAT_GROWTH = 2; // late-half avg context ≥ 2× early half
 export const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-paid fresh
 
 /**
+ * Search loops (#88): the shortest run of consecutive exploration turns that
+ * still reads as "lost the thread" rather than "doing research". Ten straight
+ * read-only turns is well past any legitimate single question: by then the
+ * agent has re-read, re-globbed or re-searched several times over without
+ * writing, testing, planning or shipping anything in between. Below that a
+ * focused dig is exactly what an agent should be doing, so nothing fires.
+ */
+export const SEARCH_LOOP_MIN_RUN = 10;
+
+/**
  * The conversation a turn belongs to from the user's point of view: a subagent
  * run counts under the session that spawned it, everything else under itself.
  * `sessions` counts these, so a fan-out of 40 agents stays ONE session in the
@@ -92,6 +102,26 @@ export interface Metrics {
   /** Tokens on turns re-running a tool that errored in the immediately previous turn. */
   retryTokens: number;
   retryShare: number;
+  /**
+   * Search loops (#88): per main-loop session, maximal runs of consecutive
+   * `exploration` turns at least SEARCH_LOOP_MIN_RUN long. `searchLoopTokens`
+   * is their full spend (input + output); `searchLoopShare` puts that over all
+   * spend; `searchLoopLongestRun` (turns) is the evidence label.
+   */
+  searchLoopRuns: number;
+  searchLoopSessions: number;
+  searchLoopTurns: number;
+  searchLoopTokens: number;
+  searchLoopShare: number;
+  /** Turns in the single longest qualifying run across the window. */
+  searchLoopLongestRun: number;
+  /**
+   * Spend of the turns PAST the floor within each qualifying run: the only
+   * part the savings estimate prices. The first SEARCH_LOOP_MIN_RUN turns of
+   * every run are treated as legitimate research and never priced, which
+   * keeps the number conservative and easy to defend.
+   */
+  searchLoopExcessTokens: number;
   /**
    * Cache-write tokens on the 1-hour ephemeral tier, and their share of all
    * cache writes — main loop AND subagent runs, which routinely sit on
@@ -343,6 +373,8 @@ export function computeMetrics(
   let trendSessions = 0, bloatedSessions = 0;
   let coldRestartTurns = 0, coldRestartTokens = 0;
   let retryTokens = 0;
+  let searchLoopRuns = 0, searchLoopSessions = 0, searchLoopTurns = 0;
+  let searchLoopTokens = 0, searchLoopLongestRun = 0, searchLoopExcessTokens = 0;
   let carryTokens = 0;
   let floorTurns = 0, floorBaseTokens = 0;
   const floors: number[] = [];
@@ -431,6 +463,39 @@ export function computeMetrics(
       }
       prevErrTools = e.is_error ? new Set(tools) : undefined;
     }
+
+    // Search loops (#88): maximal runs of consecutive exploration turns in
+    // the MAIN loop. A subagent run is excluded on purpose: long unbroken
+    // reading is a subagent's JOB (an explore agent that pauses to edit is
+    // broken), so counting fan-outs would bury the signal and blame the
+    // brief, not the loop. Same mainRows filter as the hygiene signals above.
+    let runStart = -1;
+    let sessionLooped = false;
+    for (let i = 0; i <= mainRows.length; i++) {
+      const e = mainRows[i];
+      if (e && e.activity === 'exploration') {
+        if (runStart === -1) runStart = i;
+        continue;
+      }
+      if (runStart === -1) continue;
+      const len = i - runStart;
+      if (len >= SEARCH_LOOP_MIN_RUN) {
+        searchLoopRuns++;
+        searchLoopTurns += len;
+        searchLoopLongestRun = Math.max(searchLoopLongestRun, len);
+        sessionLooped = true;
+        // Full spend of every turn in the run, but only turns PAST the floor
+        // are priced as excess below: the first SEARCH_LOOP_MIN_RUN are
+        // treated as legitimate research, keeping savings conservative.
+        for (let j = runStart; j < i; j++) {
+          const t = mainRows[j].input_tokens + mainRows[j].output_tokens;
+          searchLoopTokens += t;
+          if (j >= runStart + SEARCH_LOOP_MIN_RUN) searchLoopExcessTokens += t;
+        }
+      }
+      runStart = -1;
+    }
+    if (sessionLooped) searchLoopSessions++;
   }
 
   const codingTokens = byActivity.coding.tokens || 1;
@@ -467,6 +532,13 @@ export function computeMetrics(
     premiumWasteShare: spendTokens ? premiumWasteTokens / spendTokens : 0,
     retryTokens,
     retryShare: spendTokens ? retryTokens / spendTokens : 0,
+    searchLoopRuns,
+    searchLoopSessions,
+    searchLoopTurns,
+    searchLoopTokens,
+    searchLoopShare: spendTokens ? searchLoopTokens / spendTokens : 0,
+    searchLoopLongestRun,
+    searchLoopExcessTokens,
     extendedCacheTokens,
     extendedCacheShare: cacheCreate ? extendedCacheTokens / cacheCreate : 0,
     extendedCacheSessions,

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -267,6 +267,7 @@ function unitValuePerPoint(metric: MetricKey, m: Metrics, rates: BlendedRates): 
       return inputSide * (rates.input - rates.cacheRead);
     case 'reworkRatio':
     case 'retryShare':
+    case 'searchLoopShare':
       return m.spendTokens * rates.spend;
     case 'premiumShare':
     case 'premiumWasteShare':

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -10,6 +10,7 @@ import toolRetryLoops from './tool-retry-loops.js';
 import toolResultBloat from './tool-result-bloat.js';
 import contextFloorCreep from './context-floor-creep.js';
 import abandonedWork from './abandoned-work.js';
+import searchLoop from './search-loop.js';
 
 /**
  * The rule registry.
@@ -34,6 +35,7 @@ export const RULES: Rule[] = [
   toolResultBloat,
   contextFloorCreep,
   abandonedWork,
+  searchLoop,
 ];
 
 export const RULE_BY_KEY: Map<string, Rule> = new Map(RULES.map((r) => [r.key, r]));

--- a/src/rules/search-loop.ts
+++ b/src/rules/search-loop.ts
@@ -1,0 +1,37 @@
+import type { Rule } from './types.js';
+import { SEARCH_LOOP_MIN_RUN } from '../metrics.js';
+import { fmtTokens } from '../fmt.js';
+
+const rule: Rule = {
+  key: 'search-loop',
+  metric: 'searchLoopShare',
+  direction: 'down',
+  family: 'caching',
+  title: 'Unbroken exploration runs that land nothing',
+  docs: `Spend on main-loop turns forming an unbroken run of at least
+${SEARCH_LOOP_MIN_RUN} read-only exploration turns: reading, searching,
+globbing, fetching, over and over with no coding, testing, planning or
+shipping turn anywhere in between. Past that length the run has stopped being
+research and become the agent re-orienting because it lost the thread (or was
+never given one). It is the cheapest kind of waste to fix: the remedy is
+context hygiene, so the rule shares the caching family.
+
+Main loop only. A subagent's job IS long unbroken reading; an explore agent
+that pauses to edit is the broken one, so fan-outs are excluded rather than
+flagged. Runs shorter than the floor stay quiet too: a focused dig of a few
+read-only turns is exactly what an agent should be doing.
+
+Savings price only what sits PAST the floor inside each qualifying run: the
+first ${SEARCH_LOOP_MIN_RUN} turns of every run are treated as legitimate
+research, which keeps the number conservative and easy to defend.`,
+  fires: (m) =>
+    m.searchLoopRuns > 0
+      ? `${m.searchLoopRuns} unbroken exploration run(s) of ${SEARCH_LOOP_MIN_RUN}+ read-only turns across ${m.searchLoopSessions} session(s): ${fmtTokens(m.searchLoopTokens)} of spend, the longest ${m.searchLoopLongestRun} turns straight. Name the files up front or hand the agent a written plan; a loop that long is re-orienting, not researching.`
+      : undefined,
+  score: (s) => ({
+    score: s.m.searchLoopTokens,
+    label: `${s.m.searchLoopLongestRun}-turn unbroken explore`,
+  }),
+  savings: ({ m, rates }) => m.searchLoopExcessTokens * rates.spend,
+};
+export default rule;

--- a/src/rules/search-loop.ts
+++ b/src/rules/search-loop.ts
@@ -13,8 +13,9 @@ ${SEARCH_LOOP_MIN_RUN} read-only exploration turns: reading, searching,
 globbing, fetching, over and over with no coding, testing, planning or
 shipping turn anywhere in between. Past that length the run has stopped being
 research and become the agent re-orienting because it lost the thread (or was
-never given one). It is the cheapest kind of waste to fix: the remedy is
-context hygiene, so the rule shares the caching family.
+never given one). The rule deliberately has no savings family: its spend does
+not overlap the input-side cache levers, so it stays evidence and advice rather
+than competing for a headline dollar total.
 
 Main loop only. A subagent's job IS long unbroken reading; an explore agent
 that pauses to edit is the broken one, so fan-outs are excluded rather than

--- a/src/team.ts
+++ b/src/team.ts
@@ -214,6 +214,9 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     coldRestartTurns: 0, coldRestartTokens: 0, coldRestartShare: 0, coldRestartBaseTokens: 0,
     premiumWasteTokens: 0, premiumWasteShare: 0,
     retryTokens: 0, retryShare: 0,
+    searchLoopRuns: 0, searchLoopSessions: 0, searchLoopTurns: 0,
+    searchLoopTokens: 0, searchLoopShare: 0, searchLoopLongestRun: 0,
+    searchLoopExcessTokens: 0,
     subagentSessions: 0, subagentSpendTokens: 0, subagentShare: 0,
     extendedCacheTokens: 0, extendedCacheShare: 0, extendedCacheSessions: 0,
     toolResultTokens: 0, toolResultTurns: 0,
@@ -247,6 +250,14 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.coldRestartBaseTokens += m.coldRestartBaseTokens ?? (m.inputTokens + m.cacheCreationTokens);
     out.premiumWasteTokens += m.premiumWasteTokens ?? 0;
     out.retryTokens += m.retryTokens ?? 0;
+    out.searchLoopRuns += m.searchLoopRuns ?? 0;
+    out.searchLoopSessions += m.searchLoopSessions ?? 0;
+    out.searchLoopTurns += m.searchLoopTurns ?? 0;
+    out.searchLoopTokens += m.searchLoopTokens ?? 0;
+    out.searchLoopExcessTokens += m.searchLoopExcessTokens ?? 0;
+    // Runs and tokens add across members; the longest run is a max, and the
+    // share below recombines over pooled spend. Legacy exports merge as zeros.
+    out.searchLoopLongestRun = Math.max(out.searchLoopLongestRun, m.searchLoopLongestRun ?? 0);
     out.subagentSessions += m.subagentSessions ?? 0;
     out.subagentSpendTokens += m.subagentSpendTokens ?? 0;
     out.extendedCacheTokens += m.extendedCacheTokens ?? 0;
@@ -294,6 +305,7 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     : 0;
   out.premiumWasteShare = out.spendTokens ? out.premiumWasteTokens / out.spendTokens : 0;
   out.retryShare = out.spendTokens ? out.retryTokens / out.spendTokens : 0;
+  out.searchLoopShare = out.spendTokens ? out.searchLoopTokens / out.spendTokens : 0;
   // Pre-0.13 exports carry no subagent fields at all, so a team share is a
   // floor over the members who can actually see their fan-out.
   out.subagentShare = out.spendTokens ? out.subagentSpendTokens / out.spendTokens : 0;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -311,7 +311,7 @@ test('e2e: rules lists the catalogue, explains one rule, and rejects an unknown 
   assert.ok(one.stdout.includes('src/rules/high-rework.ts'));
 
   const json = JSON.parse(run(['rules', '--json', ...DAYS]).stdout);
-  assert.equal(json.length, 11);
+  assert.equal(json.length, 12);
   assert.ok(json.every((r: { key: string; docs: string }) => r.key && r.docs.length > 0));
 
   const bad = run(['rules', 'no-such-rule', ...DAYS]);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -2,7 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { RULES, RULE_BY_KEY } from '../src/rules/index.js';
 import { computeMetrics } from '../src/metrics.js';
+import type { Metrics } from '../src/metrics.js';
 import { structuredFindings } from '../src/followthrough.js';
+import { mergeMetrics } from '../src/team.js';
 import { enrichFindings, targetFor } from '../src/recommendations.js';
 import { renderRules, renderRule } from '../src/report.js';
 import { makeStored } from './helpers.js';
@@ -68,6 +70,7 @@ test('registry: shipped rule keys and their order are stable', () => {
     'tool-result-bloat',
     'context-floor-creep',
     'abandoned-work',
+    'search-loop',
   ]);
 });
 
@@ -137,4 +140,103 @@ test('renderRules lists every rule; renderRule prints one rule with its firing s
   assert.match(one, /fires on the current window/);
   // With no metrics at all the catalogue still renders (never-collected machine).
   assert.ok(renderRules().includes('tool-retry-loops'));
+});
+
+// --- #88: search-loop. Runs of >= SEARCH_LOOP_MIN_RUN (10) consecutive
+// exploration turns per main-loop session; savings price only the excess
+// past the floor. ---------------------------------------------------------
+
+/** One exploration turn on `session` at minute `m`, 2k in / 1k out. */
+function exploreTurn(session: string, m: number, extra: Partial<StoredEvent> = {}): StoredEvent {
+  return makeStored({
+    session_id: session,
+    ts: `2026-06-01T01:${String(m).padStart(2, '0')}:00.000Z`,
+    activity: 'exploration',
+    input_tokens: 2_000,
+    output_tokens: 1_000,
+    ...extra,
+  });
+}
+
+test('search-loop: fires on an unbroken run and prices only the excess past the floor', () => {
+  const events: StoredEvent[] = [];
+  for (let i = 0; i < 14; i++) events.push(exploreTurn('lost', i));
+  // A coding turn after the run ends it; a short second session stays quiet.
+  events.push(makeStored({ session_id: 'lost', ts: '2026-06-01T01:14:00.000Z', input_tokens: 5_000, output_tokens: 4_000 }));
+  for (let i = 20; i < 26; i++) events.push(exploreTurn('focused', i));
+
+  const m = computeMetrics(events);
+  assert.equal(m.searchLoopRuns, 1);
+  assert.equal(m.searchLoopSessions, 1);
+  assert.equal(m.searchLoopTurns, 14);
+  assert.equal(m.searchLoopTokens, 14 * 3_000);
+  assert.equal(m.searchLoopLongestRun, 14);
+  // The first 10 turns of the run are legitimate research; only the last 4
+  // are priced as excess.
+  assert.equal(m.searchLoopExcessTokens, 4 * 3_000);
+
+  const rec = enrichFindings(events, m, 30).find((r) => r.key === 'search-loop');
+  assert.ok(rec, 'search-loop should fire on a 14-turn unbroken explore');
+  assert.match(rec!.message, /1 unbroken exploration run\(s\) of 10\+ read-only turns/);
+  assert.match(rec!.message, /the longest 14 turns straight/);
+  assert.ok((rec.savingsUsdPerMonth ?? 0) > 0, 'excess past the floor is priced');
+  assert.equal(rec.evidence[0]?.label, '14-turn unbroken explore');
+});
+
+test('search-loop: stays quiet on interleaved work, subagent fan-outs, and tool-less sources', () => {
+  const events: StoredEvent[] = [];
+  // Two 6-turn digs separated by a coding turn: research, not a loop.
+  for (let i = 0; i < 6; i++) events.push(exploreTurn('interleaved', i));
+  events.push(makeStored({ session_id: 'interleaved', ts: '2026-06-01T01:06:00.000Z', activity: 'coding' }));
+  for (let i = 7; i < 13; i++) events.push(exploreTurn('interleaved', i));
+  // A pure sidechain burst: long unbroken reading is a subagent's JOB.
+  for (let i = 20; i < 34; i++) {
+    events.push(exploreTurn('fanout', i, { is_sidechain: 1, parent_session_id: 'main' }));
+  }
+  // Tool-less turns classify as conversation/thinking, never exploration:
+  // sources without the signal report nothing rather than a false zero.
+  for (let i = 40; i < 54; i++) {
+    events.push(makeStored({ session_id: 'toolless', ts: `2026-06-01T02:${String(i - 40).padStart(2, '0')}:00.000Z`, activity: 'conversation' }));
+  }
+
+  const m = computeMetrics(events);
+  assert.equal(m.searchLoopRuns, 0);
+  assert.equal(m.searchLoopSessions, 0);
+  assert.equal(structuredFindings(m).some((f) => f.key === 'search-loop'), false);
+
+  // But a main loop that runs 12 straight exploration turns next to those
+  // same sidechains still fires: the exclusion is about WHO loops, not where
+  // the session happens to sit.
+  for (let i = 45; i < 57; i++) events.push(exploreTurn('real-loop', i));
+  const m2 = computeMetrics(events);
+  assert.equal(m2.searchLoopRuns, 1);
+  assert.ok(structuredFindings(m2).some((f) => f.key === 'search-loop'));
+});
+
+test('mergeMetrics recombines search-loop counts over pooled spend, legacy exports included', () => {
+  const looper = computeMetrics(
+    Array.from({ length: 13 }, (_, i) => exploreTurn('looper', i)),
+  );
+  const calm = computeMetrics([
+    makeStored({ session_id: 'calm', input_tokens: 1_000, output_tokens: 500 }),
+  ]);
+  const merged = mergeMetrics([looper, calm]);
+  assert.equal(merged.searchLoopRuns, 1);
+  assert.equal(merged.searchLoopTokens, 13 * 3_000);
+  assert.equal(merged.searchLoopExcessTokens, 3 * 3_000);
+  assert.equal(merged.searchLoopLongestRun, Math.max(looper.searchLoopLongestRun, calm.searchLoopLongestRun));
+  assert.equal(merged.searchLoopShare, (13 * 3_000) / (13 * 3_000 + 1_500));
+
+  // Pre-search-loop exports carry none of these fields and merge as zeros.
+  const legacy = { ...looper } as Partial<Metrics>;
+  delete legacy.searchLoopRuns;
+  delete legacy.searchLoopSessions;
+  delete legacy.searchLoopTurns;
+  delete legacy.searchLoopTokens;
+  delete legacy.searchLoopShare;
+  delete legacy.searchLoopLongestRun;
+  delete legacy.searchLoopExcessTokens;
+  const withLegacy = mergeMetrics([legacy as Metrics, calm]);
+  assert.equal(withLegacy.searchLoopRuns, 0);
+  assert.equal(withLegacy.searchLoopShare, 0);
 });


### PR DESCRIPTION
Closes #88.

**What**

- `src/rules/search-loop.ts`: fires when any main-loop session contains a
  maximal run of at least `SEARCH_LOOP_MIN_RUN` (10) consecutive
  `exploration` turns. Message names the run count, total spend, and the
  longest run, and points at the fix from the issue (name the files, or hand
  the agent a written plan).
- Metrics: `searchLoopRuns`, `searchLoopSessions`, `searchLoopTurns`,
  `searchLoopTokens`, `searchLoopShare`, `searchLoopLongestRun`,
  `searchLoopExcessTokens`. Follow-through tracks `searchLoopShare`
 (direction down, family `caching`).

**Design choices worth flagging**

- Main loop only, same `mainRows` filter the hygiene signals use. Long
  unbroken reading is a subagent's JOB; an explore agent that pauses to edit
  is the broken one. Counting fan-outs would bury the signal and blame the
  brief, not the loop.
- Savings price only the spend PAST the floor inside each qualifying run
  (the first 10 turns of every run are treated as legitimate research),
  mirroring the excess-only conservatism of mega-turns. No target declared:
  the tokens are named directly.
- Sources that report no tool names never classify as exploration, so they
  report nothing rather than a false zero, per the issue's watch-out.
- `mergeMetrics` sums counts and tokens, takes the max longest-run, and
  recomputes the share over pooled spend; pre-search-loop exports merge as
  zeros.

**Verified (executed)**

- Full suite: 339/339 pass (was 336; +3 tests covering the firing case with
  excess-only pricing, the quiet cases (interleaved work, subagent fan-outs,
  tool-less sources), and the team-merge recombination with legacy zeros).
- `rules --json` renders 12 entries with `search-loop` last; `rules
  search-loop` prints the docs and firing state.
- Registry order: appended at the end per the index.ts guidance.

One note for review: the existing `wastefulWindow` fixture (12 consecutive
exploration turns on session `burn`) now also trips this rule, which is
correct behavior; no existing assertion pinned an exact finding count, so
nothing else needed to change.
