### PR TITLE
chore(rules): give each rule its own metric direction and $/point

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ const rule: Rule = {
   fires: (m) => (m.retryShare >= 0.05 ? `${(m.retryShare * 100).toFixed(0)}% of spend goes to retries...` : undefined),
   score: (s) => ({ score: s.m.retryTokens, label: `${fmtTokens(s.m.retryTokens)} retry tok` }),
   savings: ({ m, rates }) => m.retryTokens * rates.spend,
+  valuePerPoint: ({ m, rates }) => m.spendTokens * rates.spend,   // $ per 1.0 of the metric
 };
 export default rule;
 ```
@@ -60,6 +61,8 @@ export const RULES: Rule[] = [
 ```
 
 `npm test` fails with `rule file src/rules/<key>.ts is not registered` if you miss either half, so you will not find out from a confusing assertion somewhere else.
+
+`valuePerPoint` is what follow-through multiplies a point of progress by. Declare it even when the honest answer is `undefined` — a ratio with no token population of its own (see `low-think-code`) — because a rule that prices savings without it prints a dollar figure and then silently drops the $/point projection. `npm test` now fails by name if you leave it out.
 
 Only `key`, `metric`, `direction`, `title`, `docs` and `fires` are required. `score` supplies the "worst sessions" evidence; `savings` prices the finding; `target`/`personalTarget` say what it is priced against; `clause` appends a sentence that needs the raw events. See `src/rules/types.ts` for the full contract and `src/rules/low-think-code.ts` for a rule that deliberately prices nothing.
 
@@ -83,7 +86,9 @@ The generator reads the **database**, not your transcripts, and the database has
 
 Then a test in `test/rules.test.ts` (or its own file) with a synthetic window from `makeStored`: one case where it fires, one where it must stay silent, and — if it prices savings — one asserting the arithmetic. `npm test` must pass.
 
-If your new rule needs a metric that doesn't exist yet, add it to `Metrics` in `src/metrics.ts` and to the `MetricKey` union in `src/followthrough.ts` so follow-through can track whether the advice worked.
+If your new rule needs a metric that doesn't exist yet, add it to `Metrics` in `src/metrics.ts` and to the `MetricKey` union in `src/followthrough.ts` so follow-through can track whether the advice worked. Nothing else: the metric's improvement direction and its $/point both come from your rule file, and the catalogue size is counted from the registry.
+
+Two files still carry a line per rule — `src/rules/index.ts` and the `MetricKey` union — and both are deliberate: one is the order findings fire in, the other is the declaration that a number is worth tracking. Everything that used to be a third, fourth and fifth shared line now lives in the rule. If your PR conflicts with another contributor's, it should now be in those two places and your own new file, which is a conflict you can resolve without reading the other rule.
 
 ## Writing an adapter
 

--- a/src/followthrough.ts
+++ b/src/followthrough.ts
@@ -41,26 +41,26 @@ export function metricValue(m: Metrics, key: MetricKey): number {
 }
 
 /**
+ * Metrics no rule owns. `shippedShare` is reported and tracked but has no
+ * finding of its own — nothing fires on shipping more.
+ */
+const UNOWNED_DIRECTION: Partial<Record<MetricKey, 'up' | 'down'>> = {
+  shippedShare: 'up',
+};
+
+/**
  * The improvement direction for each tracked metric. LLM-suggested
  * interventions (#42) are scored against this, not against whatever direction
  * the model claims — the canonical direction is the source of truth.
+ *
+ * Derived from the registry rather than restated here: a rule already declares
+ * the direction it wants its metric to move, and two copies of that fact drift.
+ * The registry test asserts every MetricKey ends up with an entry.
  */
 export const METRIC_DIRECTION: Record<MetricKey, 'up' | 'down'> = {
-  cacheHitRatio: 'up',
-  reworkRatio: 'down',
-  thinkToCodeRatio: 'up',
-  premiumShare: 'down',
-  contextBloatShare: 'down',
-  coldRestartShare: 'down',
-  premiumWasteShare: 'down',
-  retryShare: 'down',
-  cascadeShare: 'down',
-  megaTurnShare: 'down',
-  toolResultCarryShare: 'down',
-  floorShare: 'down',
-  shippedShare: 'up',
-  abandonedShare: 'down',
-};
+  ...UNOWNED_DIRECTION,
+  ...Object.fromEntries(RULES.map((r) => [r.metric, r.direction])),
+} as Record<MetricKey, 'up' | 'down'>;
 
 /**
  * Every rule in the registry, asked whether it fires on these metrics. Rules

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -31,6 +31,14 @@ export function effectiveCacheTtlOf(rows: StoredEvent[]): number {
   return writes > 0 && extended * 2 >= writes ? EXTENDED_CACHE_TTL_MS : CACHE_TTL_MS;
 }
 /** Sessions need this many turns before a context-bloat trend is measurable. */
