### PR TITLE
feat: annotate team metric outliers with percentiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ EOF
 token-monitor merge exports/*.json --team team.yaml
 ```
 
-The team report shows per-discipline rollups: tokens, cost, cache hit, rework, think:code ratio, dominant activity, and persona — so you can see *which discipline* needs which intervention, not just a total bill.
+The team report shows per-discipline rollups: tokens, cost, cache hit, rework, think:code ratio, dominant activity, and persona — so you can see *which discipline* needs which intervention, not just a total bill. With five or more verified members, it also flags individual metrics in the extreme tail as “furthest from team pattern”; unsigned merges stay at the safer group level.
 
 ### Org rollups (lead → org)
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -4,7 +4,15 @@ import type { StoredEvent } from './store.js';
 import { ACTIVITIES } from './types.js';
 import { assignPersona, generalRecommendations } from './personas.js';
 import type { SignedExport, TeamConfig, RollupAxis } from './team.js';
-import { mergeMetrics, rollupExports, dominantActivity, displayName, staleMembers } from './team.js';
+import {
+  mergeMetrics,
+  memberOutlierPercentiles,
+  rollupExports,
+  dominantActivity,
+  displayName,
+  staleMembers,
+} from './team.js';
+import type { MemberPercentile } from './team.js';
 import type { FollowRow } from './followthrough.js';
 import { fmtMetric } from './followthrough.js';
 import type { EnrichedRec } from './recommendations.js';
@@ -869,6 +877,37 @@ export function renderTeamReport(
     for (const a of ACTIVITIES) {
       if (m.byActivity[a].tokens === 0) continue;
       out.push(`    ${a.padEnd(13)} ${bar(m.byActivity[a].share)} ${(m.byActivity[a].share * 100).toFixed(1)}%`);
+    }
+  }
+
+  // Per-member outliers are deliberately separate from group rollups and are
+  // shown only when every member is verifiably identified. A percentile over
+  // unsigned user@host identities can compare one person's two machines.
+  const percentiles = memberOutlierPercentiles(exports, opts.keyring);
+  if (exports.every((e) => e.sig?.publicKey !== undefined)) {
+    if (exports.length >= 5 && percentiles.length > 0) {
+      const labels: Record<MemberPercentile['metric'], string> = {
+        cacheHitRatio: 'Cache hit',
+        reworkRatio: 'Rework',
+        thinkToCodeRatio: 'Think:code',
+        coldRestartShare: 'Cold restarts',
+      };
+      out.push(section('Furthest from team pattern'));
+      out.push(
+        table(
+          ['Member', 'Metric', 'Team pattern'],
+          percentiles.map(({ name, metric, percentile }) => [
+            name,
+            `${labels[metric]} — ⚠ p${percentile.toFixed(0)} of team`,
+            'coaching signal',
+          ]),
+        ),
+      );
+      out.push(
+        `  ${DIM}A coaching instrument, not a review weapon. The README's gaming paragraph applies doubly to per-person comparisons.${RESET}`,
+      );
+    } else if (exports.length >= 5) {
+      out.push(`  ${DIM}No member is beyond the outlier tails on the comparable team metrics.${RESET}`);
     }
   }
 

--- a/src/team.ts
+++ b/src/team.ts
@@ -7,6 +7,7 @@ import { computeMetrics, groupBy } from './metrics.js';
 import type { StoredEvent } from './store.js';
 import { ACTIVITIES } from './types.js';
 import type { Activity } from './types.js';
+import { METRIC_DIRECTION } from './followthrough.js';
 import { fingerprint } from './sign.js';
 import type { Signature } from './sign.js';
 
@@ -350,6 +351,66 @@ export function rollupExports(
 export function dominantActivity(m: Metrics): Activity {
   return ACTIVITIES.reduce((best, a) =>
     m.byActivity[a].tokens > m.byActivity[best].tokens ? a : best,
+  );
+}
+
+/** Metrics compared side by side in the team percentile section. */
+const PERCENTILE_METRICS = [
+  'cacheHitRatio', 'reworkRatio', 'thinkToCodeRatio', 'coldRestartShare',
+] as const;
+
+type PercentileMetric = (typeof PERCENTILE_METRICS)[number];
+
+/**
+ * Average-rank percentile of `value` within `values`, from 0 to 100. Ties get
+ * the same percentile instead of depending on input order; this is display
+ * context, so a stable fractional rank is more honest than a forced order.
+ */
+function averageRankPercentile(values: number[], value: number): number {
+  const lessCount = values.filter((candidate) => candidate < value).length;
+  const equalCount = values.filter((candidate) => candidate === value).length;
+  return ((2 * lessCount + equalCount - 1) / (values.length - 1)) * 50;
+}
+
+export interface MemberPercentile {
+  name: string;
+  metric: PercentileMetric;
+  /** 0-100 percentile, with direction interpreted by the metric. */
+  percentile: number;
+}
+
+/**
+ * Outlier annotations for signed team members, using each metric's canonical
+ * improvement direction as the single source of truth for which tail is bad.
+ *
+ * Unsigned exports are excluded because their user@host identity can split one
+ * person across machines; per-person comparisons need --verify to mean "person".
+ * The middle stays unannotated on purpose: this is triage, not a leaderboard.
+ */
+export function memberOutlierPercentiles(
+  exports: SignedExport[],
+  keyring?: Record<string, string>,
+): MemberPercentile[] {
+  const signed = exports.filter((ex) => ex.sig?.publicKey !== undefined);
+  if (signed.length < 5) return [];
+
+  const names = new Map<SignedExport, string>(
+    signed.map((ex) => [ex, displayName(ex, keyring)]),
+  );
+  const out: MemberPercentile[] = [];
+  for (const metric of PERCENTILE_METRICS) {
+    const values = signed.map((ex) => ex.overall[metric]);
+    const badIsHigh = METRIC_DIRECTION[metric] === 'down';
+    for (const ex of signed) {
+      const percentile = averageRankPercentile(values, ex.overall[metric]);
+      if (badIsHigh ? percentile >= 75 : percentile <= 25) {
+        out.push({ name: names.get(ex)!, metric, percentile });
+      }
+    }
+  }
+  return out.sort((a, b) =>
+    a.name.localeCompare(b.name) ||
+    PERCENTILE_METRICS.indexOf(a.metric) - PERCENTILE_METRICS.indexOf(b.metric),
   );
 }
 

