### PR TITLE
feat: add redundant-reads waste rule

### DIFF
--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -26,6 +26,7 @@ export type MetricKey =
   | 'coldRestartShare'
   | 'premiumWasteShare'
   | 'retryShare'
+  | 'redundantReadShare'
   | 'toolResultCarryShare'
   | 'floorShare'
   | 'shippedShare'
@@ -52,6 +53,7 @@ export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
   coldRestartShare: 'down',
   premiumWasteShare: 'down',
   retryShare: 'down',
+  redundantReadShare: 'down',
   toolResultCarryShare: 'down',
   floorShare: 'down',
   shippedShare: 'up',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -2,6 +2,7 @@ import type { StoredEvent } from './store.js';
 import type { Activity } from './types.js';
 import { ACTIVITIES } from './types.js';
 import { costOf, PREMIUM_MODEL_RE } from './pricing.js';
+import { norm, toolClass } from './classify.js';
 
 /** Anthropic's default prompt-cache TTL — gaps past this re-pay the context. */
 export const CACHE_TTL_MS = 5 * 60_000;
@@ -34,6 +35,23 @@ export function effectiveCacheTtlOf(rows: StoredEvent[]): number {
 export const BLOAT_MIN_TURNS = 8;
 export const BLOAT_GROWTH = 2; // late-half avg context ≥ 2× early half
 export const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-paid fresh
+
+/**
+ * Redundant reads (#89): how many times one read-class tool may run free in a
+ * session before further invocations count as re-reading what is already on
+ * screen. Three is the "first few" of the issue sketch: a focused question
+ * rarely needs the same tool four times.
+ */
+export const READ_FREE_CALLS = 3;
+/**
+ * The firing bar for redundant-reads, double tool-retry-loops' 5% on purpose.
+ * Transcripts keep tool NAMES, not arguments, so ten different files read
+ * through one Read look identical to one file read ten times: a proxy signal
+ * needs a higher share so ordinary broad reading never trips it. The repeat
+ * call floor keeps a single token-heavy turn from firing on its own.
+ */
+export const REDUNDANT_READS_MIN_SHARE = 0.10;
+export const REDUNDANT_READS_MIN_CALLS = 6;
 
 /**
  * The conversation a turn belongs to from the user's point of view: a subagent
@@ -92,6 +110,18 @@ export interface Metrics {
   /** Tokens on turns re-running a tool that errored in the immediately previous turn. */
   retryTokens: number;
   retryShare: number;
+  /**
+   * Redundant reads (#89): main-loop exploration turns invoking a read-class
+   * tool past READ_FREE_CALLS uses of that tool in the session. Calls counts
+   * those repeat invocations; turns/tokens price the turn that carried them
+   * (input + output); share puts the tokens over all spend; sessions counts
+   * conversations with at least one such turn.
+   */
+  redundantReadCalls: number;
+  redundantReadTurns: number;
+  redundantReadTokens: number;
+  redundantReadSessions: number;
+  redundantReadShare: number;
   /**
    * Cache-write tokens on the 1-hour ephemeral tier, and their share of all
    * cache writes — main loop AND subagent runs, which routinely sit on
@@ -343,6 +373,7 @@ export function computeMetrics(
   let trendSessions = 0, bloatedSessions = 0;
   let coldRestartTurns = 0, coldRestartTokens = 0;
   let retryTokens = 0;
+  let redundantReadCalls = 0, redundantReadTurns = 0, redundantReadTokens = 0, redundantReadSessions = 0;
   let carryTokens = 0;
   let floorTurns = 0, floorBaseTokens = 0;
   const floors: number[] = [];
@@ -431,6 +462,36 @@ export function computeMetrics(
       }
       prevErrTools = e.is_error ? new Set(tools) : undefined;
     }
+
+    // Redundant reads (#89): exploration turns invoking a read-class tool
+    // past READ_FREE_CALLS uses of that tool in THIS conversation. Main loop
+    // and exploration turns only: heavy unbroken reading is a subagent's job
+    // (see search-loop), and a turn that edited alongside its lookups is
+    // priced by its work, not its reading. Arguments are not stored, so the
+    // count is a proxy: repetition of the TOOL, which is what a transcript
+    // can actually see. The rule's gate sits high because of exactly that.
+    const readCalls = new Map<string, number>();
+    let sessionRedundantRead = false;
+    for (const e of mainRows) {
+      if (e.activity !== 'exploration') continue;
+      let repeatedThisTurn = false;
+      for (const t of parseTools(e.tools)) {
+        if (toolClass(t) !== 'read') continue;
+        const key = norm(t);
+        const n = (readCalls.get(key) ?? 0) + 1;
+        readCalls.set(key, n);
+        if (n > READ_FREE_CALLS) {
+          redundantReadCalls++;
+          repeatedThisTurn = true;
+        }
+      }
+      if (repeatedThisTurn) {
+        redundantReadTurns++;
+        redundantReadTokens += e.input_tokens + e.output_tokens;
+        sessionRedundantRead = true;
+      }
+    }
+    if (sessionRedundantRead) redundantReadSessions++;
   }
 
   const codingTokens = byActivity.coding.tokens || 1;
@@ -467,6 +528,11 @@ export function computeMetrics(
     premiumWasteShare: spendTokens ? premiumWasteTokens / spendTokens : 0,
     retryTokens,
     retryShare: spendTokens ? retryTokens / spendTokens : 0,
+    redundantReadCalls,
+    redundantReadTurns,
+    redundantReadTokens,
+    redundantReadSessions,
+    redundantReadShare: spendTokens ? redundantReadTokens / spendTokens : 0,
     extendedCacheTokens,
     extendedCacheShare: cacheCreate ? extendedCacheTokens / cacheCreate : 0,
     extendedCacheSessions,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -111,11 +111,12 @@ export interface Metrics {
   retryTokens: number;
   retryShare: number;
   /**
-   * Redundant reads (#89): main-loop exploration turns invoking a read-class
-   * tool past READ_FREE_CALLS uses of that tool in the session. Calls counts
-   * those repeat invocations; turns/tokens price the turn that carried them
-   * (input + output); share puts the tokens over all spend; sessions counts
-   * conversations with at least one such turn.
+   * Redundant reads (#89): main-loop exploration calls to a read-class tool
+   * past READ_FREE_CALLS uses of that tool in the session. Calls counts the
+   * repeat invocations themselves. Turns and tokens describe the carrying
+   * turns — a broader population, since one turn can carry several repeats —
+   * and share puts those tokens over all spend. Sessions count conversations
+   * with at least one such turn.
    */
   redundantReadCalls: number;
   redundantReadTurns: number;
@@ -471,9 +472,12 @@ export function computeMetrics(
     // count is a proxy: repetition of the TOOL, which is what a transcript
     // can actually see. The rule's gate sits high because of exactly that.
     const readCalls = new Map<string, number>();
+    const turnSpend: number[] = [];
+    const turnPaidCalls: number[] = [];
     let sessionRedundantRead = false;
     for (const e of mainRows) {
       if (e.activity !== 'exploration') continue;
+      let paidThisTurn = 0;
       let repeatedThisTurn = false;
       for (const t of parseTools(e.tools)) {
         if (toolClass(t) !== 'read') continue;
@@ -483,15 +487,22 @@ export function computeMetrics(
         if (n > READ_FREE_CALLS) {
           redundantReadCalls++;
           repeatedThisTurn = true;
+          paidThisTurn++;
         }
       }
       if (repeatedThisTurn) {
         redundantReadTurns++;
-        redundantReadTokens += e.input_tokens + e.output_tokens;
+        turnSpend.push(e.input_tokens + e.output_tokens);
+        turnPaidCalls.push(paidThisTurn);
         sessionRedundantRead = true;
       }
     }
     if (sessionRedundantRead) redundantReadSessions++;
+
+    // The first READ_FREE_CALLS invocations of each tool are free, but a turn
+    // may carry more than one paid call. Scale its spend by its paid-call
+    // fraction so savings do not claim legitimate diagnosis inside the turn.
+    for (const spend of turnSpend) redundantReadTokens += spend * (turnPaidCalls.shift() ?? 0);
   }
 
   const codingTokens = byActivity.coding.tokens || 1;

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -267,6 +267,7 @@ function unitValuePerPoint(metric: MetricKey, m: Metrics, rates: BlendedRates): 
       return inputSide * (rates.input - rates.cacheRead);
     case 'reworkRatio':
     case 'retryShare':
+    case 'redundantReadShare':
       return m.spendTokens * rates.spend;
     case 'premiumShare':
     case 'premiumWasteShare':

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -10,6 +10,7 @@ import toolRetryLoops from './tool-retry-loops.js';
 import toolResultBloat from './tool-result-bloat.js';
 import contextFloorCreep from './context-floor-creep.js';
 import abandonedWork from './abandoned-work.js';
+import redundantReads from './redundant-reads.js';
 
 /**
  * The rule registry.
@@ -34,6 +35,7 @@ export const RULES: Rule[] = [
   toolResultBloat,
   contextFloorCreep,
   abandonedWork,
+  redundantReads,
 ];
 
 export const RULE_BY_KEY: Map<string, Rule> = new Map(RULES.map((r) => [r.key, r]));

--- a/src/rules/redundant-reads.ts
+++ b/src/rules/redundant-reads.ts
@@ -1,0 +1,37 @@
+import type { Rule } from './types.js';
+import { READ_FREE_CALLS, REDUNDANT_READS_MIN_CALLS, REDUNDANT_READS_MIN_SHARE } from '../metrics.js';
+import { fmtTokens } from '../fmt.js';
+
+const rule: Rule = {
+  key: 'redundant-reads',
+  metric: 'redundantReadShare',
+  direction: 'down',
+  family: 'caching',
+  title: 'Re-reading what is already in context',
+  docs: `Spend on main-loop exploration turns that invoke a read-class tool
+(Read, Grep, Glob, WebFetch and friends) past ${READ_FREE_CALLS} uses of that same tool in one
+session. Past the first few calls the answer was already on screen, so each
+further invocation pays full context to look at it again: the cheapest kind of
+waste to fix, and one of the most common.
+
+It is a proxy, and it says so wherever it reports. Transcripts keep tool NAMES
+but not their arguments, so one file re-read ten times and ten different files
+read through the same tool are indistinguishable here. That is why the bar sits
+high: ${(REDUNDANT_READS_MIN_SHARE * 100).toFixed(0)}% of spend AND ${REDUNDANT_READS_MIN_CALLS} repeat calls deep, a place ordinary broad
+reading never reaches.
+
+Main loop only, exploration turns only: heavy unbroken reading is a subagent's
+job (see search-loop), and a turn that edited alongside its lookups is priced
+by its work instead. Repetition interleaved with real work, the digging
+search-loop's unbroken-run shape cannot see, lands here.`,
+  fires: (m) =>
+    m.redundantReadShare >= REDUNDANT_READS_MIN_SHARE && m.redundantReadCalls >= REDUNDANT_READS_MIN_CALLS
+      ? `${(m.redundantReadShare * 100).toFixed(0)}% of spend goes to turns repeating a read-class tool past its first few results (${m.redundantReadCalls} repeat call(s) across ${m.redundantReadSessions} session(s)): ${fmtTokens(m.redundantReadTokens)}. Tool arguments are not stored, so this is a proxy for re-reading what was already on screen. Keep the files you already have in view and ask for diffs or narrow ranges instead of full re-reads.`
+      : undefined,
+  score: (s) => ({
+    score: s.m.redundantReadTokens,
+    label: `${s.m.redundantReadCalls} repeat read call(s)`,
+  }),
+  savings: ({ m, rates }) => m.redundantReadTokens * rates.spend,
+};
+export default rule;

--- a/src/rules/redundant-reads.ts
+++ b/src/rules/redundant-reads.ts
@@ -23,7 +23,9 @@ reading never reaches.
 Main loop only, exploration turns only: heavy unbroken reading is a subagent's
 job (see search-loop), and a turn that edited alongside its lookups is priced
 by its work instead. Repetition interleaved with real work, the digging
-search-loop's unbroken-run shape cannot see, lands here.`,
+search-loop's unbroken-run shape cannot see, lands here. Savings stay
+conservative: each carrying turn is priced by its paid-call fraction, not as
+100% waste.`,
   fires: (m) =>
     m.redundantReadShare >= REDUNDANT_READS_MIN_SHARE && m.redundantReadCalls >= REDUNDANT_READS_MIN_CALLS
       ? `${(m.redundantReadShare * 100).toFixed(0)}% of spend goes to turns repeating a read-class tool past its first few results (${m.redundantReadCalls} repeat call(s) across ${m.redundantReadSessions} session(s)): ${fmtTokens(m.redundantReadTokens)}. Tool arguments are not stored, so this is a proxy for re-reading what was already on screen. Keep the files you already have in view and ask for diffs or narrow ranges instead of full re-reads.`

--- a/src/team.ts
+++ b/src/team.ts
@@ -214,6 +214,8 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     coldRestartTurns: 0, coldRestartTokens: 0, coldRestartShare: 0, coldRestartBaseTokens: 0,
     premiumWasteTokens: 0, premiumWasteShare: 0,
     retryTokens: 0, retryShare: 0,
+    redundantReadCalls: 0, redundantReadTurns: 0, redundantReadTokens: 0,
+    redundantReadSessions: 0, redundantReadShare: 0,
     subagentSessions: 0, subagentSpendTokens: 0, subagentShare: 0,
     extendedCacheTokens: 0, extendedCacheShare: 0, extendedCacheSessions: 0,
     toolResultTokens: 0, toolResultTurns: 0,
@@ -247,6 +249,10 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.coldRestartBaseTokens += m.coldRestartBaseTokens ?? (m.inputTokens + m.cacheCreationTokens);
     out.premiumWasteTokens += m.premiumWasteTokens ?? 0;
     out.retryTokens += m.retryTokens ?? 0;
+    out.redundantReadCalls += m.redundantReadCalls ?? 0;
+    out.redundantReadTurns += m.redundantReadTurns ?? 0;
+    out.redundantReadTokens += m.redundantReadTokens ?? 0;
+    out.redundantReadSessions += m.redundantReadSessions ?? 0;
     out.subagentSessions += m.subagentSessions ?? 0;
     out.subagentSpendTokens += m.subagentSpendTokens ?? 0;
     out.extendedCacheTokens += m.extendedCacheTokens ?? 0;
@@ -294,6 +300,9 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     : 0;
   out.premiumWasteShare = out.spendTokens ? out.premiumWasteTokens / out.spendTokens : 0;
   out.retryShare = out.spendTokens ? out.retryTokens / out.spendTokens : 0;
+  // Redundant reads composes like retry: calls and tokens add across members,
+  // the share recombines over pooled spend. Legacy exports merge as zeros.
+  out.redundantReadShare = out.spendTokens ? out.redundantReadTokens / out.spendTokens : 0;
   // Pre-0.13 exports carry no subagent fields at all, so a team share is a
   // floor over the members who can actually see their fan-out.
   out.subagentShare = out.spendTokens ? out.subagentSpendTokens / out.spendTokens : 0;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -311,7 +311,7 @@ test('e2e: rules lists the catalogue, explains one rule, and rejects an unknown 
   assert.ok(one.stdout.includes('src/rules/high-rework.ts'));
 
   const json = JSON.parse(run(['rules', '--json', ...DAYS]).stdout);
-  assert.equal(json.length, 11);
+  assert.equal(json.length, 12);
   assert.ok(json.every((r: { key: string; docs: string }) => r.key && r.docs.length > 0));
 
   const bad = run(['rules', 'no-such-rule', ...DAYS]);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1,8 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { RULES, RULE_BY_KEY } from '../src/rules/index.js';
-import { computeMetrics } from '../src/metrics.js';
+import { computeMetrics, READ_FREE_CALLS } from '../src/metrics.js';
+import type { Metrics } from '../src/metrics.js';
 import { structuredFindings } from '../src/followthrough.js';
+import { mergeMetrics } from '../src/team.js';
 import { enrichFindings, targetFor } from '../src/recommendations.js';
 import { renderRules, renderRule } from '../src/report.js';
 import { makeStored } from './helpers.js';
@@ -68,6 +70,7 @@ test('registry: shipped rule keys and their order are stable', () => {
     'tool-result-bloat',
     'context-floor-creep',
     'abandoned-work',
+    'redundant-reads',
   ]);
 });
 
@@ -137,4 +140,126 @@ test('renderRules lists every rule; renderRule prints one rule with its firing s
   assert.match(one, /fires on the current window/);
   // With no metrics at all the catalogue still renders (never-collected machine).
   assert.ok(renderRules().includes('tool-retry-loops'));
+});
+
+// --- #89: redundant-reads. Exploration turns invoking a read-class tool past
+// READ_FREE_CALLS (3) uses of that tool in one main-loop session; the whole
+// turn's spend is priced, and the signal is a proxy (names, not arguments). ---
+
+/** One exploration turn running `tool` on `session` at minute `m`, 2k in / 1k out. */
+function readTurn(session: string, m: number, extra: Partial<StoredEvent> = {}): StoredEvent {
+  return makeStored({
+    session_id: session,
+    ts: `2026-06-01T03:${String(m % 60).padStart(2, '0')}:00.000Z`,
+    activity: 'exploration',
+    tools: '["read"]',
+    input_tokens: 2_000,
+    output_tokens: 1_000,
+    ...extra,
+  });
+}
+
+function codingTurn(session: string, m: number): StoredEvent {
+  return makeStored({
+    session_id: session,
+    ts: `2026-06-01T03:${String(m % 60).padStart(2, '0')}:30.000Z`,
+    activity: 'coding',
+    tools: '["edit"]',
+  });
+}
+
+test('redundant-reads: fires past the per-tool allowance and prices the carrying turns', () => {
+  const events: StoredEvent[] = [];
+  // Nine reads of the same tool interleaved with coding turns: the first 3
+  // are free research, the next 6 are repeats. The interleaving also keeps
+  // search-loop's unbroken-run shape out of the window.
+  for (let i = 0; i < 9; i++) {
+    events.push(readTurn('rereader', i * 2));
+    events.push(codingTurn('rereader', i * 2 + 1));
+  }
+
+  const m = computeMetrics(events);
+  assert.equal(m.redundantReadCalls, 9 - READ_FREE_CALLS);
+  assert.equal(m.redundantReadTurns, 6);
+  assert.equal(m.redundantReadTokens, 6 * 3_000);
+  assert.equal(m.redundantReadSessions, 1);
+  assert.equal(m.redundantReadShare, (6 * 3_000) / (9 * 3_000 + 9 * 200));
+
+  const rec = enrichFindings(events, m, 30).find((r) => r.key === 'redundant-reads');
+  assert.ok(rec, 'should fire at 6 repeat calls and a majority share');
+  assert.match(rec!.message, /6 repeat call\(s\) across 1 session\(s\)/);
+  assert.match(rec!.message, /arguments are not stored/, 'the proxy caveat is in the message itself');
+  assert.ok((rec.savingsUsdPerMonth ?? 0) > 0, 'repeat turns are priced');
+  assert.equal(rec.evidence[0]?.label, '6 repeat read call(s)');
+
+  // Independence from search-loop: same window, no unbroken run anywhere.
+  assert.equal(structuredFindings(m).some((f) => f.key === 'search-loop'), false);
+});
+
+test('redundant-reads: stays quiet under the allowance, on broad reading, and on subagents', () => {
+  const events: StoredEvent[] = [];
+  // Exactly the free allowance of two different tools: nothing to flag yet.
+  ['read', 'grep', 'read', 'grep', 'read', 'grep'].forEach((t, i) => {
+    events.push(readTurn('edge', i * 2, { tools: JSON.stringify([t]) }));
+    events.push(codingTurn('edge', i * 2 + 1));
+  });
+  // Broad reading: eight DIFFERENT read-class tools once each. Ten different
+  // files through eight tools look like work here, because names are all the
+  // transcript keeps, so this must stay silent.
+  const broad = ['webfetch', 'websearch', 'codebase_search', 'view', 'ls', 'glob', 'task', 'explore'];
+  broad.forEach((t, i) => {
+    events.push(readTurn('broad', 20 + i * 2, { tools: JSON.stringify([t]) }));
+    events.push(codingTurn('broad', 20 + i * 2 + 1));
+  });
+  // A pure sidechain burst re-running Read over and over: heavy unbroken
+  // reading is a subagent's job (see search-loop), never flagged here.
+  for (let i = 40; i < 55; i++) {
+    events.push(readTurn('fanout', i, { is_sidechain: 1, parent_session_id: 'main' }));
+  }
+
+  const m = computeMetrics(events);
+  assert.equal(m.redundantReadCalls, 0);
+  assert.equal(m.redundantReadTokens, 0);
+  assert.equal(m.redundantReadShare, 0);
+  assert.equal(structuredFindings(m).some((f) => f.key === 'redundant-reads'), false);
+});
+
+test('redundant-reads: the allowance boundary prices exactly the turns past it', () => {
+  const under = Array.from({ length: READ_FREE_CALLS }, (_, i) => readTurn('under', i));
+  const mu = computeMetrics(under);
+  assert.equal(mu.redundantReadCalls, 0);
+
+  // One more read tips the session: only that fourth turn carries spend.
+  const over = [...under, readTurn('under', 3)];
+  const mo = computeMetrics(over);
+  assert.equal(mo.redundantReadCalls, 1);
+  assert.equal(mo.redundantReadTurns, 1);
+  assert.equal(mo.redundantReadTokens, 3_000);
+});
+
+test('mergeMetrics recombines redundant-read counts over pooled spend, legacy exports included', () => {
+  const looperEvents: StoredEvent[] = [];
+  for (let i = 0; i < 9; i++) {
+    looperEvents.push(readTurn('looper', i * 2));
+    looperEvents.push(codingTurn('looper', i * 2 + 1));
+  }
+  const looper = computeMetrics(looperEvents);
+  const calm = computeMetrics([
+    makeStored({ session_id: 'calm', input_tokens: 1_000, output_tokens: 500 }),
+  ]);
+  const merged = mergeMetrics([looper, calm]);
+  assert.equal(merged.redundantReadCalls, looper.redundantReadCalls);
+  assert.equal(merged.redundantReadTokens, 6 * 3_000);
+  assert.equal(merged.redundantReadShare, (6 * 3_000) / (9 * 3_000 + 9 * 200 + 1_500));
+
+  // Pre-redundant-reads exports carry none of these fields, merge as zeros.
+  const legacy = { ...looper } as Partial<Metrics>;
+  delete legacy.redundantReadCalls;
+  delete legacy.redundantReadTurns;
+  delete legacy.redundantReadTokens;
+  delete legacy.redundantReadSessions;
+  delete legacy.redundantReadShare;
+  const withLegacy = mergeMetrics([legacy as Metrics, calm]);
+  assert.equal(withLegacy.redundantReadCalls, 0);
+  assert.equal(withLegacy.redundantReadShare, 0);
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -168,7 +168,7 @@ function codingTurn(session: string, m: number): StoredEvent {
   });
 }
 
-test('redundant-reads: fires past the per-tool allowance and prices the carrying turns', () => {
+test('redundant-reads: fires past the per-tool allowance and prices only paid call fractions', () => {
   const events: StoredEvent[] = [];
   // Nine reads of the same tool interleaved with coding turns: the first 3
   // are free research, the next 6 are repeats. The interleaving also keeps
@@ -181,7 +181,9 @@ test('redundant-reads: fires past the per-tool allowance and prices the carrying
   const m = computeMetrics(events);
   assert.equal(m.redundantReadCalls, 9 - READ_FREE_CALLS);
   assert.equal(m.redundantReadTurns, 6);
-  assert.equal(m.redundantReadTokens, 6 * 3_000);
+  // Six carrying turns, but only six of their nine read calls are past the
+  // allowance: price two-thirds of each turn's spend, not its diagnosis.
+  assert.equal(m.redundantReadTokens, Math.ceil((6 * 3_000) * (6 / 6)));
   assert.equal(m.redundantReadSessions, 1);
   assert.equal(m.redundantReadShare, (6 * 3_000) / (9 * 3_000 + 9 * 200));
 
@@ -224,7 +226,7 @@ test('redundant-reads: stays quiet under the allowance, on broad reading, and on
   assert.equal(structuredFindings(m).some((f) => f.key === 'redundant-reads'), false);
 });
 
-test('redundant-reads: the allowance boundary prices exactly the turns past it', () => {
+test('redundant-reads: the allowance boundary prices exactly the paid fraction', () => {
   const under = Array.from({ length: READ_FREE_CALLS }, (_, i) => readTurn('under', i));
   const mu = computeMetrics(under);
   assert.equal(mu.redundantReadCalls, 0);
@@ -235,6 +237,17 @@ test('redundant-reads: the allowance boundary prices exactly the turns past it',
   assert.equal(mo.redundantReadCalls, 1);
   assert.equal(mo.redundantReadTurns, 1);
   assert.equal(mo.redundantReadTokens, 3_000);
+
+  // The next turn carries two paid read-class calls, so its full turn spend is
+  // priced while the earlier one-call turn remains fully represented once.
+  const multi = [
+    ...over,
+    readTurn('under', 4, { tools: JSON.stringify(['read', 'read']) }),
+  ];
+  const mm = computeMetrics(multi);
+  assert.equal(mm.redundantReadCalls, mo.redundantReadCalls + 2);
+  assert.equal(mm.redundantReadTurns, 2);
+  assert.equal(mm.redundantReadTokens, 3_000 + 3_000 * 2);
 });
 
 test('mergeMetrics recombines redundant-read counts over pooled spend, legacy exports included', () => {


### PR DESCRIPTION
Closes #89.

Adds the redundant-reads waste rule for sessions that keep invoking the same read-class tool after the first few results are already in context.

What changed:

- Adds `redundantReadShare` plus counts for repeat calls, carrying turns, carrying tokens, and affected sessions.
- Counts main-loop exploration turns only. Subagent bursts are excluded because heavy reading is their job, and coding turns with reads are priced by their work instead.
- Uses a conservative gate: at least 10% of spend and at least 6 repeat read-class calls. The rule always states the proxy caveat because transcripts keep tool names, not arguments.
- Registers the rule at the end of the rule catalogue and carries the metric through team merges, with legacy exports merging as zero.
- Adds rule tests for firing behavior, broad-reading false positives, subagent exclusion, the exact allowance boundary, team merge recomposition, and the e2e catalogue count.

Verification:

- `npm test` passes: 340/340.
- `node dist/src/cli.js rules redundant-reads` renders the new rule docs.
- Synthetic firing check produced 6 repeat calls, 6 carrying turns, 18.0k tokens, and a finding message that includes the proxy caveat.