+/**
+ * Every token billed on the input side: fresh input, cache writes and cache
+ * reads. The population a cache-hit point is worth something over.
+ */
+export function inputSideTokens(m: Metrics): number {
+  return m.cacheReadTokens + m.inputTokens + m.cacheCreationTokens;
+}
+
 export const BLOAT_MIN_TURNS = 8;
 export const BLOAT_GROWTH = 2; // late-half avg context ≥ 2× early half
 export const BLOAT_FRESH_SHARE = 0.3; // ...and ≥30% of late context is re-paid fresh

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -5,7 +5,7 @@ import type { Finding, FollowRow, MetricKey } from './followthrough.js';
 import { structuredFindings, fmtMetric } from './followthrough.js';
 import { PRICES, PREMIUM_MODEL_RE } from './pricing.js';
 import type { BlendedRates, RuleFamily, SessionInfo, Target } from './rules/types.js';
-import { RULE_BY_KEY, RULES } from './rules/index.js';
+import { RULE_BY_KEY, RULE_BY_METRIC, RULES } from './rules/index.js';
 import type { CauseBreakdown } from './causes.js';
 import { decomposeCause } from './causes.js';
 
@@ -259,33 +259,14 @@ export function realizedMonthly(
   return usd > 0 ? usd : undefined;
 }
 
-/** $ value of a full 1.0 move in the metric, at the current window's volumes. */
+/**
+ * $ value of a full 1.0 move in the metric, at the current window's volumes.
+ * Owned by the rule that moves the metric (see Rule.valuePerPoint), so adding
+ * a finding no longer means editing a switch in this file. LLM-tracked rows
+ * carry a metric rather than a rule key, which is why the lookup is by metric.
+ */
 function unitValuePerPoint(metric: MetricKey, m: Metrics, rates: BlendedRates): number | undefined {
-  const inputSide = m.cacheReadTokens + m.inputTokens + m.cacheCreationTokens;
-  switch (metric) {
-    case 'cacheHitRatio':
-      return inputSide * (rates.input - rates.cacheRead);
-    case 'reworkRatio':
-    case 'retryShare':
-    case 'cascadeShare':
-    case 'megaTurnShare':
-      return m.spendTokens * rates.spend;
-    case 'premiumShare':
-    case 'premiumWasteShare':
-      return m.spendTokens * Math.max(0, rates.premium - rates.cheap);
-    case 'coldRestartShare':
-      // Same population as the ratio — see the cold-restarts rule's savings().
-      return (m.coldRestartBaseTokens ?? m.inputTokens + m.cacheCreationTokens) * (rates.input - rates.cacheRead);
-    case 'toolResultCarryShare':
-      // Carried context is re-read from cache; same rate its rule prices with.
-      return inputSide * rates.cacheRead;
-    case 'floorShare':
-      return (m.floorBaseTokens ?? 0) * rates.cacheRead;
-    case 'abandonedShare':
-      return m.spendTokens * rates.spend;
-    default:
-      return undefined; // thinkToCodeRatio, contextBloatShare: not $-translatable
-  }
+  return RULE_BY_METRIC.get(metric)?.valuePerPoint?.({ m, rates });
 }
 
 /** "≈ ~$84/mo" — shared by the terminal report, analyze, and the dashboard. */

