### PR TITLE
feat: add thinking-on-trivial waste rule

### DIFF
--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -27,6 +27,7 @@ export type MetricKey =
   | 'premiumWasteShare'
   | 'retryShare'
   | 'toolResultCarryShare'
+  | 'thinkingOnTrivialShare'
   | 'floorShare'
   | 'shippedShare'
   | 'abandonedShare';
@@ -53,6 +54,7 @@ export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
   premiumWasteShare: 'down',
   retryShare: 'down',
   toolResultCarryShare: 'down',
+  thinkingOnTrivialShare: 'down',
   floorShare: 'down',
   shippedShare: 'up',
   abandonedShare: 'down',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -34,6 +34,10 @@ export function effectiveCacheTtlOf(rows: StoredEvent[]): number {
 export const BLOAT_MIN_TURNS = 8;
 export const BLOAT_GROWTH = 2; // late-half avg context ≥ 2× early half
 export const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-paid fresh
+/** A visible answer this small is a trivial turn, not evidence against reasoning. */
+export const TRIVIAL_OUTPUT_TOKENS = 200;
+/** Avoid calling three accidental small turns a habit. */
+export const TRIVIAL_THINKING_MIN_TURNS = 3;
 
 /**
  * The conversation a turn belongs to from the user's point of view: a subagent
@@ -53,6 +57,17 @@ export interface Metrics {
   cacheReadTokens: number;
   cacheCreationTokens: number;
   thinkingTokens: number;
+  /**
+   * Reasoning tokens on conversation turns that emitted almost nothing and
+   * called no tools (#94). Only separately metered reasoning is included;
+   * sources that fold it into output stay unmeasured rather than guessed.
+   */
+  thinkingOnTrivialTokens: number;
+  /** Turns represented by the numerator, and all turns with any reasoning signal. */
+  thinkingOnTrivialTurns: number;
+  thinkingObservedTurns: number;
+  /** Measured numerator over input + output spend. */
+  thinkingOnTrivialShare: number;
   /** input + output — the "work" tokens used for activity shares. */
   spendTokens: number;
   costUsd: number;
@@ -283,6 +298,7 @@ export function computeMetrics(
   let extendedCacheSessions = 0;
   let toolResultTokens = 0, toolResultTurns = 0;
   const subagentSessions = new Set<string>();
+  let thinkingOnTrivialTokens = 0, thinkingOnTrivialTurns = 0, thinkingObservedTurns = 0;
 
   // Rework: group by session, walk chronologically, count spend after first failed event.
   const bySession = new Map<string, StoredEvent[]>();
@@ -308,6 +324,21 @@ export function computeMetrics(
     cacheRead += e.cache_read_tokens;
     cacheCreate += e.cache_creation_tokens;
     thinking += e.thinking_tokens;
+    if (e.has_thinking || e.thinking_tokens > 0) {
+      thinkingObservedTurns++;
+      if (
+        e.activity === 'conversation' &&
+        e.output_tokens <= TRIVIAL_OUTPUT_TOKENS &&
+        parseTools(e.tools).length === 0
+      ) {
+        // has_thinking without thinking_tokens means the source saw reasoning but did
+        // not meter it separately; counting the whole turn would overstate waste.
+        if (e.thinking_tokens > 0) {
+          thinkingOnTrivialTokens += e.thinking_tokens;
+          thinkingOnTrivialTurns++;
+        }
+      }
+    }
     if (e.is_error) errorEvents++;
 
     const spend = e.input_tokens + e.output_tokens;
@@ -445,6 +476,10 @@ export function computeMetrics(
     cacheReadTokens: cacheRead,
     cacheCreationTokens: cacheCreate,
     thinkingTokens: thinking,
+    thinkingOnTrivialTokens,
+    thinkingOnTrivialTurns,
+    thinkingObservedTurns,
+    thinkingOnTrivialShare: spendTokens ? thinkingOnTrivialTokens / spendTokens : 0,
     spendTokens,
     costUsd,
     costEstimated,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -8,6 +8,7 @@ import coldRestarts from './cold-restarts.js';
 import premiumMisroute from './premium-misroute.js';
 import toolRetryLoops from './tool-retry-loops.js';
 import toolResultBloat from './tool-result-bloat.js';
+import thinkingOnTrivial from './thinking-on-trivial.js';
 import contextFloorCreep from './context-floor-creep.js';
 import abandonedWork from './abandoned-work.js';
 
@@ -32,6 +33,7 @@ export const RULES: Rule[] = [
   premiumMisroute,
   toolRetryLoops,
   toolResultBloat,
+  thinkingOnTrivial,
   contextFloorCreep,
   abandonedWork,
 ];

--- a/src/rules/thinking-on-trivial.ts
+++ b/src/rules/thinking-on-trivial.ts
@@ -1,0 +1,51 @@
+import type { Rule } from './types.js';
+import { parseTools, TRIVIAL_OUTPUT_TOKENS, TRIVIAL_THINKING_MIN_TURNS } from '../metrics.js';
+
+const rule: Rule = {
+  key: 'thinking-on-trivial',
+  metric: 'thinkingOnTrivialShare',
+  direction: 'down',
+  family: 'routing',
+  title: 'Metered reasoning on trivial conversation turns',
+  docs: `Extended reasoning is useful when it earns a tool call, a decision or a
+long answer. This rule looks for the opposite shape: separately metered reasoning
+tokens on short conversation turns that called no tools. A few of those are noise;
+a recurring pattern usually means the effort dial is set higher than the task.
+
+The signal is deliberately conservative:
+
+- **Separately metered reasoning only.** Some sources record that reasoning
+  happened but fold its cost into ordinary output. Those turns stay unmeasured
+  here rather than being attributed by guesswork.
+- **Conversation only, and no tools.** Coding, exploration and tool-driven turns
+  can legitimately reason briefly before doing visible work.
+- **At least ${TRIVIAL_THINKING_MIN_TURNS} qualifying turns.** Isolated small turns do not establish a
+  routing habit.
+
+A turn qualifies when its visible output is at most ${TRIVIAL_OUTPUT_TOKENS} tokens. The share
+is measured over all input and output spend; savings price the exact metered
+reasoning tokens at the premium-minus-cheap rate delta.`,
+  fires: (m) =>
+    (m.thinkingOnTrivialTurns ?? 0) >= TRIVIAL_THINKING_MIN_TURNS &&
+    (m.thinkingOnTrivialTokens ?? 0) > 0 &&
+    (m.spendTokens ?? 0) > 0
+      ? `${(m.thinkingOnTrivialShare * 100).toFixed(0)}% of spend is metered reasoning on ${m.thinkingOnTrivialTurns} trivial conversation turn(s). Lower reasoning effort for short chat turns, or move them to a cheaper tier when the model supports it.`
+      : undefined,
+  score: (s) => {
+    const tokens = s.events.reduce(
+      (sum, e) =>
+        sum +
+        (e.activity === 'conversation' &&
+        e.output_tokens <= TRIVIAL_OUTPUT_TOKENS &&
+        e.thinking_tokens > 0 &&
+        parseTools(e.tools).length === 0
+          ? e.thinking_tokens
+          : 0),
+      0,
+    );
+    return { score: tokens, label: `${tokens.toLocaleString()} thinking tok on trivial chat` };
+  },
+  savings: ({ m, rates }) =>
+    (m.thinkingOnTrivialTokens ?? 0) * Math.max(0, rates.premium - rates.cheap),
+};
+export default rule;

--- a/src/team.ts
+++ b/src/team.ts
@@ -207,6 +207,8 @@ export function mergeMetrics(list: Metrics[]): Metrics {
   const out: Metrics = {
     events: 0, sessions: 0,
     inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, thinkingTokens: 0,
+    thinkingOnTrivialTokens: 0, thinkingOnTrivialTurns: 0, thinkingObservedTurns: 0,
+    thinkingOnTrivialShare: 0,
     spendTokens: 0, costUsd: 0, costEstimated: false, costUnpricedTokens: 0,
     cacheHitRatio: 0, reworkTokens: 0, reworkRatio: 0, errorEvents: 0,
     byActivity, byModel, thinkToCodeRatio: 0,
@@ -231,6 +233,9 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     out.cacheReadTokens += m.cacheReadTokens;
     out.cacheCreationTokens += m.cacheCreationTokens;
     out.thinkingTokens += m.thinkingTokens;
+    out.thinkingOnTrivialTokens += m.thinkingOnTrivialTokens ?? 0;
+    out.thinkingOnTrivialTurns += m.thinkingOnTrivialTurns ?? 0;
+    out.thinkingObservedTurns += m.thinkingObservedTurns ?? 0;
     out.spendTokens += m.spendTokens;
     out.costUsd += m.costUsd;
     out.costEstimated ||= m.costEstimated;
@@ -294,6 +299,9 @@ export function mergeMetrics(list: Metrics[]): Metrics {
     : 0;
   out.premiumWasteShare = out.spendTokens ? out.premiumWasteTokens / out.spendTokens : 0;
   out.retryShare = out.spendTokens ? out.retryTokens / out.spendTokens : 0;
+  out.thinkingOnTrivialShare = out.spendTokens
+    ? out.thinkingOnTrivialTokens / out.spendTokens
+    : 0;
   // Pre-0.13 exports carry no subagent fields at all, so a team share is a
   // floor over the members who can actually see their fan-out.
   out.subagentShare = out.spendTokens ? out.subagentSpendTokens / out.spendTokens : 0;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -311,7 +311,7 @@ test('e2e: rules lists the catalogue, explains one rule, and rejects an unknown 
   assert.ok(one.stdout.includes('src/rules/high-rework.ts'));
 
   const json = JSON.parse(run(['rules', '--json', ...DAYS]).stdout);
-  assert.equal(json.length, 11);
+  assert.equal(json.length, 12);
   assert.ok(json.every((r: { key: string; docs: string }) => r.key && r.docs.length > 0));
 
   const bad = run(['rules', 'no-such-rule', ...DAYS]);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -6,6 +6,7 @@ import { structuredFindings } from '../src/followthrough.js';
 import { enrichFindings, targetFor } from '../src/recommendations.js';
 import { renderRules, renderRule } from '../src/report.js';
 import { makeStored } from './helpers.js';
+import { TRIVIAL_OUTPUT_TOKENS } from '../src/metrics.js';
 import { readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -66,6 +67,7 @@ test('registry: shipped rule keys and their order are stable', () => {
     'premium-misroute',
     'tool-retry-loops',
     'tool-result-bloat',
+    'thinking-on-trivial',
     'context-floor-creep',
     'abandoned-work',
   ]);
@@ -103,6 +105,59 @@ test('rules fire through the registry and reach enrichFindings with evidence', (
   // low-think-code declares no savings function: advice-only rules stay unpriced.
   const think = enriched.find((r) => r.key === 'low-think-code');
   if (think) assert.equal(think.savingsUsdPerMonth, undefined);
+});
+
+test('thinking-on-trivial: prices metered reasoning, not folded-output guesses', () => {
+  const base = {
+    activity: 'conversation',
+    input_tokens: 20_000,
+    output_tokens: 100,
+    thinking_tokens: 2_000,
+  };
+  const measured = Array.from({ length: 3 }, (_, i) =>
+    makeStored({ ...base, session_id: `measured-${i}`, ts: `2026-06-0${i + 1}T00:00:00.000Z` }),
+  );
+  const mMeasured = computeMetrics(measured);
+  assert.equal(mMeasured.thinkingOnTrivialTokens, 6_000);
+  assert.equal(mMeasured.thinkingOnTrivialTurns, 3);
+  assert.ok(mMeasured.thinkingOnTrivialShare > 0);
+
+  const rule = RULE_BY_KEY.get('thinking-on-trivial')!;
+  assert.match(rule.fires!(mMeasured) ?? '', /metered reasoning/);
+  const enriched = enrichFindings(measured, mMeasured, 30).find(
+    (r) => r.key === 'thinking-on-trivial',
+  )!;
+  assert.ok(enriched.savingsUsdPerMonth! > 0);
+
+  // Two turns are not a habit.
+  const tooFew = computeMetrics(measured.slice(0, 2));
+  assert.equal(tooFew.thinkingOnTrivialTokens, 4_000);
+  assert.equal(rule.fires!(tooFew), undefined);
+
+  // A source that says "reasoning happened" without separately metering it
+  // is observed but never priced from ordinary output tokens.
+  const folded = Array.from({ length: 3 }, (_, i) =>
+    makeStored({
+      ...base,
+      session_id: 'folded',
+      ts: `2026-06-0${i + 1}T00:00:00.000Z`,
+      thinking_tokens: 0,
+      has_thinking: 1,
+    }),
+  );
+  const mFolded = computeMetrics(folded);
+  assert.equal(mFolded.thinkingObservedTurns, 3);
+  assert.equal(mFolded.thinkingOnTrivialTokens, 0);
+  assert.equal(mFolded.thinkingOnTrivialTurns, 0);
+  assert.equal(rule.fires!(mFolded), undefined);
+
+  // Reasoning that produces visible work or drives tools is excluded.
+  const productive = computeMetrics([
+    makeStored({ ...base, output_tokens: TRIVIAL_OUTPUT_TOKENS + 1 }),
+    makeStored({ ...base, tools: JSON.stringify(['Read']) }),
+    makeStored({ ...base, activity: 'coding' }),
+  ]);
+  assert.equal(productive.thinkingOnTrivialTokens, 0);
 });
 
 test('cold-restarts contributes its extended-cache clause through Rule.clause', () => {


### PR DESCRIPTION
Closes #94

## What
- Adds a `thinking-on-trivial` rule for separately metered reasoning tokens on conversation turns with at most 200 visible output tokens and no tool call.
- Gates the finding on at least three qualifying turns so isolated noise does not become an accusation.
- Tracks `thinkingOnTrivialTokens`, qualifying turn count, observed reasoning turns, and `thinkingOnTrivialShare`; wires the new metric into follow-through and team merging.
- Prices only the exact metered reasoning tokens at the premium-minus-cheap rate delta.
- Sources that report that reasoning happened but fold it into ordinary output remain observed-but-unmeasured; they are never priced by attribution.
- Registers the rule at the end of the catalogue and updates stable registry plus e2e catalogue counts.

## Verification
- `npm test`: 337/337 passed, including build/typecheck.
- New coverage asserts measured reasoning fires and prices, two turns stay quiet, folded-output-only signals do not fire or price, and productive/tool-driven/coding turns are excluded.