--- a/test/team.test.ts
+++ b/test/team.test.ts
@@ -4,7 +4,16 @@ import { writeFileSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { computeMetrics } from '../src/metrics.js';
-import { mergeMetrics, parseTeamConfig, rollupExports, dominantActivity, identityOf, displayName, dedupeExports } from '../src/team.js';
+import {
+  mergeMetrics,
+  memberOutlierPercentiles,
+  parseTeamConfig,
+  rollupExports,
+  dominantActivity,
+  identityOf,
+  displayName,
+  dedupeExports,
+} from '../src/team.js';
 import type { ExportV1, SignedExport } from '../src/team.js';
 import { signObject, fingerprint } from '../src/sign.js';
 import { makeStored } from './helpers.js';
@@ -87,6 +96,58 @@ test('parseTeamConfig reads two-level teams.yaml and nested JSON', () => {
 function mkExport(user: string, m: ReturnType<typeof metricsOf>, generatedAt = 'now'): ExportV1 {
   return { version: 1, user, host: 'h', generatedAt, days: 30, overall: m, byProject: {} };
 }
+
+const keyDir = mkdtempSync(join(tmpdir(), 'tm-percentile-'));
+const keyring = { 'member-0': fingerprint(signObject(mkExport('member-0', metricsOf({ session_id: 'key-probe' })), keyDir).sig.publicKey) };
+
+function signedExport(
+  user: string,
+  overall: ReturnType<typeof metricsOf>,
+  keyDir: string,
+): SignedExport {
+  return signObject(mkExport(user, overall), keyDir);
+}
+
+test('memberOutlierPercentiles uses average ranks and only flags the bad tail', () => {
+  // Cache hit is good-high; rework is good-low. The same raw percentile must
+  // therefore flag the opposite ends of these two metrics.
+  const cache = [0.1, 0.2, 0.3, 0.4, 0.5];
+  const rework = [0.5, 0.4, 0.3, 0.2, 0.1];
+  const exports = cache.map((ratio, i) =>
+    signedExport(
+      `member-${i}`,
+      metricsOf({
+        session_id: `p${i}`,
+        activity: 'coding',
+        input_tokens: 1000 + i,
+        output_tokens: 100,
+        cache_read_tokens: (ratio * (1100 + i)) / (1 - ratio),
+      }),
+      keyDir,
+    ),
+  );
+  const annotated = exports.map((ex, i) => ({
+    ...ex,
+    overall: { ...ex.overall, reworkRatio: rework[i] },
+  }));
+
+  const outliers = memberOutlierPercentiles(annotated, keyring);
+  assert.ok(outliers.some((x) => x.name === 'member-0' && x.metric === 'cacheHitRatio' && x.percentile === 0));
+  assert.ok(outliers.some((x) => x.name === 'member-0' && x.metric === 'reworkRatio' && x.percentile === 100));
+  assert.equal(outliers.filter((x) => x.name === 'member-2').length, 0);
+});
+
+test('memberOutlierPercentiles suppresses small teams and unsigned merges', () => {
+  const four = Array.from({ length: 4 }, (_, i) =>
+    signedExport(`small-${i}`, metricsOf({ session_id: `small-${i}` }), keyDir),
+  );
+  const unsignedFive = Array.from({ length: 5 }, (_, i) =>
+    mkExport(`unsigned-${i}`, metricsOf({ session_id: `unsigned-${i}` })),
+  );
+
+  assert.deepEqual(memberOutlierPercentiles(four), []);
+  assert.deepEqual(memberOutlierPercentiles(unsignedFive), []);
+});
 
 test('rollupExports groups by discipline and by team', () => {
   const exports = [


### PR DESCRIPTION
Closes #69

## What
- Adds merge-side percentile context for `cacheHitRatio`, `reworkRatio`, `thinkToCodeRatio`, and `coldRestartShare` — no new export fields.
- Uses the existing `METRIC_DIRECTION` map as the single source of truth for which percentile tail is undesirable.
- Computes deterministic average-rank percentiles, including stable tie handling.
- Annotates only extreme members (p25 or beyond in the bad direction) under a "Furthest from team pattern" section.
- Requires at least five signed exports. Unsigned user@host identities are excluded from per-person comparison because one person on two machines can otherwise read as two people.
- Adds a coaching-not-review caveat to the rendered section and documents the verified-member gate in the README.

## Verification
- `npm test` — 338/338 tests passed.
- New unit coverage pins average-rank math, direction-aware tails, small-N suppression, and unsigned-export suppression.