--- a/src/rules/abandoned-work.ts
+++ b/src/rules/abandoned-work.ts
@@ -11,6 +11,7 @@ const rule: Rule = {
   key: 'abandoned-work',
   metric: 'abandonedShare',
   direction: 'down',
+  valuePerPoint: ({ m, rates }) => m.spendTokens * rates.spend,
   family: 'outcomes',
   title: 'Coding work that never reached a ship signal',
   docs: `Spend in work STREAMS — a project plus a branch — that contain coding turns

--- a/src/rules/cold-restarts.ts
+++ b/src/rules/cold-restarts.ts
@@ -13,6 +13,8 @@ const rule: Rule = {
   key: 'cold-restarts',
   metric: 'coldRestartShare',
   direction: 'down',
+  // Same population as the ratio — see this rule's savings().
+  valuePerPoint: ({ m, rates }) => (m.coldRestartBaseTokens ?? m.inputTokens + m.cacheCreationTokens) * (rates.input - rates.cacheRead),
   family: 'caching',
   title: 'Context re-paid after idle gaps',
   docs: `Turns that resume after a gap longer than their session's prompt-cache TTL

--- a/src/rules/context-bloat.ts
+++ b/src/rules/context-bloat.ts
@@ -17,6 +17,8 @@ const rule: Rule = {
   key: 'context-bloat',
   metric: 'contextBloatShare',
   direction: 'down',
+  // Not $-translatable: the share is a count of sessions, not spend.
+  valuePerPoint: () => undefined,
   family: 'caching',
   title: 'Sessions that balloon their own context',
   docs: `Long sessions whose late-half context per turn is at least twice their

--- a/src/rules/context-floor-creep.ts
+++ b/src/rules/context-floor-creep.ts
@@ -6,6 +6,7 @@ const rule: Rule = {
   key: 'context-floor-creep',
   metric: 'floorShare',
   direction: 'down',
+  valuePerPoint: ({ m, rates }) => (m.floorBaseTokens ?? 0) * rates.cacheRead,
   family: 'caching',
   title: 'A standing context every turn re-reads',
   docs: `Before a session does anything it loads a block of context nobody chose

--- a/src/rules/error-cascade.ts
+++ b/src/rules/error-cascade.ts
@@ -9,6 +9,7 @@ const rule: Rule = {
   key: 'error-cascade',
   metric: 'cascadeShare',
   direction: 'down',
+  valuePerPoint: ({ m, rates }) => m.spendTokens * rates.spend,
   family: 'rework',
   title: 'Error cascades: retrying against a broken premise',
   docs: `Spend inside runs of ${CASCADE_MIN_RUN}+ consecutive failed turns in one

--- a/src/rules/high-rework.ts
+++ b/src/rules/high-rework.ts
@@ -5,6 +5,7 @@ const rule: Rule = {
   key: 'high-rework',
   metric: 'reworkRatio',
   direction: 'down',
+  valuePerPoint: ({ m, rates }) => m.spendTokens * rates.spend,
   family: 'rework',
   title: 'High rework after failures',
   docs: `Share of spend on coding/testing turns that happen after the first failed

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -42,6 +42,15 @@ export const RULES: Rule[] = [
 
 export const RULE_BY_KEY: Map<string, Rule> = new Map(RULES.map((r) => [r.key, r]));
 
+/**
+ * Rules indexed by the metric they move, so the pipeline can ask "what is a
+ * point of this metric worth?" without a second list to keep in step. First
+ * rule wins if two ever share a metric — the duplicate-metric test says so.
+ */
+export const RULE_BY_METRIC: Map<string, Rule> = new Map(
+  [...RULES].reverse().map((r) => [r.metric, r]),
+);
+
 // A duplicate key would silently shadow a rule and corrupt follow-through
 // baselines (they are keyed on it). Fail at import instead — the contributor
 // who just copied a rule file sees it on the first `npm test`.

--- a/src/rules/low-cache-hit.ts
+++ b/src/rules/low-cache-hit.ts
@@ -1,4 +1,5 @@
 import type { Rule } from './types.js';
+import { inputSideTokens } from '../metrics.js';
 import { fmtTokens } from '../fmt.js';
 
 /** Cache reads cost ~10% of fresh input, so this is the biggest single lever. */
@@ -6,6 +7,7 @@ const rule: Rule = {
   key: 'low-cache-hit',
   metric: 'cacheHitRatio',
   direction: 'up',
+  valuePerPoint: ({ m, rates }) => inputSideTokens(m) * (rates.input - rates.cacheRead),
   family: 'caching',
   title: 'Low cache hit ratio',
   docs: `Cache reads are billed at roughly a tenth of fresh input, so the share of

--- a/src/rules/low-think-code.ts
+++ b/src/rules/low-think-code.ts
@@ -10,6 +10,8 @@ const rule: Rule = {
   key: 'low-think-code',
   metric: 'thinkToCodeRatio',
   direction: 'up',
+  // Not $-translatable: a think:code ratio has no token population of its own.
+  valuePerPoint: () => undefined,
   title: 'Very low think:code ratio',
   docs: `Planning and exploration tokens per coding token. Teams that spend 15-30%
 of their tokens understanding the problem before writing code ship with

--- a/src/rules/mega-turns.ts
+++ b/src/rules/mega-turns.ts
@@ -10,6 +10,7 @@ const rule: Rule = {
   key: 'mega-turns',
   metric: 'megaTurnShare',
   direction: 'down',
+  valuePerPoint: ({ m, rates }) => m.spendTokens * rates.spend,
   family: 'rework',
   title: 'Single turns emitting runaway output',
   docs: `Spend on turns whose OUTPUT alone cleared the window's bar: a whole file

--- a/src/rules/premium-misroute.ts
+++ b/src/rules/premium-misroute.ts
@@ -5,6 +5,7 @@ const rule: Rule = {
   key: 'premium-misroute',
   metric: 'premiumWasteShare',
   direction: 'down',
+  valuePerPoint: ({ m, rates }) => m.spendTokens * Math.max(0, rates.premium - rates.cheap),
   family: 'routing',
   title: 'Premium tokens on reading and chat',
   docs: `The sharper half of the routing story: premium-model tokens spent on

--- a/src/rules/premium-model-overuse.ts
+++ b/src/rules/premium-model-overuse.ts
@@ -14,6 +14,7 @@ const rule: Rule = {
   key: 'premium-model-overuse',
   metric: 'premiumShare',
   direction: 'down',
+  valuePerPoint: ({ m, rates }) => m.spendTokens * Math.max(0, rates.premium - rates.cheap),
   family: 'routing',
   title: 'Almost everything on the premium tier',
   docs: `Share of spend on premium models. Fires above 90% — and only when the mix

--- a/src/rules/tool-result-bloat.ts
+++ b/src/rules/tool-result-bloat.ts
@@ -1,4 +1,5 @@
 import type { Rule } from './types.js';
+import { inputSideTokens } from '../metrics.js';
 import { fmtTokens } from '../fmt.js';
 
 /**
@@ -12,6 +13,8 @@ const rule: Rule = {
   key: 'tool-result-bloat',
   metric: 'toolResultCarryShare',
   direction: 'down',
+  // Carried context is re-read from cache; same rate the rule prices with.
+  valuePerPoint: ({ m, rates }) => inputSideTokens(m) * rates.cacheRead,
   family: 'caching',
   title: 'Tool results riding along after they were read',
   docs: `A tool result is not paid once. It enters the context and is re-read in

--- a/src/rules/tool-retry-loops.ts
+++ b/src/rules/tool-retry-loops.ts
@@ -5,6 +5,7 @@ const rule: Rule = {
   key: 'tool-retry-loops',
   metric: 'retryShare',
   direction: 'down',
+  valuePerPoint: ({ m, rates }) => m.spendTokens * rates.spend,
   family: 'rework',
   title: 'Paying to retry a tool that just failed',
   docs: `Spend on turns that re-run a tool which errored in the immediately

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -105,6 +105,18 @@ export interface Rule {
    * reachable"). Only for per-session skills — model choice is not one.
    */
   personalTarget?: { metric: (m: Metrics) => number; direction: 'up' | 'down' };
+  /**
+   * $ value of a full 1.0 move in `metric` at this window's volumes — what
+   * follow-through multiplies a point of progress by.
+   *
+   * Declare it even when the answer is undefined (a ratio with no token
+   * population of its own). It used to live as a `case` in one switch in
+   * recommendations.ts whose `default` returned undefined, so a rule that
+   * forgot its case still printed a savings figure while silently dropping
+   * the $/point projection — a shared line that four contributor PRs in a row
+   * missed, which is why it now sits next to the metric it prices.
+   */
+  valuePerPoint?(a: { m: Metrics; rates: BlendedRates }): number | undefined;
   /** Estimated $ saved over the window if the metric hit its target. */
   savings?(a: SavingsArgs): number | undefined;
   /** Extra sentence appended to the message when the rule fires (needs events). */

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { makeCursorFixture, makeAntigravityFixture } from './helpers.js';
 import { cursorUserDir } from '../src/adapters/cursor.js';
 import { codeUserDir } from '../src/adapters/copilot.js';
+import { RULES } from '../src/rules/index.js';
 
 /**
  * True end-to-end: runs the built CLI as a subprocess against a synthetic
@@ -311,7 +312,7 @@ test('e2e: rules lists the catalogue, explains one rule, and rejects an unknown 
   assert.ok(one.stdout.includes('src/rules/high-rework.ts'));
 
   const json = JSON.parse(run(['rules', '--json', ...DAYS]).stdout);
-  assert.equal(json.length, 13);
+  assert.equal(json.length, RULES.length);
   assert.ok(json.every((r: { key: string; docs: string }) => r.key && r.docs.length > 0));
 
   const bad = run(['rules', 'no-such-rule', ...DAYS]);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1,11 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { RULES, RULE_BY_KEY } from '../src/rules/index.js';
+import { RULES, RULE_BY_KEY, RULE_BY_METRIC } from '../src/rules/index.js';
 import { computeMetrics, MEGA_TURN_FLOOR_TOKENS } from '../src/metrics.js';
 import type { Metrics } from '../src/metrics.js';
-import { structuredFindings } from '../src/followthrough.js';
+import { structuredFindings, METRIC_DIRECTION } from '../src/followthrough.js';
 import { enrichFindings, targetFor } from '../src/recommendations.js';
 import { mergeMetrics } from '../src/team.js';
+import { TRACKABLE_METRICS } from '../src/analyze.js';
 import { renderRules, renderRule } from '../src/report.js';
 import { makeStored } from './helpers.js';
 import { readdirSync } from 'node:fs';
@@ -47,6 +48,34 @@ test('registry: every rule file is registered, and its filename is its key', () 
   for (const rule of RULES) {
     assert.ok(files.includes(rule.key), `rule "${rule.key}" has no src/rules/${rule.key}.ts (filename must match the key)`);
   }
+});
+
+/**
+ * The three facts that used to live in a shared line somewhere else: the
+ * metric's direction (followthrough.ts), what a point of it is worth
+ * (recommendations.ts) and the catalogue size (e2e). Each one was a merge
+ * conflict for every contributor and a silent hole when someone missed it.
+ */
+test('registry: every rule owns its metric, its direction and its $/point', () => {
+  const metrics = RULES.map((r) => r.metric);
+  assert.equal(new Set(metrics).size, metrics.length, 'two rules share a metric — RULE_BY_METRIC would shadow one');
+
+  for (const r of RULES) {
+    assert.equal(METRIC_DIRECTION[r.metric], r.direction, `${r.key}: direction disagrees with METRIC_DIRECTION`);
+    assert.equal(RULE_BY_METRIC.get(r.metric), r, `${r.key}: not reachable by its own metric`);
+    assert.ok(
+      'valuePerPoint' in r,
+      `${r.key} must declare valuePerPoint — return undefined if the metric is not $-translatable, ` +
+        'but declare it, or follow-through drops the $/point projection while the finding still prints savings',
+    );
+  }
+
+  // Anything the LLM path can hand to recordLlmFindings must have a direction;
+  // that lookup is unchecked at runtime.
+  for (const k of TRACKABLE_METRICS) {
+    assert.ok(METRIC_DIRECTION[k], `TRACKABLE_METRICS has ${k}, which has no direction`);
+  }
+  assert.equal(METRIC_DIRECTION.shippedShare, 'up', 'a metric no rule owns still needs its direction');
 });
 
 test('registry: a rule that declares no target still yields no target', () => {


### PR DESCRIPTION
## Why

Merging #112 made #113 conflict in six files — `followthrough.ts`, `metrics.ts`, `recommendations.ts`, `rules/index.ts`, `team.ts` and `test/rules.test.ts` — none of them because the two rules disagreed about anything. Every conflict was two contributors appending to the same list.

That matters more than the nuisance: GitHub builds a fork PR's checks from a merge commit it can't compute while there's a conflict, so a conflicted contributor PR gets **no CI run at all**. Five rule PRs are open behind this one, and each merge re-conflicts the rest.

Two of those shared lines had no reason to exist.

## What changed

**`Rule.valuePerPoint`** replaces the `unitValuePerPoint` switch in `recommendations.ts`. The switch's `default` returned `undefined`, so a rule that forgot its case still printed a savings figure while quietly dropping the $/point projection — #112, #114, #115 and #116 all missed it, which is four contributor PRs in a row failing the same way at the same line. It now lives next to the metric it prices, and is mandatory: return `undefined` when a ratio has no token population of its own (`low-think-code`, `context-bloat` both do), but declare it. The suite fails by rule name:

```
mega-turns must declare valuePerPoint — return undefined if the metric is not
$-translatable, but declare it, or follow-through drops the $/point projection
while the finding still prints savings
```

**`METRIC_DIRECTION`** derives from the registry. A rule already declares the direction it wants its metric to move; the second copy could only drift. Metrics no rule owns (`shippedShare`) keep an explicit entry.

**The e2e catalogue count** reads `RULES.length` rather than a literal that every rule PR has to bump.

Also adds `inputSideTokens(m)` in `metrics.ts` — the input-side population two rules price against, which was previously inlined in the switch.

## What deliberately did not change, and what this actually buys

Measured rather than assumed. A new rule touched **seven** shared edit points across six files; it now touches **five**:

| Shared edit point | Before | After |
|---|---|---|
| `rules/index.ts` — import + array entry | yes | yes (the firing order) |
| `MetricKey` union | yes | yes (the declaration that a number is tracked) |
| `Metrics` field in `metrics.ts` | yes | yes |
| `mergeMetrics` plumbing in `team.ts` | yes | yes |
| stable key list in `test/rules.test.ts` | yes | yes |
| `METRIC_DIRECTION` | yes | **gone** |
| `unitValuePerPoint` switch | yes | **gone** |
| e2e catalogue count | yes | **gone** |

So this is a dent, not a cure. The rule-owned `Metrics` field and its `mergeMetrics` plumbing are the two biggest remaining ones, and folding those into the registry is a larger change that wants its own PR.

**It also costs the five open rule PRs a one-time conflict each.** #107, #114, #115, #116 and #117 all add a `METRIC_DIRECTION` entry and bump the e2e literal, and both of those lines are deleted here — so each will need to drop those two edits and add `valuePerPoint` on rebase. #116 goes from two conflicted files to three. That is the right trade only because it is paid once and the sixth, seventh and eighth rule PRs don't pay it.

The honest headline is the guard, not the conflict count: four PRs in a row silently dropped their $/point projection, and that class of mistake is now a named test failure rather than something I have to catch by reading.

## Verification

- `npm test` — 342/342, including the new registry test.
- No behaviour change: every $/point expression moved verbatim from the switch. Removing `valuePerPoint` from a rule was checked to fail the suite, and restoring it to pass.
